### PR TITLE
Change refund granularity to monthly

### DIFF
--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -422,6 +422,15 @@ func CalculatePartialYearValue(value int, startDate time.Time) int {
 	return int(math.Round(float64(value*daysSince) / float64(days)))
 }
 
+// CalculateMonthlyRefundValue returns the value multiplied by the number
+//   of full calendar months left between the startDate and the end of
+//   the same year divided by 12  (rounded)
+func CalculateMonthlyRefundValue(value int, startDate time.Time) int {
+	startMonth := startDate.Month()
+	remainingMonths := 12 - int(startMonth)
+	return int(math.Round(float64(value*remainingMonths) / 12.0))
+}
+
 func BeginningOfLastMonth(date time.Time) time.Time {
 	return date.AddDate(0, -1, -date.Day()+1)
 }

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -426,8 +426,7 @@ func CalculatePartialYearValue(value int, startDate time.Time) int {
 //   of full calendar months left between the startDate and the end of
 //   the same year divided by 12  (rounded)
 func CalculateMonthlyRefundValue(value int, startDate time.Time) int {
-	startMonth := startDate.Month()
-	remainingMonths := 12 - int(startMonth)
+	remainingMonths := 12 - int(startDate.Month())
 	return int(math.Round(float64(value*remainingMonths) / 12.0))
 }
 

--- a/application/domain/domain_test.go
+++ b/application/domain/domain_test.go
@@ -123,6 +123,52 @@ func (ts *TestSuite) TestCalculatePartialYearValue() {
 	}
 }
 
+func (ts *TestSuite) TestCalculateMonthlyRefundValue() {
+	tests := []struct {
+		name      string
+		input     int
+		startDate time.Time
+		want      int
+	}{
+		{
+			name:      "end of January",
+			input:     120,
+			startDate: time.Date(2021, 1, 31, 10, 0, 0, 0, time.UTC),
+			want:      110,
+		},
+		{
+			name:      "first of February",
+			input:     120,
+			startDate: time.Date(2021, 2, 1, 20, 0, 0, 0, time.UTC),
+			want:      100,
+		},
+		{
+			name:      "end of November",
+			input:     120,
+			startDate: time.Date(2021, 11, 30, 0, 0, 0, 0, time.UTC),
+			want:      10,
+		},
+		{
+			name:      "first of December",
+			input:     120,
+			startDate: time.Date(2021, 12, 1, 0, 0, 0, 0, time.UTC),
+			want:      0,
+		},
+		{
+			name:      "check rounding",
+			input:     46,
+			startDate: time.Date(2021, 11, 30, 0, 0, 0, 0, time.UTC),
+			want:      4, // 3.83333 rounded up to 4
+		},
+	}
+	for _, tt := range tests {
+		ts.T().Run(tt.name, func(t *testing.T) {
+			got := CalculateMonthlyRefundValue(tt.input, tt.startDate)
+			ts.Equal(tt.want, got, "incorrect output value")
+		})
+	}
+}
+
 func (ts *TestSuite) Test_BeginningOfLastMonth() {
 	tests := []struct {
 		name string

--- a/application/models/item.go
+++ b/application/models/item.go
@@ -683,8 +683,15 @@ func (i *Item) calculateProratedPremium(t time.Time) api.Currency {
 }
 
 func (i *Item) calculateCancellationCredit(t time.Time) api.Currency {
-	p := domain.CalculatePartialYearValue(int(i.CalculateAnnualPremium()), t)
-	return api.Currency(-1 * p)
+	premium := int(i.CalculateAnnualPremium())
+	credit := premium
+	// Only a partial refund if it's past January or
+	//  if it's still January but the item's coverage just started this same month.
+	if t.Month() > 1 || i.CoverageStartDate.Year() == t.Year() {
+		credit = domain.CalculateMonthlyRefundValue(premium, t)
+	}
+
+	return api.Currency(-1 * credit)
 }
 
 func (i *Item) calculatePremiumChange(t time.Time, oldCoverageAmount int) api.Currency {

--- a/application/models/item.go
+++ b/application/models/item.go
@@ -683,15 +683,29 @@ func (i *Item) calculateProratedPremium(t time.Time) api.Currency {
 }
 
 func (i *Item) calculateCancellationCredit(t time.Time) api.Currency {
-	premium := int(i.CalculateAnnualPremium())
-	credit := premium
-	// Only a partial refund if it's past January or
-	//  if it's still January but the item's coverage just started this same month.
-	if t.Month() > 1 || i.CoverageStartDate.Year() == t.Year() {
-		credit = domain.CalculateMonthlyRefundValue(premium, t)
+	// If we're in December already, then no credit
+	if t.Month() == 12 {
+		return 0
 	}
 
+	// If the coverage was from a previous year and today is still in January,
+	//   give a full year's refund.
+	// If today is after January, give a refund for the following months only.
+	if i.CoverageStartDate.Year() < t.Year() {
+		premium := int(i.CalculateAnnualPremium())
+		if t.Month() == 1 {
+			return api.Currency(-1 * premium)
+		}
+		credit := domain.CalculateMonthlyRefundValue(premium, t)
+		return api.Currency(-1 * credit)
+	}
+
+	// If the coverage is from this year, give a refund for the following months only
+	//   based on the partial year's premium that would have been calculated for the item.
+	premium := int(i.calculateProratedPremium(i.CoverageStartDate))
+	credit := domain.CalculateMonthlyRefundValue(premium, t)
 	return api.Currency(-1 * credit)
+
 }
 
 func (i *Item) calculatePremiumChange(t time.Time, oldCoverageAmount int) api.Currency {

--- a/application/models/item_test.go
+++ b/application/models/item_test.go
@@ -767,9 +767,8 @@ func (ms *ModelSuite) TestItem_calculateProratedPremium() {
 
 func (ms *ModelSuite) TestItem_calculateCancellationCredit() {
 	domain.Env.PremiumFactor = 0.02
-	earlyJanuary := time.Date(2020, 1, 1, 1, 1, 1, 1, time.UTC)
-	midJanuary := time.Date(2020, 1, 11, 1, 1, 1, 1, time.UTC)
-	coverage := 6000 //  6000 * 0.02 == 120  which is easily divisible by 12
+	earlyJanuary := time.Date(2019, 1, 1, 1, 1, 1, 1, time.UTC)
+	midJanuary := time.Date(2019, 1, 11, 1, 1, 1, 1, time.UTC)
 
 	tests := []struct {
 		name              string
@@ -780,37 +779,45 @@ func (ms *ModelSuite) TestItem_calculateCancellationCredit() {
 	}{
 		{
 			name:              "Now January and created last year",
-			coverage:          coverage,
-			coverageStartDate: time.Date(2019, 12, 1, 1, 1, 1, 1, time.UTC),
+			coverage:          6000, //  6000 * 0.02 == 120 ,
+			coverageStartDate: time.Date(2018, 12, 1, 1, 1, 1, 1, time.UTC),
 			testTime:          midJanuary,
 			want:              -120,
 		},
 		{
-			name:              "Now January and created this year",
-			coverage:          coverage,
-			coverageStartDate: earlyJanuary,
+			name: "Now January and created same year",
+			//  219000 * 0.02 / 365 (days in the year) = 12 per day
+			//  Prorated Premium = 361 * 12 = 4332  (starting Jan 5)
+			//  Monthly premium = 4332 / 12 = 361
+			//  11 months credit = 3971
+			coverage:          219000,
+			coverageStartDate: time.Date(2019, 1, 5, 1, 1, 1, 1, time.UTC),
 			testTime:          midJanuary,
-			want:              -110,
+			want:              -3971,
 		},
 		{
-			name:              "Now February",
-			coverage:          coverage,
-			coverageStartDate: earlyJanuary,
-			testTime:          time.Date(2020, 2, 1, 1, 1, 1, 1, time.UTC),
-			want:              -100,
+			name: "Now February same year",
+			//  219000 * 0.02 / 365 (days in the year) = 12 per day
+			//  Prorated Premium = 355 * 12 = 4260   (starting Jan 11)
+			//  Monthly premium = 4260 / 12 = 355
+			//  10 months credit = 3550
+			coverage:          219000,
+			coverageStartDate: midJanuary,
+			testTime:          time.Date(2019, 2, 1, 1, 1, 1, 1, time.UTC),
+			want:              -3550,
 		},
 		{
-			name:              "November Round Up",
-			coverage:          coverage - 100,
-			coverageStartDate: earlyJanuary,
-			testTime:          time.Date(2020, 11, 1, 1, 1, 1, 1, time.UTC),
-			want:              -10,
+			name:              "November Round Up", // one month's credit
+			coverage:          218900,              // slightly lower than previous test case
+			coverageStartDate: midJanuary,
+			testTime:          time.Date(2019, 11, 1, 1, 1, 1, 1, time.UTC),
+			want:              -355,
 		},
 		{
-			name:              "Now December",
-			coverage:          coverage,
+			name:              "Now December same year",
+			coverage:          6000,
 			coverageStartDate: earlyJanuary,
-			testTime:          time.Date(2020, 12, 1, 1, 1, 1, 1, time.UTC),
+			testTime:          time.Date(2019, 12, 1, 1, 1, 1, 1, time.UTC),
 			want:              0,
 		},
 	}


### PR DESCRIPTION
It was easy enough to distinguish between refunds for old items stopped in January and newly covered items stopped in January, so I implemented that.  Old items stopped in January get full refund.  New items stopped in January get 11/12 refund, similar to the other months.