### PR TITLE
add a listener delay up front

### DIFF
--- a/application/actions/app.go
+++ b/application/actions/app.go
@@ -184,7 +184,7 @@ func App() *buffalo.App {
 		policiesGroup.GET(idRegex+"/members", policiesListMembers)
 	}
 
-	listeners.RegisterListeners()
+	listeners.RegisterListener()
 
 	return app
 }

--- a/application/listeners/claim.go
+++ b/application/listeners/claim.go
@@ -28,12 +28,6 @@ func newClaimMessageForMember(claim models.Claim, member models.User) notificati
 }
 
 func claimReview1(e events.Event) {
-	if e.Kind != domain.EventApiClaimReview1 {
-		return
-	}
-
-	defer panicRecover(e.Kind)
-
 	var claim models.Claim
 	if err := findObject(e.Payload, &claim, e.Kind); err != nil {
 		return
@@ -56,16 +50,9 @@ func claimReview1(e events.Event) {
 	if err := notifications.Send(msg, notifiers...); err != nil {
 		domain.ErrLogger.Printf("error sending claim review1 notification, %s", err)
 	}
-
 }
 
 func claimRevision(e events.Event) {
-	if e.Kind != domain.EventApiClaimRevision {
-		return
-	}
-
-	defer panicRecover(e.Kind)
-
 	var claim models.Claim
 	if err := findObject(e.Payload, &claim, e.Kind); err != nil {
 		return
@@ -91,12 +78,6 @@ func claimRevision(e events.Event) {
 }
 
 func claimPreapproved(e events.Event) {
-	if e.Kind != domain.EventApiClaimPreapproved {
-		return
-	}
-
-	defer panicRecover(e.Kind)
-
 	var claim models.Claim
 	if err := findObject(e.Payload, &claim, e.Kind); err != nil {
 		return
@@ -122,12 +103,6 @@ func claimPreapproved(e events.Event) {
 }
 
 func claimReceipt(e events.Event) {
-	if e.Kind != domain.EventApiClaimReceipt {
-		return
-	}
-
-	defer panicRecover(e.Kind)
-
 	var claim models.Claim
 	if err := findObject(e.Payload, &claim, e.Kind); err != nil {
 		return
@@ -153,12 +128,6 @@ func claimReceipt(e events.Event) {
 }
 
 func claimReview2(e events.Event) {
-	if e.Kind != domain.EventApiClaimReview2 {
-		return
-	}
-
-	defer panicRecover(e.Kind)
-
 	var claim models.Claim
 	if err := findObject(e.Payload, &claim, e.Kind); err != nil {
 		return
@@ -184,12 +153,6 @@ func claimReview2(e events.Event) {
 }
 
 func claimReview3(e events.Event) {
-	if e.Kind != domain.EventApiClaimReview3 {
-		return
-	}
-
-	defer panicRecover(e.Kind)
-
 	var claim models.Claim
 	if err := findObject(e.Payload, &claim, e.Kind); err != nil {
 		return
@@ -215,12 +178,6 @@ func claimReview3(e events.Event) {
 }
 
 func claimApproved(e events.Event) {
-	if e.Kind != domain.EventApiClaimApproved {
-		return
-	}
-
-	defer panicRecover(e.Kind)
-
 	var claim models.Claim
 	if err := findObject(e.Payload, &claim, e.Kind); err != nil {
 		return
@@ -230,12 +187,6 @@ func claimApproved(e events.Event) {
 }
 
 func claimDenied(e events.Event) {
-	if e.Kind != domain.EventApiClaimDenied {
-		return
-	}
-
-	defer panicRecover(e.Kind)
-
 	var claim models.Claim
 	if err := findObject(e.Payload, &claim, e.Kind); err != nil {
 		return

--- a/application/listeners/item.go
+++ b/application/listeners/item.go
@@ -36,12 +36,6 @@ func newItemMessageForMember(item models.Item, member models.User) notifications
 }
 
 func itemSubmitted(e events.Event) {
-	if e.Kind != domain.EventApiItemSubmitted {
-		return
-	}
-
-	defer panicRecover(e.Kind)
-
 	var item models.Item
 	if err := findObject(e.Payload, &item, e.Kind); err != nil {
 		return
@@ -96,12 +90,6 @@ func notifyItemSubmitted(item models.Item, memberName string, notifiers []interf
 }
 
 func itemRevision(e events.Event) {
-	if e.Kind != domain.EventApiItemRevision {
-		return
-	}
-
-	defer panicRecover(e.Kind)
-
 	var item models.Item
 	if err := findObject(e.Payload, &item, e.Kind); err != nil {
 		return
@@ -128,12 +116,6 @@ func itemRevision(e events.Event) {
 }
 
 func itemApproved(e events.Event) {
-	if e.Kind != domain.EventApiItemApproved {
-		return
-	}
-
-	defer panicRecover(e.Kind)
-
 	var item models.Item
 	if err := findObject(e.Payload, &item, e.Kind); err != nil {
 		return
@@ -152,12 +134,6 @@ func itemApproved(e events.Event) {
 }
 
 func itemDenied(e events.Event) {
-	if e.Kind != domain.EventApiItemDenied {
-		return
-	}
-
-	defer panicRecover(e.Kind)
-
 	var item models.Item
 	if err := findObject(e.Payload, &item, e.Kind); err != nil {
 		return

--- a/application/listeners/listeners.go
+++ b/application/listeners/listeners.go
@@ -15,108 +15,42 @@ import (
 
 const EventPayloadNotifier = "notifier"
 
-type apiListener struct {
-	name     string
-	listener func(events.Event)
-}
-
 //
 // Register new listener functions here.  Remember, though, that these groupings just
 // describe what we want.  They don't make it happen this way. The listeners
 // themselves still need to verify the event kind
 //
-var apiListeners = map[string][]apiListener{
-	domain.EventApiUserCreated: {
-		{
-			name:     "user-created-create-policy",
-			listener: createUserPolicy,
-		},
-	},
-	domain.EventApiItemSubmitted: {
-		{
-			name:     "item-submitted",
-			listener: itemSubmitted,
-		},
-	},
-	domain.EventApiItemRevision: {
-		{
-			name:     "item-revision",
-			listener: itemRevision,
-		},
-	},
-	domain.EventApiItemApproved: {
-		{
-			name:     "item-approved",
-			listener: itemApproved,
-		},
-	},
-	domain.EventApiItemDenied: {
-		{
-			name:     "item-denied",
-			listener: itemDenied,
-		},
-	},
-	domain.EventApiClaimReview1: {
-		{
-			name:     "claim-review1",
-			listener: claimReview1,
-		},
-	},
-	domain.EventApiClaimRevision: {
-		{
-			name:     "claim-revision",
-			listener: claimRevision,
-		},
-	},
-	domain.EventApiClaimPreapproved: {
-		{
-			name:     "claim-preapproved",
-			listener: claimPreapproved,
-		},
-	},
-	domain.EventApiClaimReceipt: {
-		{
-			name:     "claim-receipt",
-			listener: claimReceipt,
-		},
-	},
-	domain.EventApiClaimReview2: {
-		{
-			name:     "claim-review2",
-			listener: claimReview2,
-		},
-	},
-	domain.EventApiClaimReview3: {
-		{
-			name:     "claim-review3",
-			listener: claimReview3,
-		},
-	},
-	domain.EventApiClaimApproved: {
-		{
-			name:     "claim-approved",
-			listener: claimApproved,
-		},
-	},
-	domain.EventApiClaimDenied: {
-		{
-			name:     "claim-denied",
-			listener: claimDenied,
-		},
-	},
+var eventTypes = map[string]func(event events.Event){
+	domain.EventApiUserCreated:      createUserPolicy,
+	domain.EventApiItemSubmitted:    itemSubmitted,
+	domain.EventApiItemRevision:     itemRevision,
+	domain.EventApiItemApproved:     itemApproved,
+	domain.EventApiItemDenied:       itemDenied,
+	domain.EventApiClaimReview1:     claimReview1,
+	domain.EventApiClaimRevision:    claimRevision,
+	domain.EventApiClaimPreapproved: claimPreapproved,
+	domain.EventApiClaimReceipt:     claimReceipt,
+	domain.EventApiClaimReview2:     claimReview2,
+	domain.EventApiClaimReview3:     claimReview3,
+	domain.EventApiClaimApproved:    claimApproved,
+	domain.EventApiClaimDenied:      claimDenied,
 }
 
-// RegisterListeners registers all the listeners to be used by the app
-func RegisterListeners() {
-	for _, listeners := range apiListeners {
-		for _, l := range listeners {
-			_, err := events.NamedListen(l.name, l.listener)
-			if err != nil {
-				domain.ErrLogger.Printf("Failed registering listener: %s, err: %s", l.name, err.Error())
-			}
-		}
+func listener(e events.Event) {
+	handler, ok := eventTypes[e.Kind]
+	if ok {
+		time.Sleep(time.Second * 5) // a rough guess at the longest time it takes for the database transaction to close
+		handler(e)
 	}
 }
+
+// RegisterListener registers the event listener
+func RegisterListener() {
+	if _, err := events.Listen(listener); err != nil {
+		panic("failed to register event listener")
+	}
+}
+
 func getID(p events.Payload) (uuid.UUID, error) {
 	i, ok := p[domain.EventPayloadID]
 	if !ok {

--- a/application/listeners/policy.go
+++ b/application/listeners/policy.go
@@ -8,12 +8,6 @@ import (
 )
 
 func createUserPolicy(e events.Event) {
-	if e.Kind != domain.EventApiUserCreated {
-		return
-	}
-
-	defer panicRecover(e.Kind)
-
 	var user models.User
 	if err := findObject(e.Payload, &user, e.Kind); err != nil {
 		return


### PR DESCRIPTION
This addresses a known issue that caused a panic in several listeners. Listeners were failing if a transaction that included an update did not close before the listener executed the database query.