### PR TITLE
remove unused fields from PolicyCreate struct

### DIFF
--- a/application/api/policies.go
+++ b/application/api/policies.go
@@ -77,14 +77,6 @@ type PolicyCreate struct {
 	// policy name
 	Name string `json:"name"`
 
-	// Policy type. Only needed for steward endpoints. For customers, this will be set by the api.
-	Type string `json:"type"`
-
-	// Household ID for billing. Only required/allowed on Household type policies. (not actually uuid4; added as a doc generator hack)
-	//
-	// swagger:strfmt uuid4
-	HouseholdID nulls.String `json:"household_id,omitempty"`
-
 	// Cost center for billing. Only required/allowed on Team type policies.
 	CostCenter string `json:"cost_center,omitempty"`
 


### PR DESCRIPTION
https://trello.com/c/U97T7hun/173-remove-household-type-policy-fields-from-policiescorporatecreate-api-endpoint-or-rename-endpoint