### PR TITLE
update payout amount for all Claim updates

### DIFF
--- a/application/messages/messages.go
+++ b/application/messages/messages.go
@@ -73,7 +73,7 @@ func (m MessageData) addClaimData(tx *pop.Connection, claim models.Claim) {
 
 	m["payoutOption"] = string(claim.ClaimItems[0].PayoutOption)
 	m["payoutOptionDescription"] = api.PayoutOptionDescriptions[claim.ClaimItems[0].PayoutOption]
-	m["maximumPayout"] = "$0.00" // TODO: calculate this value
+	m["maximumPayout"] = "$" + claim.TotalPayout.String()
 	m["submitted"] = domain.TimeBetween(time.Now().UTC(), claim.SubmittedAt(tx))
 }
 

--- a/application/models/claim.go
+++ b/application/models/claim.go
@@ -385,7 +385,7 @@ func (c *Claim) SubmitForApproval(ctx context.Context) error {
 		}
 	}
 
-	c.calculatePayout(ctx)
+	c.updatePayoutAmount(ctx)
 
 	if err := c.Update(ctx); err != nil {
 		return err
@@ -888,11 +888,11 @@ func (c *Claim) SubmittedAt(tx *pop.Connection) time.Time {
 	return c.UpdatedAt
 }
 
-func (c *Claim) calculatePayout(ctx context.Context) error {
+func (c *Claim) updatePayoutAmount(ctx context.Context) error {
 	c.LoadClaimItems(Tx(ctx), false)
 	var payout api.Currency
 	for _, claimItem := range c.ClaimItems {
-		if err := claimItem.calculatePayout(ctx); err != nil {
+		if err := claimItem.updatePayoutAmount(ctx); err != nil {
 			return err
 		}
 		payout += claimItem.PayoutAmount

--- a/application/models/claim.go
+++ b/application/models/claim.go
@@ -146,6 +146,10 @@ func (c *Claim) Update(ctx context.Context) error {
 		}
 	}
 
+	if err = c.calculatePayoutAmount(ctx); err != nil {
+		return err
+	}
+
 	if err = update(tx, c); err != nil {
 		return err
 	}
@@ -384,8 +388,6 @@ func (c *Claim) SubmitForApproval(ctx context.Context) error {
 			return api.NewAppError(err, errorKey, api.CategoryUser)
 		}
 	}
-
-	c.updatePayoutAmount(ctx)
 
 	if err := c.Update(ctx); err != nil {
 		return err
@@ -888,7 +890,7 @@ func (c *Claim) SubmittedAt(tx *pop.Connection) time.Time {
 	return c.UpdatedAt
 }
 
-func (c *Claim) updatePayoutAmount(ctx context.Context) error {
+func (c *Claim) calculatePayoutAmount(ctx context.Context) error {
 	c.LoadClaimItems(Tx(ctx), false)
 	var payout api.Currency
 	for _, claimItem := range c.ClaimItems {
@@ -898,6 +900,5 @@ func (c *Claim) updatePayoutAmount(ctx context.Context) error {
 		payout += claimItem.PayoutAmount
 	}
 	c.TotalPayout = payout
-
-	return c.Update(ctx)
+	return nil
 }

--- a/application/models/claim.go
+++ b/application/models/claim.go
@@ -146,7 +146,7 @@ func (c *Claim) Update(ctx context.Context) error {
 		}
 	}
 
-	if err = c.calculatePayoutAmount(ctx); err != nil {
+	if err = c.calculatePayout(ctx); err != nil {
 		return err
 	}
 
@@ -890,7 +890,7 @@ func (c *Claim) SubmittedAt(tx *pop.Connection) time.Time {
 	return c.UpdatedAt
 }
 
-func (c *Claim) calculatePayoutAmount(ctx context.Context) error {
+func (c *Claim) calculatePayout(ctx context.Context) error {
 	c.LoadClaimItems(Tx(ctx), false)
 	var payout api.Currency
 	for _, claimItem := range c.ClaimItems {

--- a/application/models/claim_test.go
+++ b/application/models/claim_test.go
@@ -887,7 +887,7 @@ func (ms *ModelSuite) TestClaims_ByStatus() {
 	}
 }
 
-func (ms *ModelSuite) TestClaim_calculatePayoutAmount() {
+func (ms *ModelSuite) TestClaim_calculatePayout() {
 	fixtures := CreateItemFixtures(ms.DB, FixturesConfig{ClaimsPerPolicy: 1, ClaimItemsPerClaim: 1})
 	fixtures.Claims[0].ClaimItems[0].RepairEstimate = 100
 	ms.NoError(ms.DB.Update(&fixtures.Claims[0].ClaimItems[0]))
@@ -898,7 +898,7 @@ func (ms *ModelSuite) TestClaim_calculatePayoutAmount() {
 
 	before := claim.TotalPayout
 
-	ms.NoError(claim.calculatePayoutAmount(CreateTestContext(fixtures.Users[0])))
+	ms.NoError(claim.calculatePayout(CreateTestContext(fixtures.Users[0])))
 
 	// The claim item test will check the actual amount. Just make sure it changed.
 	ms.False(claim.TotalPayout == before, "payout was not updated")

--- a/application/models/claim_test.go
+++ b/application/models/claim_test.go
@@ -887,7 +887,7 @@ func (ms *ModelSuite) TestClaims_ByStatus() {
 	}
 }
 
-func (ms *ModelSuite) TestClaim_calculatePayout() {
+func (ms *ModelSuite) TestClaim_updatePayoutAmount() {
 	fixtures := CreateItemFixtures(ms.DB, FixturesConfig{ClaimsPerPolicy: 1, ClaimItemsPerClaim: 1})
 	fixtures.Claims[0].ClaimItems[0].RepairEstimate = 100
 	ms.NoError(ms.DB.Update(&fixtures.Claims[0].ClaimItems[0]))
@@ -896,7 +896,7 @@ func (ms *ModelSuite) TestClaim_calculatePayout() {
 	var claim Claim
 	ms.NoError(claim.FindByID(ms.DB, fixtures.Claims[0].ID))
 
-	ms.NoError(claim.calculatePayout(CreateTestContext(fixtures.Users[0])))
+	ms.NoError(claim.updatePayoutAmount(CreateTestContext(fixtures.Users[0])))
 
 	// The claim item test will check the actual amount. Just make sure it's not zero.
 	ms.Greater(claim.TotalPayout, 0, "payout was not set")

--- a/application/models/claim_test.go
+++ b/application/models/claim_test.go
@@ -887,7 +887,7 @@ func (ms *ModelSuite) TestClaims_ByStatus() {
 	}
 }
 
-func (ms *ModelSuite) TestClaim_updatePayoutAmount() {
+func (ms *ModelSuite) TestClaim_calculatePayoutAmount() {
 	fixtures := CreateItemFixtures(ms.DB, FixturesConfig{ClaimsPerPolicy: 1, ClaimItemsPerClaim: 1})
 	fixtures.Claims[0].ClaimItems[0].RepairEstimate = 100
 	ms.NoError(ms.DB.Update(&fixtures.Claims[0].ClaimItems[0]))
@@ -896,8 +896,10 @@ func (ms *ModelSuite) TestClaim_updatePayoutAmount() {
 	var claim Claim
 	ms.NoError(claim.FindByID(ms.DB, fixtures.Claims[0].ID))
 
-	ms.NoError(claim.updatePayoutAmount(CreateTestContext(fixtures.Users[0])))
+	before := claim.TotalPayout
 
-	// The claim item test will check the actual amount. Just make sure it's not zero.
-	ms.Greater(claim.TotalPayout, 0, "payout was not set")
+	ms.NoError(claim.calculatePayoutAmount(CreateTestContext(fixtures.Users[0])))
+
+	// The claim item test will check the actual amount. Just make sure it changed.
+	ms.False(claim.TotalPayout == before, "payout was not updated")
 }

--- a/application/models/claimitem.go
+++ b/application/models/claimitem.go
@@ -419,7 +419,12 @@ func (c *ClaimItem) updatePayoutAmount(ctx context.Context) error {
 		maxValue = float64(coverageAmount)
 	}
 
+	before := c.PayoutAmount
 	c.PayoutAmount = api.Currency(math.Round(math.Min(maxValue, float64(coverageAmount)) * (1.0 - deductible)))
+
+	if c.PayoutAmount == before {
+		return nil
+	}
 
 	return c.Update(ctx)
 }

--- a/application/models/claimitem.go
+++ b/application/models/claimitem.go
@@ -419,12 +419,11 @@ func (c *ClaimItem) updatePayoutAmount(ctx context.Context) error {
 		maxValue = float64(coverageAmount)
 	}
 
-	before := c.PayoutAmount
-	c.PayoutAmount = api.Currency(math.Round(math.Min(maxValue, float64(coverageAmount)) * (1.0 - deductible)))
-
-	if c.PayoutAmount == before {
+	payout := api.Currency(math.Round(math.Min(maxValue, float64(coverageAmount)) * (1.0 - deductible)))
+	if c.PayoutAmount == payout {
 		return nil
 	}
 
+	c.PayoutAmount = payout
 	return c.Update(ctx)
 }

--- a/application/models/claimitem.go
+++ b/application/models/claimitem.go
@@ -396,25 +396,20 @@ func (c *ClaimItem) NewHistory(ctx context.Context, action string, fieldUpdate F
 
 func (c *ClaimItem) updatePayoutAmount(ctx context.Context) error {
 	c.LoadItem(Tx(ctx), false)
-	c.LoadClaim(Tx(ctx), false)
 
 	coverageAmount := c.Item.CoverageAmount
-
-	status := c.Claim.Status
-	useActual := status == api.ClaimStatusReview2 || status == api.ClaimStatusReview3 ||
-		status == api.ClaimStatusApproved || status == api.ClaimStatusPaid
 
 	deductible := 0.05
 	maxValue := 0.0
 	switch c.PayoutOption {
 	case api.PayoutOptionRepair:
 		maxValue = float64(c.RepairEstimate)
-		if useActual {
+		if c.RepairActual > 0 {
 			maxValue = float64(c.RepairActual)
 		}
 	case api.PayoutOptionReplacement:
 		maxValue = float64(c.ReplaceEstimate)
-		if useActual {
+		if c.ReplaceActual > 0 {
 			maxValue = float64(c.ReplaceActual)
 		}
 	case api.PayoutOptionFMV:

--- a/application/models/claimitem.go
+++ b/application/models/claimitem.go
@@ -394,7 +394,7 @@ func (c *ClaimItem) NewHistory(ctx context.Context, action string, fieldUpdate F
 	}
 }
 
-func (c *ClaimItem) calculatePayout(ctx context.Context) error {
+func (c *ClaimItem) updatePayoutAmount(ctx context.Context) error {
 	c.LoadItem(Tx(ctx), false)
 	c.LoadClaim(Tx(ctx), false)
 

--- a/application/models/claimitem_test.go
+++ b/application/models/claimitem_test.go
@@ -344,7 +344,7 @@ func (ms *ModelSuite) TestClaimItem_Compare() {
 	}
 }
 
-func (ms *ModelSuite) TestClaimItem_calculatePayout() {
+func (ms *ModelSuite) TestClaimItem_updatePayoutAmount() {
 	params := []UpdateClaimItemsParams{
 		{PayoutOption: api.PayoutOptionRepair, RepairEstimate: 100},
 		{PayoutOption: api.PayoutOptionReplacement, ReplaceEstimate: 200},

--- a/application/models/testutils.go
+++ b/application/models/testutils.go
@@ -183,6 +183,8 @@ type UpdateClaimItemsParams struct {
 	IsRepairable    bool
 	RepairEstimate  api.Currency
 	ReplaceEstimate api.Currency
+	RepairActual    api.Currency
+	ReplaceActual   api.Currency
 }
 
 // UpdateClaimItems sets the claim items to a state ready for submission.
@@ -194,6 +196,8 @@ func UpdateClaimItems(tx *pop.Connection, claim Claim, params UpdateClaimItemsPa
 		claim.ClaimItems[i].IsRepairable = params.IsRepairable
 		claim.ClaimItems[i].RepairEstimate = params.RepairEstimate
 		claim.ClaimItems[i].ReplaceEstimate = params.ReplaceEstimate
+		claim.ClaimItems[i].RepairActual = params.RepairActual
+		claim.ClaimItems[i].ReplaceActual = params.ReplaceActual
 		claim.ClaimItems[i].FMV = params.FMV
 		if err := tx.Update(&claim.ClaimItems[0]); err != nil {
 			panic("error trying to update claim items: " + err.Error())


### PR DESCRIPTION
Also changed the use of "actual" figures. Using the state value alone, the user would see the calculation based on "estimate" when the claim is at Receipt after they've entered an "actual" but before they submit to Review2. To eliminate that possibility, this change ignores the state and uses "actual" if it's non-zero.