### PR TITLE
calculate claim payout on submit

### DIFF
--- a/application/models/claim.go
+++ b/application/models/claim.go
@@ -396,6 +396,8 @@ func (c *Claim) SubmitForApproval(ctx context.Context) error {
 		}
 	}
 
+	c.calculatePayout(ctx)
+
 	if err := c.Update(ctx); err != nil {
 		return err
 	}
@@ -892,4 +894,18 @@ func (c *Claim) UpdateStatus(ctx context.Context, newStatus api.ClaimStatus) err
 func (c *Claim) SubmittedAt(tx *pop.Connection) time.Time {
 	// TODO: use the history table to get the real date
 	return c.UpdatedAt
+}
+
+func (c *Claim) calculatePayout(ctx context.Context) error {
+	c.LoadClaimItems(Tx(ctx), false)
+	var payout api.Currency
+	for _, claimItem := range c.ClaimItems {
+		if err := claimItem.calculatePayout(ctx); err != nil {
+			return err
+		}
+		payout += claimItem.PayoutAmount
+	}
+	c.TotalPayout = payout
+
+	return c.Update(ctx)
 }

--- a/application/models/claim_test.go
+++ b/application/models/claim_test.go
@@ -193,6 +193,7 @@ func (ms *ModelSuite) TestClaim_SubmitForApproval() {
 			ms.NoError(got)
 
 			ms.Equal(tt.wantStatus, tt.claim.Status, "incorrect status")
+			ms.Greater(tt.claim.TotalPayout, 0, "total payout was not set")
 		})
 	}
 }
@@ -884,4 +885,19 @@ func (ms *ModelSuite) TestClaims_ByStatus() {
 			ms.ElementsMatch(tt.wantClaimIDs, gotIDs)
 		})
 	}
+}
+
+func (ms *ModelSuite) TestClaim_calculatePayout() {
+	fixtures := CreateItemFixtures(ms.DB, FixturesConfig{ClaimsPerPolicy: 1, ClaimItemsPerClaim: 1})
+	fixtures.Claims[0].ClaimItems[0].RepairEstimate = 100
+	ms.NoError(ms.DB.Update(&fixtures.Claims[0].ClaimItems[0]))
+
+	// Get a fresh copy of the claim to ensure the UUT hydrates it as necessary
+	var claim Claim
+	ms.NoError(claim.FindByID(ms.DB, fixtures.Claims[0].ID))
+
+	ms.NoError(claim.calculatePayout(CreateTestContext(fixtures.Users[0])))
+
+	// The claim item test will check the actual amount. Just make sure it's not zero.
+	ms.Greater(claim.TotalPayout, 0, "payout was not set")
 }

--- a/application/models/claim_test.go
+++ b/application/models/claim_test.go
@@ -588,11 +588,13 @@ func (ms *ModelSuite) TestClaim_HasReceiptFile() {
 }
 
 func (ms *ModelSuite) TestClaim_ConvertToAPI() {
-	policy := CreatePolicyFixtures(ms.DB, FixturesConfig{}).Policies[0]
-	claim := createClaimFixture(ms.DB, policy, FixturesConfig{
+	fixtures := CreateItemFixtures(ms.DB, FixturesConfig{
+		ClaimsPerPolicy:    1,
 		ClaimItemsPerClaim: 2,
 		ClaimFilesPerClaim: 3,
 	})
+	claim := fixtures.Claims[0]
+
 	claim.StatusReason = "change request " + domain.RandomString(8, "0123456789")
 
 	got := claim.ConvertToAPI(ms.DB)

--- a/application/models/claimitem.go
+++ b/application/models/claimitem.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"time"
 
@@ -450,4 +451,28 @@ func (c *ClaimItem) NewHistory(ctx context.Context, action string, fieldUpdate F
 		OldValue:    fieldUpdate.OldValue,
 		NewValue:    fieldUpdate.NewValue,
 	}
+}
+
+func (c *ClaimItem) calculatePayout(ctx context.Context) error {
+	c.LoadItem(Tx(ctx), false)
+
+	coverageAmount := c.Item.CoverageAmount
+
+	deductible := 0.05
+	maxValue := 0.0
+	switch c.PayoutOption {
+	case api.PayoutOptionRepair:
+		maxValue = float64(c.RepairEstimate)
+	case api.PayoutOptionReplacement:
+		maxValue = float64(c.ReplaceEstimate)
+	case api.PayoutOptionFMV:
+		maxValue = float64(c.FMV)
+	case api.PayoutOptionFixedFraction:
+		deductible = 1.0 / 3.0
+		maxValue = float64(coverageAmount)
+	}
+
+	c.PayoutAmount = api.Currency(math.Round(math.Min(maxValue, float64(coverageAmount)) * (1.0 - deductible)))
+
+	return c.Update(ctx)
 }

--- a/application/models/item_test.go
+++ b/application/models/item_test.go
@@ -1019,16 +1019,16 @@ func (ms *ModelSuite) TestItem_Compare() {
 
 func (ms *ModelSuite) TestItem_canBeDeleted() {
 	f := CreateItemFixtures(ms.DB, FixturesConfig{
-		ItemsPerPolicy:     2,
-		ClaimsPerPolicy:    1,
-		ClaimItemsPerClaim: 1,
+		NumberOfPolicies: 3,
+		ItemsPerPolicy:   1,
 	})
-	yes := f.Items[0]
+	yes := f.Policies[0].Items[0]
 
-	hasClaim := f.Claims[0].ClaimItems[0].Item
+	hasClaim := f.Policies[1].Items[0]
+	createClaimFixture(ms.DB, f.Policies[1], FixturesConfig{ClaimItemsPerClaim: 1})
 
-	hasLedgerEntry := f.Items[1]
-	ms.NoError(hasLedgerEntry.Approve(CreateTestContext(f.Users[0]), false))
+	hasLedgerEntry := f.Policies[2].Items[0]
+	ms.NoError(hasLedgerEntry.Approve(CreateTestContext(f.Policies[2].Members[0]), false))
 
 	tests := []struct {
 		name string

--- a/application/models/testutils.go
+++ b/application/models/testutils.go
@@ -109,6 +109,9 @@ func CreateItemFixtures(tx *pop.Connection, config FixturesConfig) Fixtures {
 	if config.ItemsPerPolicy < 1 {
 		config.ItemsPerPolicy = 1
 	}
+	if config.ItemsPerPolicy < config.ClaimsPerPolicy*config.ClaimItemsPerClaim {
+		config.ItemsPerPolicy = config.ClaimsPerPolicy * config.ClaimItemsPerClaim
+	}
 
 	fixtures := CreatePolicyFixtures(tx, config)
 	policies := fixtures.Policies
@@ -202,6 +205,11 @@ func UpdateClaimItems(tx *pop.Connection, claim Claim, params UpdateClaimItemsPa
 // createClaimFixture generates a Claim, a number of ClaimItems, and a number of ClaimFiles
 // Uses FixturesConfig fields: ClaimItemsPerClaim, ClaimFilesPerClaim
 func createClaimFixture(tx *pop.Connection, policy Policy, config FixturesConfig) Claim {
+	if len(policy.Items) < config.ClaimItemsPerClaim {
+		panic(fmt.Sprintf("policy fixture must have at least %d items, it only has %d",
+			config.ClaimItemsPerClaim, len(policy.Items)))
+	}
+
 	claim := Claim{
 		PolicyID:            policy.ID,
 		IncidentDate:        time.Date(2020, 5, 1, 12, 0, 0, 0, time.UTC),
@@ -211,11 +219,9 @@ func createClaimFixture(tx *pop.Connection, policy Policy, config FixturesConfig
 	}
 	MustCreate(tx, &claim)
 
-	icFixtures := CreateCategoryFixtures(tx, config.ClaimItemsPerClaim)
-
 	claim.ClaimItems = make(ClaimItems, config.ClaimItemsPerClaim)
 	for i := range claim.ClaimItems {
-		item := createItemFixture(tx, policy.ID, icFixtures.ItemCategories[i].ID)
+		item := policy.Items[i]
 		claim.ClaimItems[i] = ClaimItem{
 			ID:              uuid.UUID{},
 			ClaimID:         claim.ID,


### PR DESCRIPTION
Will likely move the call to `calculatePayout` after this PR. This is just to get the functionality in place before figuring out the correct place(s) to do it.