### PR TITLE
decouple inactivation of ended items from other means of inactivation

### DIFF
--- a/application/models/item.go
+++ b/application/models/item.go
@@ -694,7 +694,7 @@ func (i *Item) ConvertToAPI(tx *pop.Connection) api.Item {
 func (i *Item) inactivateEnded(ctx context.Context) error {
 	tx := Tx(ctx)
 
-	if safe := i.canBeUpdated(tx); !safe {
+	if !i.canBeUpdated(tx) {
 		err := errors.New("item cannot be updated because it has an active claim")
 		return api.NewAppError(err, api.ErrorItemHasActiveClaim, api.CategoryUser)
 	}

--- a/application/models/item.go
+++ b/application/models/item.go
@@ -99,7 +99,7 @@ func (i *Item) Update(ctx context.Context) error {
 		}
 	}
 
-	if safe := i.canBeUpdated(tx); !safe {
+	if !i.canBeUpdated(tx) {
 		err := errors.New("item cannot be updated because it has an active claim")
 		return api.NewAppError(err, api.ErrorItemHasActiveClaim, api.CategoryUser)
 	}

--- a/application/models/item.go
+++ b/application/models/item.go
@@ -688,6 +688,37 @@ func (i *Item) ConvertToAPI(tx *pop.Connection) api.Item {
 	return apiItem
 }
 
+// This function is only intended to be used for items that have been active
+// but are now scheduled to become inactive.
+// As such, any credit ledger entries should have already been created.
+func (i *Item) inactivateEnded(ctx context.Context) error {
+	tx := Tx(ctx)
+
+	if safe := i.canBeUpdated(tx); !safe {
+		err := errors.New("item cannot be updated because it has an active claim")
+		return api.NewAppError(err, api.ErrorItemHasActiveClaim, api.CategoryUser)
+	}
+
+	i.LoadPolicyMembers(tx, false)
+
+	history := i.Policy.NewHistory(ctx,
+		api.HistoryActionUpdate,
+		FieldUpdate{
+			OldValue:  string(i.CoverageStatus),
+			NewValue:  string(api.ItemCoverageStatusInactive),
+			FieldName: FieldItemCoverageStatus,
+		})
+	history.ItemID = nulls.NewUUID(i.ID)
+	history.UserID = i.Policy.Members[0].ID
+	if err := history.Create(tx); err != nil {
+		return err
+	}
+
+	i.CoverageStatus = api.ItemCoverageStatusInactive
+
+	return update(tx, i)
+}
+
 // InactivateApprovedButEnded fetches all the items that have coverage_status=Approved
 //   and coverage_end_date before today and then
 //   saves them with coverage_status=Inactive
@@ -704,7 +735,7 @@ func (i *Items) InactivateApprovedButEnded(ctx context.Context) error {
 	errCount := 0
 	var lastErr error
 	for _, ii := range *i {
-		if err := ii.Inactivate(ctx); err != nil {
+		if err := ii.inactivateEnded(ctx); err != nil {
 			errCount++
 			domain.ErrLogger.Printf("InactivateApprovedButEnded error, %s", err)
 			lastErr = err

--- a/application/models/item_test.go
+++ b/application/models/item_test.go
@@ -647,7 +647,7 @@ func (ms *ModelSuite) TestItem_InactivateApprovedButEnded() {
 	fixtures := CreateItemFixtures(ms.DB, fixConfig)
 	policy := fixtures.Policies[0]
 	policy.LoadItems(ms.DB, false)
-	user := policy.Members[0]
+	user := User{}
 	items := policy.Items
 
 	ctx := CreateTestContext(user)


### PR DESCRIPTION
The lack of a real user for the history entry was causing it to fail.
When I tried to look through what was happening, I figured there was too much happening for this one little use case when the other common function was being called.