### PR TITLE
verify claim status before updating it on behalf of a user

### DIFF
--- a/application/actions/claims.go
+++ b/application/actions/claims.go
@@ -110,7 +110,7 @@ func claimsUpdate(c buffalo.Context) error {
 	claim.IncidentDescription = input.IncidentDescription
 	claim.IncidentDate = input.IncidentDate
 
-	if err := claim.Update(c); err != nil {
+	if err := claim.UpdateByUser(c); err != nil {
 		return reportError(c, err)
 	}
 

--- a/application/models/claim.go
+++ b/application/models/claim.go
@@ -153,6 +153,29 @@ func (c *Claim) Update(ctx context.Context) error {
 	return update(tx, c)
 }
 
+// UpdateByUser ensures the Claim has an appropriate status for being modified by the user
+//  and then writes the Claim data to an existing database record.
+func (c *Claim) UpdateByUser(ctx context.Context) error {
+	user := CurrentUser(ctx)
+	if user.IsAdmin() {
+		return c.Update(ctx)
+	}
+
+	switch c.Status {
+	case api.ClaimStatusDraft, api.ClaimStatusRevision, api.ClaimStatusReview1:
+	default:
+		err := errors.New("user may not edit a claim that is too far along in the review process.")
+		appErr := api.NewAppError(err, api.ErrorClaimStatus, api.CategoryUser)
+		return appErr
+	}
+
+	if c.Status == api.ClaimStatusReview1 {
+		c.Status = api.ClaimStatusDraft
+	}
+
+	return c.Update(ctx)
+}
+
 func (c *Claim) GetID() uuid.UUID {
 	return c.ID
 }
@@ -208,6 +231,7 @@ func claimStatusTransitions() map[api.ClaimStatus][]api.ClaimStatus {
 			api.ClaimStatusReview1,
 		},
 		api.ClaimStatusReview1: {
+			api.ClaimStatusDraft,
 			api.ClaimStatusRevision,
 			api.ClaimStatusReceipt,
 			api.ClaimStatusReview3,

--- a/application/models/claim.go
+++ b/application/models/claim.go
@@ -169,6 +169,8 @@ func (c *Claim) UpdateByUser(ctx context.Context) error {
 		return appErr
 	}
 
+	// If the user edits something, it should take it off of the steward's list of things to review and
+	//  also force the user to resubmit it.
 	if c.Status == api.ClaimStatusReview1 {
 		c.Status = api.ClaimStatusDraft
 	}

--- a/application/models/claim.go
+++ b/application/models/claim.go
@@ -162,6 +162,7 @@ func (c *Claim) UpdateByUser(ctx context.Context) error {
 	}
 
 	switch c.Status {
+	// OK to modify the Claim when it has one of these statuses but not any others
 	case api.ClaimStatusDraft, api.ClaimStatusRevision, api.ClaimStatusReview1:
 	default:
 		err := errors.New("user may not edit a claim that is too far along in the review process.")


### PR DESCRIPTION
Checking if this is the right way to go before doing something similar on a ClaimItem update.