### PR TITLE
a couple import tweaks

### DIFF
--- a/application/grifts/import.go
+++ b/application/grifts/import.go
@@ -577,6 +577,9 @@ func createUserFromEmailAddress(tx *pop.Connection, email, firstName, lastName s
 }
 
 func validMailAddress(address string) (string, bool) {
+	if strings.HasSuffix(address, "@sil") {
+		address = address + ".org"
+	}
 	addr, err := mail.ParseAddress(address)
 	if err != nil {
 		return "", false

--- a/application/grifts/import.go
+++ b/application/grifts/import.go
@@ -782,7 +782,6 @@ func importItems(tx *pop.Connection, policyUUID uuid.UUID, policyID int, items [
 			RiskCategoryID:    riskCategoryMap[item.CategoryId],
 			InStorage:         item.InStorage == 1,
 			Country:           trim(item.Country),
-			Description:       trim(item.Description),
 			PolicyID:          policyUUID,
 			Make:              trim(item.Make),
 			Model:             trim(item.Model),


### PR DESCRIPTION
- item name and description are identical in json data, don't need both
- import: add missing ".org" on emails ending in "@sil"