### PR TITLE
email template fixes

### DIFF
--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -84,6 +84,7 @@ const (
 const (
 	CurrencyFactor = 100
 	DateFormat     = "2006-01-02"
+	LocalizedDate  = "2 January 2006"
 
 	// How many hours old an item can be until it's not allowed to be deleted
 	ItemDeleteCutOffHours = 72

--- a/application/messages/claim_test.go
+++ b/application/messages/claim_test.go
@@ -37,7 +37,7 @@ func (ts *TestSuite) Test_ClaimReview1QueueMessage() {
 		{
 			name:                  "submitted to review1",
 			wantToEmails:          []interface{}{steward.EmailOfChoice()},
-			wantSubjectContains:   "just (re)submitted a claim for approval",
+			wantSubjectContains:   "just submitted a claim for approval",
 			wantInappTextContains: "A new claim is waiting for your approval",
 			wantBodyContains: []string{
 				domain.Env.UIURL,
@@ -75,7 +75,6 @@ func (ts *TestSuite) Test_ClaimRevisionQueueMessage() {
 				domain.Env.UIURL,
 				revisionClaim.ReferenceNumber,
 				revisionClaim.StatusReason,
-				"The claim you submitted has not yet been approved.",
 			},
 		},
 	}

--- a/application/messages/item.go
+++ b/application/messages/item.go
@@ -93,7 +93,6 @@ func ItemRevisionQueueMessage(tx *pop.Connection, item models.Item) {
 
 	data := newEmailMessageData()
 	data.addItemData(tx, item)
-	data["itemStatusReason"] = item.StatusReason
 
 	notn := models.Notification{
 		ItemID:  nulls.NewUUID(item.ID),
@@ -136,7 +135,6 @@ func ItemDeniedQueueMessage(tx *pop.Connection, item models.Item) {
 
 	data := newEmailMessageData()
 	data.addItemData(tx, item)
-	data["itemStatusReason"] = item.StatusReason
 
 	notn := models.Notification{
 		ItemID:    nulls.NewUUID(item.ID),

--- a/application/messages/policy.go
+++ b/application/messages/policy.go
@@ -9,9 +9,8 @@ import (
 
 // PolicyUserInviteQueueMessage queues messages to an invited policy user
 func PolicyUserInviteQueueMessage(tx *pop.Connection, invite models.PolicyUserInvite) {
-
 	data := newEmailMessageData()
-	data["policyName"] = invite.Policy.CostCenter // TODO update with policy name once added to model for corporate policies
+	data["policyName"] = invite.Policy.Name
 	data["acceptURL"] = invite.GetAcceptURL()
 	data["inviterEmail"] = invite.InviterEmail
 	data["inviterName"] = invite.InviterName
@@ -30,5 +29,4 @@ func PolicyUserInviteQueueMessage(tx *pop.Connection, invite models.PolicyUserIn
 	}
 
 	notn.CreateNotificationUser(tx, nulls.UUID{}, invite.Email, invite.InviteeName)
-
 }

--- a/application/models/claim.go
+++ b/application/models/claim.go
@@ -888,3 +888,8 @@ func (c *Claim) UpdateStatus(ctx context.Context, newStatus api.ClaimStatus) err
 
 	return nil
 }
+
+func (c *Claim) SubmittedAt(tx *pop.Connection) time.Time {
+	// TODO: use the history table to get the real date
+	return c.UpdatedAt
+}

--- a/application/models/user.go
+++ b/application/models/user.go
@@ -293,6 +293,7 @@ func (u *User) CreateInitialPolicy(tx *pop.Connection) error {
 	}
 
 	policy := Policy{
+		Name:        u.Name() + " Household policy",
 		Type:        api.PolicyTypeHousehold,
 		HouseholdID: nulls.NewString(fmt.Sprintf("HHID-%s-%s", u.FirstName, u.LastName)),
 	}

--- a/application/notifications/email_test.go
+++ b/application/notifications/email_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func (ts *TestSuite) TestSend() {
-
 	item := models.Item{
 		Name: "My Item",
 	}
@@ -25,11 +24,12 @@ func (ts *TestSuite) TestSend() {
 		Data: map[string]interface{}{
 			"uiURL":             "example.com",
 			"appName":           "Our App",
-			"itemURL":           "my-item.example.com",
+			"itemURL":           "https://my-item.example.com",
 			"item":              item,
 			"memberName":        "John Doe",
 			"supportEmail":      "support@example.com",
-			"coverageAmount":    "$100",
+			"coverageAmount":    "$100.00",
+			"coverageEndDate":   "2021-12-31",
 			"coverageStartDate": "2021-01-01",
 			"annualPremium":     "$3.50",
 			"accountablePerson": "John Doe",

--- a/application/templates/mail/_claim_card.plush.html
+++ b/application/templates/mail/_claim_card.plush.html
@@ -5,14 +5,14 @@
 </div>
 
 <%= partial("category", {
-		name: claim.IncidentType,
-		helpText: "",
+		name: incidentType,
+		helpText: "lorem ipsum dolor (description of the incident type)"
 	}
 ) %>
 
 <div>
 	<h4 style="margin:0; padding:0">Incident</h4>
-	<%= claim.IncidentDate %>
+	<%= incidentDate %>
 	<p>
 		<%= claim.IncidentDescription %>
 	</p>
@@ -20,7 +20,7 @@
 
 <div>
 	<h4 style="margin:0; padding:0">Desired resolution</h4>
-	<%= claimItem.PayoutOption %>
+	<%= payoutOption %>
 	<%= payoutOptionDescription %>
 </div>
 

--- a/application/templates/mail/claim_denied_member.plush.html
+++ b/application/templates/mail/claim_denied_member.plush.html
@@ -3,5 +3,5 @@
 	This is an unofficial draft email.
     We're sorry. The claim you submitted has been denied.
 	<br>
-	<%= claimStatusReason %>
+	<%= claim.StatusReason %>
 </p>

--- a/application/templates/mail/claim_review1_steward.plush.html
+++ b/application/templates/mail/claim_review1_steward.plush.html
@@ -10,7 +10,8 @@
 
 	<%= partial("claim_card", {
 			claim: claim,
-			claimItem: claimItem,
+			incidentDate: incidentDate,
+			incidentType: incidentType,
 			payoutOptionDescription: payoutOptionDescription,
 			maximumPayout: maximumPayout,
 		}

--- a/application/templates/mail/claim_revision_member.plush.html
+++ b/application/templates/mail/claim_revision_member.plush.html
@@ -1,8 +1,26 @@
-<h4><a href="<%= claimURL %>"><%= claim.ReferenceNumber %></a></h4>
-<p>
-	This is an unofficial draft email.
-    The claim you submitted has not yet been approved.
-	In particular, certain revisions have been requested.
-	<br>
-	<%= claimStatusReason %>
-</p>
+<div>
+	<%= partial("body_header", {
+	title: "Claim revisions needed",
+	subTitle: "Your claim has not yet been approved " + claim.StatusReason,
+	alert: "Needs revisions",
+	alert_description: "Reviewed " + submitted,
+	alert_icon: "clipboard",
+	}
+	) %>
+
+	<%= partial("claim_card", {
+			claim: claim,
+			incidentDate: incidentDate,
+			incidentType: incidentType,
+			payoutOptionDescription: payoutOptionDescription,
+			maximumPayout: maximumPayout,
+		}
+	) %>
+
+	<%= partial("button", {
+			url: claimURL,
+			label: "Open in Cover",
+		}
+	) %>
+
+</div>

--- a/application/templates/mail/item_approved_member.plush.html
+++ b/application/templates/mail/item_approved_member.plush.html
@@ -8,14 +8,12 @@
 		alert_icon: "clock"}
 	) %>
 
-	<%# TODO Add this back in when we're ready for it %>
-	<%# coverageEndDate: item.CoverageEndDate, %>
-
 	<%= partial("item_card", {
 		item: item,
 		coverageAmount: coverageAmount,
 		premium: annualPremium,
 		coverageStartDate: coverageStartDate,
+		coverageEndDate: coverageEndDate,
 		accountablePerson: accountablePerson,
 		householdID: policy.HouseholdID}
 	) %>

--- a/application/templates/mail/item_auto_approved_steward.html
+++ b/application/templates/mail/item_auto_approved_steward.html
@@ -7,9 +7,6 @@
 		alert_icon: ""}
 	) %>
 
-	<%# TODO Add this back in when we're ready for it %>
-	<%# coverageEndDate: item.CoverageEndDate, %>
-
 	<%= partial("item_card", {
 		item: item,
 		coverageAmount: coverageAmount,

--- a/application/templates/mail/item_denied_member.plush.html
+++ b/application/templates/mail/item_denied_member.plush.html
@@ -13,6 +13,7 @@
 		coverageAmount: "",
 		premium: "",
 		coverageStartDate: "",
+		coverageEndDate: "",
 		accountablePerson: accountablePerson,
 		householdID: policy.HouseholdID}
 	) %>

--- a/application/templates/mail/item_pending_steward.plush.html
+++ b/application/templates/mail/item_pending_steward.plush.html
@@ -7,14 +7,12 @@
 		alert_icon: ""}
 	) %>
 
-	<%# TODO Add this back in when we're ready for it %>
-	<%# coverageEndDate: item.CoverageEndDate, %>
-
 	<%= partial("item_card", {
 		item: item,
 		coverageAmount: coverageAmount,
 		premium: annualPremium,
 		coverageStartDate: coverageStartDate,
+		coverageEndDate: coverageEndDate,
 		accountablePerson: accountablePerson,
 		householdID: policy.HouseholdID}
 	) %>

--- a/application/templates/mail/item_revision_member.plush.html
+++ b/application/templates/mail/item_revision_member.plush.html
@@ -13,6 +13,7 @@
 		coverageAmount: coverageAmount,
 		premium: annualPremium,
 		coverageStartDate: "",
+		coverageEndDate: "",
 		accountablePerson: accountablePerson,
 		householdID: policy.HouseholdID}
 	) %>


### PR DESCRIPTION
By observation, it appears that gobuffalo/plush cannot handle custom string types (e.g. `type myType string`) even if they have a `String()` function. On the flip side, `nulls.String` seems to work, so it's not exactly clear where the difference lies. Also, function calls like `item.GetMakeModel()` appear to work, so we may want to move some of these one-off template variables into model functions (e.g. `item.AnnualPremiumForTemplate()`)