### PR TITLE
revert ClaimItem.Update to accept the old status (not the new status)

### DIFF
--- a/application/models/claimitem.go
+++ b/application/models/claimitem.go
@@ -65,16 +65,14 @@ func (c *ClaimItem) Create(tx *pop.Connection) error {
 }
 
 // Update changes the status if it is a valid transition.
-func (c *ClaimItem) Update(tx *pop.Connection, newStatus api.ClaimItemStatus, user User) error {
-	oldStatus := c.Status
-	if !isClaimItemTransitionValid(oldStatus, newStatus) {
-		err := fmt.Errorf("invalid claim item status transition from %s to %s", oldStatus, newStatus)
+func (c *ClaimItem) Update(tx *pop.Connection, oldStatus api.ClaimItemStatus, user User) error {
+	if !isClaimItemTransitionValid(oldStatus, c.Status) {
+		err := fmt.Errorf("invalid claim item status transition from %s to %s", oldStatus, c.Status)
 		appErr := api.NewAppError(err, api.ErrorValidation, api.CategoryUser)
 		return appErr
 	}
 
-	c.Status = newStatus
-	if newStatus == api.ClaimItemStatusDenied || newStatus == api.ClaimItemStatusRevision || newStatus == api.ClaimItemStatusApproved {
+	if c.Status == api.ClaimItemStatusDenied || c.Status == api.ClaimItemStatusRevision || c.Status == api.ClaimItemStatusApproved {
 		c.ReviewerID = nulls.NewUUID(user.ID)
 		c.ReviewDate = nulls.NewTime(time.Now().UTC())
 	}

--- a/application/models/claimitem_test.go
+++ b/application/models/claimitem_test.go
@@ -109,34 +109,35 @@ func (ms *ModelSuite) TestClaimItem_Update() {
 
 	claim := fixtures.Claims[0]
 	claim.LoadClaimItems(db, false)
-	claimItem := claim.ClaimItems[0]
 
 	tests := []struct {
 		name      string
-		claimItem *ClaimItem
 		newStatus api.ClaimItemStatus
 		wantErr   bool
 		appError  api.AppError
 	}{
 		{
 			name:      "invalid transition",
-			claimItem: &claimItem,
 			newStatus: api.ClaimItemStatusDraft,
 			appError:  api.AppError{Key: api.ErrorValidation, Category: api.CategoryUser},
 			wantErr:   true,
 		},
 		{
 			name:      "ok",
-			claimItem: &claimItem,
 			newStatus: api.ClaimItemStatusDenied,
 			wantErr:   false,
 		},
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			err := (*tt.claimItem).Update(db, tt.newStatus, user)
+			claimItem := claim.ClaimItems[0]
+			oldStatus := claimItem.Status
+			claimItem.Status = tt.newStatus
+
+			err := claimItem.Update(db, oldStatus, user)
+
 			var fromDB ClaimItem
-			ms.NoError(fromDB.FindByID(db, tt.claimItem.ID))
+			ms.NoError(fromDB.FindByID(db, claimItem.ID))
 
 			if tt.wantErr {
 				ms.Error(err)


### PR DESCRIPTION
This a leftover from feedback on PR #107 . It makes the interface similar with other "Update" functions.