### PR TITLE
remove fields from claim_items: status, review_date, reviewer_id

### DIFF
--- a/application/actions/claimitems_test.go
+++ b/application/actions/claimitems_test.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-	"time"
-
-	"github.com/gobuffalo/nulls"
 
 	"github.com/silinternational/cover-api/api"
 	"github.com/silinternational/cover-api/models"
@@ -45,8 +42,6 @@ func (as *ActionSuite) Test_ClaimItemsUpdate() {
 	approvedClaim := models.UpdateClaimStatus(db, policy.Claims[2], api.ClaimStatusApproved, "")
 	approvedClaim.LoadClaimItems(as.DB, false)
 	approvedClaimItem := approvedClaim.ClaimItems[0]
-	approvedClaimItem.ReviewerID = nulls.NewUUID(appAdmin.ID)
-	approvedClaimItem.ReviewDate = nulls.NewTime(time.Now().UTC())
 
 	ctx := models.CreateTestContext(appAdmin)
 	approvedClaimItem.Update(ctx)

--- a/application/actions/claims_test.go
+++ b/application/actions/claims_test.go
@@ -557,7 +557,7 @@ func (as *ActionSuite) Test_ClaimsItemsCreate() {
 			wantInBody: []string{
 				`"item_id":"` + input.ItemID.String(),
 				`"claim_id":"` + claim.ID.String(),
-				`"status":"` + string(api.ClaimItemStatusDraft),
+				`"status":"` + string(api.ClaimStatusDraft),
 				fmt.Sprintf(`"is_repairable":%t`, input.IsRepairable),
 				fmt.Sprintf(`"repair_estimate":%v`, int(input.RepairEstimate)),
 				fmt.Sprintf(`"replace_estimate":%v`, int(input.ReplaceEstimate)),

--- a/application/api/claimitems.go
+++ b/application/api/claimitems.go
@@ -6,34 +6,6 @@ import (
 	"github.com/gofrs/uuid"
 )
 
-// ClaimItemStatus
-//
-// may be one of: Draft, Review1, Review2, Review3, Revision, Receipt, Approved, Paid, Denied
-//
-// swagger:model
-type ClaimItemStatus string
-
-func (s ClaimItemStatus) WasReviewed() bool {
-	switch s {
-	case ClaimItemStatusDenied, ClaimItemStatusRevision, ClaimItemStatusReceipt,
-		ClaimItemStatusApproved, ClaimItemStatusPaid, ClaimItemStatusReview3:
-		return true
-	}
-	return false
-}
-
-const (
-	ClaimItemStatusDraft    = ClaimItemStatus(ClaimStatusDraft)
-	ClaimItemStatusReview1  = ClaimItemStatus(ClaimStatusReview1)
-	ClaimItemStatusReview2  = ClaimItemStatus(ClaimStatusReview2)
-	ClaimItemStatusReview3  = ClaimItemStatus(ClaimStatusReview3)
-	ClaimItemStatusRevision = ClaimItemStatus(ClaimStatusRevision)
-	ClaimItemStatusReceipt  = ClaimItemStatus(ClaimStatusReceipt)
-	ClaimItemStatusApproved = ClaimItemStatus(ClaimStatusApproved)
-	ClaimItemStatusPaid     = ClaimItemStatus(ClaimStatusPaid)
-	ClaimItemStatusDenied   = ClaimItemStatus(ClaimStatusDenied)
-)
-
 // PayoutOption
 //
 // may be one of: Repair, Replacement, FMV, FixedFraction
@@ -82,7 +54,7 @@ type ClaimItem struct {
 	ClaimID uuid.UUID `json:"claim_id"`
 
 	// claim item status
-	Status ClaimItemStatus `json:"status"`
+	Status ClaimStatus `json:"status"`
 
 	// is item repairable?
 	IsRepairable bool `json:"is_repairable"`

--- a/application/grifts/db.go
+++ b/application/grifts/db.go
@@ -423,7 +423,6 @@ func createClaimFixtures(tx *pop.Connection, fixPolicies []*models.Policy, items
 			ID:           uuid.FromStringOrNil(claimItemUUIDs[i]),
 			ClaimID:      fixClaims[i].ID,
 			ItemID:       items[i*2].ID,
-			Status:       api.ClaimItemStatusDraft,
 			PayoutOption: api.PayoutOptionRepair,
 		}
 

--- a/application/grifts/import.go
+++ b/application/grifts/import.go
@@ -713,7 +713,6 @@ func importClaimItems(tx *pop.Connection, claim models.Claim, items []LegacyClai
 		newClaimItem := models.ClaimItem{
 			ClaimID:         claim.ID,
 			ItemID:          itemUUID,
-			Status:          api.ClaimItemStatusPaid,
 			IsRepairable:    getIsRepairable(c),
 			RepairEstimate:  fixedPointStringToCurrency(c.RepairEstimate, "ClaimItem.RepairEstimate"),
 			RepairActual:    fixedPointStringToCurrency(c.RepairActual, "ClaimItem.RepairActual"),
@@ -722,8 +721,6 @@ func importClaimItems(tx *pop.Connection, claim models.Claim, items []LegacyClai
 			PayoutOption:    getPayoutOption(c.PayoutOption, itemDesc+"PayoutOption"),
 			PayoutAmount:    fixedPointStringToCurrency(c.PayoutAmount, "ClaimItem.PayoutAmount"),
 			FMV:             fixedPointStringToCurrency(c.Fmv, "ClaimItem.FMV"),
-			ReviewDate:      nulls.Time(c.ReviewDate),
-			ReviewerID:      getAdminUserUUID(strconv.Itoa(c.ReviewerId), itemDesc+"ReviewerID"),
 			LegacyID:        nulls.NewInt(claimItemID),
 			CreatedAt:       time.Time(c.CreatedAt),
 			City:            trim(c.City),

--- a/application/migrations/20211110152550_remove_claimitems_fields.down.fizz
+++ b/application/migrations/20211110152550_remove_claimitems_fields.down.fizz
@@ -1,0 +1,3 @@
+add_column("claim_items", "status", "string", {})
+add_column("claim_items", "review_date", "timestamp", {"null": true})
+add_column("claim_items", "reviewer_id", "uuid", {"null": true})

--- a/application/migrations/20211110152550_remove_claimitems_fields.up.fizz
+++ b/application/migrations/20211110152550_remove_claimitems_fields.up.fizz
@@ -1,0 +1,3 @@
+drop_column("claim_items", "status")
+drop_column("claim_items", "reviewer_id")
+drop_column("claim_items", "review_date")

--- a/application/models/claim.go
+++ b/application/models/claim.go
@@ -156,17 +156,6 @@ func (c *Claim) Update(ctx context.Context) error {
 		if err := history.Create(tx); err != nil {
 			return appErrorFromDB(err, api.ErrorCreateFailure)
 		}
-
-		// If status changed, update the ClaimItem status
-		// TODO: improve this when we support multiple items per claim
-		if updates[i].FieldName == FieldClaimStatus && len(c.ClaimItems) > 0 &&
-			c.ClaimItems[0].Status != api.ClaimItemStatus(c.Status) {
-
-			c.ClaimItems[0].Status = api.ClaimItemStatus(c.Status)
-			if err = c.ClaimItems[0].Update(ctx); err != nil {
-				return appErrorFromDB(err, api.ErrorUpdateFailure)
-			}
-		}
 	}
 
 	return nil

--- a/application/models/claimitem_test.go
+++ b/application/models/claimitem_test.go
@@ -3,17 +3,12 @@ package models
 import (
 	"fmt"
 	"testing"
-	"time"
-
-	"github.com/gobuffalo/nulls"
 
 	"github.com/silinternational/cover-api/api"
 	"github.com/silinternational/cover-api/domain"
 )
 
 func (ms *ModelSuite) TestClaimItem_Validate() {
-	user := CreateUserFixtures(ms.DB, 1).Users[0]
-
 	tests := []struct {
 		name      string
 		claimItem *ClaimItem
@@ -21,68 +16,20 @@ func (ms *ModelSuite) TestClaimItem_Validate() {
 		wantErr   bool
 	}{
 		{
-			name:      "empty struct",
-			claimItem: &ClaimItem{},
-			errField:  "ClaimItem.Status",
-			wantErr:   true,
-		},
-		{
 			name: "valid status, not approved",
 			claimItem: &ClaimItem{
 				Claim: Claim{
 					IncidentType: api.ClaimIncidentTypeImpact,
 				},
-				Status:       api.ClaimItemStatusReview1,
 				PayoutOption: api.PayoutOptionRepair,
 			},
 			errField: "",
 			wantErr:  false,
 		},
 		{
-			name: "valid status, missing claim incident type",
-			claimItem: &ClaimItem{
-				Status:       api.ClaimItemStatusReview1,
-				PayoutOption: api.PayoutOptionRepair,
-			},
-			errField: "ClaimItem.IncidentType",
-			wantErr:  true,
-		},
-		{
-			name: "approved, but no reviewer",
-			claimItem: &ClaimItem{
-				Claim: Claim{
-					IncidentType: api.ClaimIncidentTypeImpact,
-				},
-				Status:       api.ClaimItemStatusApproved,
-				PayoutOption: api.PayoutOptionRepair,
-				ReviewDate:   nulls.NewTime(time.Now()),
-			},
-			errField: "ClaimItem.ReviewerID",
-			wantErr:  true,
-		},
-		{
-			name: "denied, but no review date",
-			claimItem: &ClaimItem{
-				Claim: Claim{
-					IncidentType: api.ClaimIncidentTypeImpact,
-				},
-				Status:       api.ClaimItemStatusDenied,
-				PayoutOption: api.PayoutOptionRepair,
-				ReviewerID:   nulls.NewUUID(user.ID),
-			},
-			errField: "ClaimItem.ReviewDate",
-			wantErr:  true,
-		},
-		{
 			name: "invalid payout option",
 			claimItem: &ClaimItem{
-				Claim: Claim{
-					IncidentType: api.ClaimIncidentTypeImpact,
-				},
-				Status:       api.ClaimItemStatusDenied,
 				PayoutOption: api.PayoutOption("bitcoin"),
-				ReviewerID:   nulls.NewUUID(user.ID),
-				ReviewDate:   nulls.NewTime(time.Now()),
 			},
 			errField: "ClaimItem.PayoutOption",
 			wantErr:  true,
@@ -91,12 +38,10 @@ func (ms *ModelSuite) TestClaimItem_Validate() {
 			name: "invalid payout option for Evacuation",
 			claimItem: &ClaimItem{
 				Claim: Claim{
+					Status:       api.ClaimStatusDraft,
 					IncidentType: api.ClaimIncidentTypeEvacuation,
 				},
-				Status:       api.ClaimItemStatusDraft,
 				PayoutOption: api.PayoutOptionFMV,
-				ReviewerID:   nulls.NewUUID(user.ID),
-				ReviewDate:   nulls.NewTime(time.Now()),
 			},
 			errField: "ClaimItem.PayoutOption",
 			wantErr:  true,
@@ -107,10 +52,7 @@ func (ms *ModelSuite) TestClaimItem_Validate() {
 				Claim: Claim{
 					IncidentType: api.ClaimIncidentTypeEvacuation,
 				},
-				Status:       api.ClaimItemStatusDraft,
 				PayoutOption: api.PayoutOptionFixedFraction,
-				ReviewerID:   nulls.NewUUID(user.ID),
-				ReviewDate:   nulls.NewTime(time.Now()),
 			},
 			wantErr: false,
 		},
@@ -118,12 +60,10 @@ func (ms *ModelSuite) TestClaimItem_Validate() {
 			name: "invalid payout option for Theft",
 			claimItem: &ClaimItem{
 				Claim: Claim{
+					Status:       api.ClaimStatusDraft,
 					IncidentType: api.ClaimIncidentTypeTheft,
 				},
-				Status:       api.ClaimItemStatusDraft,
 				PayoutOption: api.PayoutOptionFixedFraction,
-				ReviewerID:   nulls.NewUUID(user.ID),
-				ReviewDate:   nulls.NewTime(time.Now()),
 			},
 			errField: "ClaimItem.PayoutOption",
 			wantErr:  true,
@@ -134,10 +74,7 @@ func (ms *ModelSuite) TestClaimItem_Validate() {
 				Claim: Claim{
 					IncidentType: api.ClaimIncidentTypeTheft,
 				},
-				Status:       api.ClaimItemStatusDraft,
 				PayoutOption: api.PayoutOptionFMV,
-				ReviewerID:   nulls.NewUUID(user.ID),
-				ReviewDate:   nulls.NewTime(time.Now()),
 			},
 			wantErr: false,
 		},
@@ -145,12 +82,10 @@ func (ms *ModelSuite) TestClaimItem_Validate() {
 			name: "invalid payout option for Impact",
 			claimItem: &ClaimItem{
 				Claim: Claim{
+					Status:       api.ClaimStatusDraft,
 					IncidentType: api.ClaimIncidentTypeImpact,
 				},
-				Status:       api.ClaimItemStatusDraft,
 				PayoutOption: api.PayoutOptionFixedFraction,
-				ReviewerID:   nulls.NewUUID(user.ID),
-				ReviewDate:   nulls.NewTime(time.Now()),
 			},
 			errField: "ClaimItem.PayoutOption",
 			wantErr:  true,
@@ -161,20 +96,14 @@ func (ms *ModelSuite) TestClaimItem_Validate() {
 				Claim: Claim{
 					IncidentType: api.ClaimIncidentTypeImpact,
 				},
-				Status:       api.ClaimItemStatusDraft,
 				PayoutOption: api.PayoutOptionRepair,
-				ReviewerID:   nulls.NewUUID(user.ID),
-				ReviewDate:   nulls.NewTime(time.Now()),
 			},
 			wantErr: false,
 		},
 		{
 			name: "valid status, approved",
 			claimItem: &ClaimItem{
-				Status:       api.ClaimItemStatusApproved,
 				PayoutOption: api.PayoutOptionRepair,
-				ReviewerID:   nulls.NewUUID(user.ID),
-				ReviewDate:   nulls.NewTime(time.Now()),
 			},
 			errField: "",
 			wantErr:  false,
@@ -331,7 +260,6 @@ func (ms *ModelSuite) TestClaimItem_Compare() {
 
 	oldCItem := ClaimItem{
 		ItemID:          domain.GetUUID(),
-		Status:          api.ClaimItemStatusReview3,
 		IsRepairable:    true,
 		RepairEstimate:  1111,
 		RepairActual:    1112,
@@ -340,8 +268,6 @@ func (ms *ModelSuite) TestClaimItem_Compare() {
 		PayoutOption:    api.PayoutOptionReplacement,
 		PayoutAmount:    3331,
 		FMV:             4441,
-		ReviewDate:      nulls.NewTime(time.Date(1991, 1, 1, 1, 1, 1, 1, time.UTC)),
-		ReviewerID:      nulls.NewUUID(domain.GetUUID()),
 		Country:         "Mali",
 	}
 
@@ -360,11 +286,6 @@ func (ms *ModelSuite) TestClaimItem_Compare() {
 					FieldName: FieldClaimItemItemID,
 					OldValue:  oldCItem.ItemID.String(),
 					NewValue:  newCItem.ItemID.String(),
-				},
-				{
-					FieldName: FieldClaimItemStatus,
-					OldValue:  string(oldCItem.Status),
-					NewValue:  string(newCItem.Status),
 				},
 				{
 					FieldName: FieldClaimItemIsRepairable,
@@ -405,16 +326,6 @@ func (ms *ModelSuite) TestClaimItem_Compare() {
 					FieldName: FieldClaimItemFMV,
 					OldValue:  api.Currency(oldCItem.FMV).String(),
 					NewValue:  api.Currency(newCItem.FMV).String(),
-				},
-				{
-					FieldName: FieldClaimItemReviewDate,
-					OldValue:  oldCItem.ReviewDate.Time.Format(domain.DateFormat),
-					NewValue:  newCItem.ReviewDate.Time.Format(domain.DateFormat),
-				},
-				{
-					FieldName: FieldClaimItemReviewerID,
-					OldValue:  oldCItem.ReviewerID.UUID.String(),
-					NewValue:  newCItem.ReviewerID.UUID.String(),
 				},
 				{
 					FieldName: FieldClaimItemLocation,

--- a/application/models/item.go
+++ b/application/models/item.go
@@ -849,17 +849,18 @@ func (i *Item) GetMakeModel() string {
 // canBeUpdated returns a value of true when the item can be updated, and returns false when there is an open
 // Claim on the item.
 func (i *Item) canBeUpdated(tx *pop.Connection) bool {
-	// SafeClaimItemStatuses are states in which related items can be edited, e.g. can change CoverageAmount
-	SafeClaimItemStatuses := []api.ClaimItemStatus{
-		api.ClaimItemStatusDraft,
-		api.ClaimItemStatusPaid,
-		api.ClaimItemStatusDenied,
+	// SafeClaimStatuses are states in which related items can be edited, e.g. can change CoverageAmount
+	SafeClaimStatuses := []api.ClaimStatus{
+		api.ClaimStatusDraft,
+		api.ClaimStatusPaid,
+		api.ClaimStatusDenied,
 	}
 
-	var claimItems ClaimItems
-	n, err := tx.Where("item_id = ?", i.ID).
-		Where("status NOT IN (?)", SafeClaimItemStatuses).
-		Count(&claimItems)
+	var claims Claims
+	n, err := tx.Where("claim_items.item_id = ?", i.ID).
+		Where("claims.status NOT IN (?)", SafeClaimStatuses).
+		Join("claim_items", "claims.id = claim_items.claim_id").
+		Count(&claims)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/application/models/ledgerentry_test.go
+++ b/application/models/ledgerentry_test.go
@@ -280,9 +280,6 @@ func (ms *ModelSuite) TestLedgerEntries_Reconcile() {
 				if after.ClaimID.Valid {
 					after.LoadClaim(ms.DB)
 					ms.Equal(api.ClaimStatusPaid, after.Claim.Status, "claim Status was not set to Paid")
-					after.Claim.LoadClaimItems(ms.DB, true)
-					ms.Equal(api.ClaimItemStatusPaid, after.Claim.ClaimItems[0].Status,
-						"claim item Status was not set to Paid")
 				}
 			}
 		})

--- a/application/models/models.go
+++ b/application/models/models.go
@@ -73,7 +73,6 @@ const (
 	FieldClaimCountry             = "Country"
 
 	FieldClaimItemItemID          = "ItemID"
-	FieldClaimItemStatus          = "Status"
 	FieldClaimItemIsRepairable    = "IsRepairable"
 	FieldClaimItemRepairEstimate  = "RepairEstimate"
 	FieldClaimItemRepairActual    = "RepairActual"

--- a/application/models/testutils.go
+++ b/application/models/testutils.go
@@ -174,12 +174,6 @@ func UpdateClaimStatus(tx *pop.Connection, claim Claim, status api.ClaimStatus, 
 	if err := tx.Update(&claim); err != nil {
 		panic("error trying to update claim status for test: " + err.Error())
 	}
-	if len(claim.ClaimItems) > 0 {
-		claim.ClaimItems[0].Status = api.ClaimItemStatus(status)
-		if err := tx.Update(&claim.ClaimItems[0]); err != nil {
-			panic("error trying to update claim item status for test: " + err.Error())
-		}
-	}
 	return claim
 }
 
@@ -232,7 +226,6 @@ func createClaimFixture(tx *pop.Connection, policy Policy, config FixturesConfig
 			ID:              uuid.UUID{},
 			ClaimID:         claim.ID,
 			ItemID:          item.ID,
-			Status:          api.ClaimItemStatus(claim.Status),
 			IsRepairable:    false,
 			RepairEstimate:  0,
 			RepairActual:    0,
@@ -244,8 +237,6 @@ func createClaimFixture(tx *pop.Connection, policy Policy, config FixturesConfig
 			City:            randStr(10),
 			State:           randStr(2),
 			Country:         randStr(10),
-			ReviewDate:      nulls.Time{},
-			ReviewerID:      nulls.UUID{},
 		}
 		MustCreate(tx, &claim.ClaimItems[i])
 	}

--- a/application/models/validation.go
+++ b/application/models/validation.go
@@ -18,7 +18,6 @@ var fieldValidators = map[string]func(validator.FieldLevel) bool{
 	"appRole":                       validateAppRole,
 	"claimIncidentType":             validateClaimIncidentType,
 	"claimStatus":                   validateClaimStatus,
-	"claimItemStatus":               validateClaimItemStatus,
 	"claimFilePurpose":              validateClaimFilePurpose,
 	"payoutOption":                  validatePayoutOption,
 	"policyDependentChildBirthYear": validatePolicyDependentChildBirthYear,
@@ -61,14 +60,6 @@ func validateClaimIncidentType(field validator.FieldLevel) bool {
 func validateClaimStatus(field validator.FieldLevel) bool {
 	if value, ok := field.Field().Interface().(api.ClaimStatus); ok {
 		_, valid := ValidClaimStatus[value]
-		return valid
-	}
-	return false
-}
-
-func validateClaimItemStatus(field validator.FieldLevel) bool {
-	if value, ok := field.Field().Interface().(api.ClaimItemStatus); ok {
-		_, valid := ValidClaimItemStatus[value]
 		return valid
 	}
 	return false
@@ -166,8 +157,8 @@ func claimItemStructLevelValidation(sl validator.StructLevel) {
 		panic("claimItemStructLevelValidation registered to a type other than ClaimItem")
 	}
 
-	switch claimItem.Status {
-	case api.ClaimItemStatusDraft, api.ClaimItemStatusRevision, api.ClaimItemStatusReview1:
+	switch claimItem.Claim.Status {
+	case api.ClaimStatusDraft, api.ClaimStatusRevision, api.ClaimStatusReview1:
 		incidentTypePayoutOptions, ok := ValidClaimIncidentTypePayoutOptions[claimItem.Claim.IncidentType]
 		if !ok {
 			sl.ReportError(claimItem.Claim.IncidentType, "IncidentType", "IncidentType", "invalid Incident type", "")
@@ -185,16 +176,6 @@ func claimItemStructLevelValidation(sl validator.StructLevel) {
 		}
 
 		return
-	}
-
-	if claimItem.Status.WasReviewed() {
-		if !claimItem.ReviewerID.Valid {
-			sl.ReportError(claimItem.Status, "reviewer_id", "ReviewerID", "reviewer_required", "")
-		}
-
-		if !claimItem.ReviewDate.Valid {
-			sl.ReportError(claimItem.Status, "review_date", "ReviewDate", "review_date_required", "")
-		}
 	}
 }
 


### PR DESCRIPTION
It was becoming increasingly difficult to keep these fields in-sync with the same fields on the parent Claim without causing infinite recursion. If we later decide they are needed, hopefully we can make a safe implementation at that time.