### PR TITLE
remove TODOs related to steward/signator distinction

### DIFF
--- a/application/actions/claims_test.go
+++ b/application/actions/claims_test.go
@@ -935,7 +935,6 @@ func (as *ActionSuite) Test_ClaimsApprove() {
 	policy := fixtures.Policies[0]
 	policyCreator := policy.Members[0]
 
-	// TODO when code distinguishes between admin types, then check that here
 	appAdmin := models.CreateAdminUsers(as.DB)[models.AppRoleSteward]
 
 	draftClaim := policy.Claims[0]
@@ -1057,7 +1056,6 @@ func (as *ActionSuite) Test_ClaimsDeny() {
 	policy := fixtures.Policies[0]
 	policyCreator := policy.Members[0]
 
-	// TODO when code distinguishes between admin types, then try with both
 	appAdmin := models.CreateAdminUsers(as.DB)[models.AppRoleSteward]
 
 	draftClaim := policy.Claims[0]

--- a/application/models/claim.go
+++ b/application/models/claim.go
@@ -227,7 +227,6 @@ func (c *Claim) FindByReferenceNumber(tx *pop.Connection, ref string) error {
 }
 
 // IsActorAllowedTo ensure the actor is either an admin, or a member of this policy to perform any permission
-// TODO Differentiate between admins (steward and signator)
 func (c *Claim) IsActorAllowedTo(tx *pop.Connection, actor User, perm Permission, sub SubResource, r *http.Request) bool {
 	if actor.IsAdmin() {
 		return true
@@ -473,7 +472,6 @@ func (c *Claim) RequestReceipt(ctx buffalo.Context, reason string) error {
 
 // Approve changes the status of the claim from either Review1, Review2 to Review3 or
 //  from Review3 to Approved. It also adds the ReviewerID and ReviewDate.
-// TODO distinguish between admin types (steward vs. signator)
 func (c *Claim) Approve(ctx context.Context) error {
 	var eventType string
 


### PR DESCRIPTION
I believe that we have this resolved, simply by disallowing the same user from approving at Review2 and Review3. Is that sufficient?