### PR TITLE
filter policies by whether or not they have approved items

### DIFF
--- a/application/models/policy.go
+++ b/application/models/policy.go
@@ -297,9 +297,8 @@ func scopeSearchPoliciesByActive(active string) pop.ScopeFunc {
 				"WHERE policies.id=items.policy_id AND items.coverage_status='Approved')")
 		}
 		if active == "false" {
-			return q.Where("policies.id IN (SELECT policies.id FROM policies LEFT JOIN items " +
-				"ON policies.id=items.policy_id " +
-				"WHERE items.coverage_status!='Approved' AND items.id IS NULL)")
+			return q.Where("policies.id NOT IN (SELECT policies.id FROM policies,items " +
+				"WHERE policies.id=items.policy_id AND items.coverage_status='Approved')")
 		}
 		return q
 	}

--- a/application/models/policy.go
+++ b/application/models/policy.go
@@ -271,18 +271,37 @@ func (p *Policies) Query(tx *pop.Connection, query api.Query) error {
 	}
 
 	if v := query.Search("name"); v != "" {
-		q.Scope(scopeSearchPolicyByName(v))
+		q.Scope(scopeSearchPoliciesByName(v))
+	}
+
+	if v := query.Search("active"); v != "" {
+		q.Scope(scopeSearchPoliciesByActive(v))
 	}
 
 	return appErrorFromDB(q.All(p), api.ErrorQueryFailure)
 }
 
-func scopeSearchPolicyByName(name string) pop.ScopeFunc {
+func scopeSearchPoliciesByName(name string) pop.ScopeFunc {
 	name = "%" + name + "%"
 	return func(q *pop.Query) *pop.Query {
 		return q.Join("policy_users", "policies.id = policy_users.policy_id").
 			Join("users", "users.id = policy_users.user_id").
 			Where(`users.first_name ILIKE ? OR users.last_name ILIKE ?`, name, name)
+	}
+}
+
+func scopeSearchPoliciesByActive(active string) pop.ScopeFunc {
+	return func(q *pop.Query) *pop.Query {
+		if active == "true" {
+			return q.Where("policies.id IN (SELECT policies.id FROM policies,items " +
+				"WHERE policies.id=items.policy_id AND items.coverage_status='Approved')")
+		}
+		if active == "false" {
+			return q.Where("policies.id IN (SELECT policies.id FROM policies LEFT JOIN items " +
+				"ON policies.id=items.policy_id " +
+				"WHERE items.coverage_status!='Approved' AND items.id IS NULL)")
+		}
+		return q
 	}
 }
 

--- a/application/models/policy_test.go
+++ b/application/models/policy_test.go
@@ -605,6 +605,11 @@ func (ms *ModelSuite) TestPolicies_Query() {
 			query:                "search=active:true",
 			wantNumberOfPolicies: 0,
 		},
+		{
+			name:                 "only inactive",
+			query:                "search=active:false",
+			wantNumberOfPolicies: 4,
+		},
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {

--- a/application/models/policy_test.go
+++ b/application/models/policy_test.go
@@ -600,6 +600,11 @@ func (ms *ModelSuite) TestPolicies_Query() {
 			query:                "search=name:john&limit=1",
 			wantNumberOfPolicies: 1,
 		},
+		{
+			name:                 "only active",
+			query:                "search=active:true",
+			wantNumberOfPolicies: 0,
+		},
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This PR does not change the default behavior, though we may want to consider a default of `search=active:true` for admins.