### PR TITLE
remove rendering from notifiers

### DIFF
--- a/application/notifications/dummy.go
+++ b/application/notifications/dummy.go
@@ -1,7 +1,6 @@
 package notifications
 
 import (
-	"bytes"
 	"errors"
 
 	"github.com/silinternational/cover-api/domain"
@@ -24,16 +23,7 @@ type DummyMessageInfo struct {
 func (t *DummyEmailService) Send(msg Message) error {
 	body := msg.Body
 
-	if body == "" {
-		eTemplate := msg.Template
-		bodyBuf := &bytes.Buffer{}
-		if err := EmailRenderer.HTML(eTemplate).Render(bodyBuf, msg.Data); err != nil {
-			errMsg := "error rendering dummy email message body - " + err.Error()
-			domain.ErrLogger.Printf(errMsg)
-			return errors.New(errMsg)
-		}
-		body = bodyBuf.String()
-	} else if body == "ERROR" {
+	if body == "ERROR" {
 		return errors.New("mock error for testing sending email message")
 	}
 

--- a/application/notifications/email_test.go
+++ b/application/notifications/email_test.go
@@ -1,41 +1,19 @@
 package notifications
 
 import (
-	"text/template"
-
-	"github.com/gobuffalo/nulls"
-
 	"github.com/silinternational/cover-api/domain"
-	"github.com/silinternational/cover-api/models"
 )
 
 func (ts *TestSuite) TestSend() {
-	item := models.Item{
-		Name: "My Item",
-	}
-
 	nickname := "nickname"
+	const body = "This is the message body."
 	msg := Message{
 		FromName:  "from name",
 		FromEmail: domain.EmailFromAddress(&nickname),
 		ToName:    "to name",
 		ToEmail:   "to@example.com",
 		Template:  "item_pending_steward",
-		Data: map[string]interface{}{
-			"uiURL":             "example.com",
-			"appName":           "Our App",
-			"buttonLabel":       "Open in Our App",
-			"itemURL":           "https://my-item.example.com",
-			"item":              item,
-			"memberName":        "John Doe",
-			"supportEmail":      "support@example.com",
-			"coverageAmount":    "$100.00",
-			"coverageEndDate":   "2021-12-31",
-			"coverageStartDate": "2021-01-01",
-			"annualPremium":     "$3.50",
-			"accountablePerson": "John Doe",
-			"policy":            models.Policy{HouseholdID: nulls.NewString("007")},
-		},
+		Body:      body,
 	}
 	var emailService EmailService
 	var testService DummyEmailService
@@ -47,8 +25,5 @@ func (ts *TestSuite) TestSend() {
 	n := len(testService.GetSentMessages())
 	ts.Require().Equal(1, n, "incorrect number of messages sent")
 
-	body := testService.GetLastBody()
-
-	ts.Contains(body, template.HTMLEscapeString(msg.Data["itemURL"].(string)))
-	ts.NotContains(body, "<script>")
+	ts.Equal(body, testService.GetLastBody())
 }

--- a/application/notifications/ses.go
+++ b/application/notifications/ses.go
@@ -1,8 +1,6 @@
 package notifications
 
 import (
-	"bytes"
-	"errors"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -24,23 +22,10 @@ type awsConfig struct {
 
 // Send a message
 func (s *SES) Send(msg Message) error {
-	body := msg.Body
-	if body == "" { // TODO decide if this is needed, where the body needs to get rendered here
-		msg.Data["uiURL"] = domain.Env.UIURL
-		msg.Data["appName"] = domain.Env.AppName
-
-		bodyBuf := &bytes.Buffer{}
-		if err := EmailRenderer.HTML(msg.Template).Render(bodyBuf, msg.Data); err != nil {
-			return errors.New("error rendering ses message body - " + err.Error())
-		}
-		body = bodyBuf.String()
-	}
-
 	to := addressWithName(msg.ToName, msg.ToEmail)
 	from := addressWithName(msg.FromName, msg.FromEmail)
-	subject := msg.Subject
 
-	return SendRaw(from, rawEmail(to, from, subject, body))
+	return SendRaw(from, rawEmail(to, from, msg.Subject, msg.Body))
 }
 
 func addressWithName(name, address string) string {


### PR DESCRIPTION
Rendering must be done earlier in order to support the new queued message functionality.