### PR TITLE
add calc totals to policy endpoints

### DIFF
--- a/application/actions/policies.go
+++ b/application/actions/policies.go
@@ -33,10 +33,6 @@ import (
 //   in: query
 //   required: false
 //   description: comma-separated list of search pairs like "field:text". Presently, only meta-field 'active' is supported
-// - name: totals
-//   in: query
-//   required: false
-//   description: calculate and return policy totals
 // responses:
 //   '200':
 //     description: all policies
@@ -101,7 +97,7 @@ func policiesListCustomer(c buffalo.Context) error {
 func policiesView(c buffalo.Context) error {
 	policy := getReferencedPolicyFromCtx(c)
 
-	return renderOk(c, policy.ConvertToAPI(models.Tx(c), true, true))
+	return renderOk(c, policy.ConvertToAPI(models.Tx(c), true))
 }
 
 // swagger:operation POST /policies Policies PoliciesCreateTeam
@@ -144,7 +140,7 @@ func policiesCreateTeam(c buffalo.Context) error {
 		return reportError(c, err)
 	}
 
-	return renderOk(c, policy.ConvertToAPI(tx, true, true))
+	return renderOk(c, policy.ConvertToAPI(tx, true))
 }
 
 // swagger:operation PUT /policies/{id} Policies PoliciesUpdate
@@ -202,7 +198,7 @@ func policiesUpdate(c buffalo.Context) error {
 		return reportError(c, err)
 	}
 
-	return renderOk(c, policy.ConvertToAPI(tx, true, true))
+	return renderOk(c, policy.ConvertToAPI(tx, true))
 }
 
 // swagger:operation GET /policies/{id}/members PolicyMembers PolicyMembersList

--- a/application/actions/policies.go
+++ b/application/actions/policies.go
@@ -33,6 +33,10 @@ import (
 //   in: query
 //   required: false
 //   description: comma-separated list of search pairs like "field:text". Presently, only meta-field 'active' is supported
+// - name: totals
+//   in: query
+//   required: false
+//   description: calculate and return policy totals
 // responses:
 //   '200':
 //     description: all policies
@@ -97,7 +101,7 @@ func policiesListCustomer(c buffalo.Context) error {
 func policiesView(c buffalo.Context) error {
 	policy := getReferencedPolicyFromCtx(c)
 
-	return renderOk(c, policy.ConvertToAPI(models.Tx(c), true))
+	return renderOk(c, policy.ConvertToAPI(models.Tx(c), true, true))
 }
 
 // swagger:operation POST /policies Policies PoliciesCreateTeam
@@ -140,7 +144,7 @@ func policiesCreateTeam(c buffalo.Context) error {
 		return reportError(c, err)
 	}
 
-	return renderOk(c, policy.ConvertToAPI(tx, true))
+	return renderOk(c, policy.ConvertToAPI(tx, true, true))
 }
 
 // swagger:operation PUT /policies/{id} Policies PoliciesUpdate
@@ -198,7 +202,7 @@ func policiesUpdate(c buffalo.Context) error {
 		return reportError(c, err)
 	}
 
-	return renderOk(c, policy.ConvertToAPI(tx, true))
+	return renderOk(c, policy.ConvertToAPI(tx, true, true))
 }
 
 // swagger:operation GET /policies/{id}/members PolicyMembers PolicyMembersList

--- a/application/api/claims.go
+++ b/application/api/claims.go
@@ -49,6 +49,14 @@ func (s ClaimStatus) WasReviewed() bool {
 	return false
 }
 
+func (s ClaimStatus) IsOpen() bool {
+	switch s {
+	case ClaimStatusDraft, ClaimStatusReview1, ClaimStatusReview2, ClaimStatusReview3, ClaimStatusRevision, ClaimStatusReceipt:
+		return true
+	}
+	return false
+}
+
 const (
 	ClaimIncidentTypeTheft           = ClaimIncidentType("Theft")
 	ClaimIncidentTypePhysicalDamage  = ClaimIncidentType("Physical damage")

--- a/application/api/items.go
+++ b/application/api/items.go
@@ -13,6 +13,10 @@ import (
 // swagger:model
 type ItemCoverageStatus string
 
+func (status ItemCoverageStatus) IsActive() bool {
+	return status == ItemCoverageStatusApproved
+}
+
 const (
 	ItemCoverageStatusDraft    = ItemCoverageStatus("Draft")
 	ItemCoverageStatusPending  = ItemCoverageStatus("Pending")

--- a/application/api/policies.go
+++ b/application/api/policies.go
@@ -68,6 +68,9 @@ type Policy struct {
 
 	// List of claims on policy
 	Claims Claims `json:"claims"`
+
+	// Calculated policy totals
+	Totals PolicyTotals `json:"totals"`
 }
 
 // PolicyCreate represents payload for creating a policy

--- a/application/api/totals.go
+++ b/application/api/totals.go
@@ -10,7 +10,7 @@ type PolicyTotals struct {
 // ItemTotals contains totals calculated from all items
 type ItemTotals struct {
 	// coverage amount (0.01 USD)
-	CoverageAmount int `json:"coverage_amount"`
+	CoverageAmount Currency `json:"coverage_amount"`
 
 	// annual premium (0.01 USD)
 	AnnualPremium Currency `json:"annual_premium"`

--- a/application/api/totals.go
+++ b/application/api/totals.go
@@ -1,0 +1,23 @@
+package api
+
+// PolicyTotals contains calculated totals for a policy
+// swagger:model
+type PolicyTotals struct {
+	Items  ItemTotals  `json:"items"`
+	Claims ClaimTotals `json:"claims"`
+}
+
+// ItemTotals contains totals calculated from all items
+type ItemTotals struct {
+	// coverage amount (0.01 USD)
+	CoverageAmount int `json:"coverage_amount"`
+
+	// annual premium (0.01 USD)
+	AnnualPremium Currency `json:"annual_premium"`
+}
+
+// ClaimTotals contains totals calculated from all claims
+type ClaimTotals struct {
+	OpenClaims   int      `json:"open_claims"`
+	PayoutAmount Currency `json:"payout_amount"`
+}

--- a/application/models/claim.go
+++ b/application/models/claim.go
@@ -650,6 +650,19 @@ func (c *Claims) ByStatus(tx *pop.Connection, statuses []api.ClaimStatus) error 
 	return appErrorFromDB(err, api.ErrorQueryFailure)
 }
 
+func (c *Claims) CalcTotals() api.ClaimTotals {
+	var claimTotals api.ClaimTotals
+
+	for _, claim := range *c {
+		if claim.Status.IsOpen() {
+			claimTotals.OpenClaims++
+		}
+		claimTotals.PayoutAmount += claim.TotalPayout
+	}
+
+	return claimTotals
+}
+
 func ConvertClaimCreateInput(input api.ClaimCreateInput) Claim {
 	return Claim{
 		IncidentDate:        input.IncidentDate,

--- a/application/models/item.go
+++ b/application/models/item.go
@@ -374,7 +374,7 @@ func (i *Items) CalcTotals() api.ItemTotals {
 
 	for _, item := range *i {
 		if item.CoverageStatus.IsActive() {
-			itemTotals.CoverageAmount += item.CoverageAmount
+			itemTotals.CoverageAmount += api.Currency(item.CoverageAmount)
 			itemTotals.AnnualPremium += item.CalculateAnnualPremium()
 		}
 	}

--- a/application/models/item.go
+++ b/application/models/item.go
@@ -369,6 +369,19 @@ func (i *Item) IsActorAllowedTo(tx *pop.Connection, actor User, perm Permission,
 	return false
 }
 
+func (i *Items) CalcTotals() api.ItemTotals {
+	var itemTotals api.ItemTotals
+
+	for _, item := range *i {
+		if item.CoverageStatus.IsActive() {
+			itemTotals.CoverageAmount += item.CoverageAmount
+			itemTotals.AnnualPremium += item.CalculateAnnualPremium()
+		}
+	}
+
+	return itemTotals
+}
+
 func itemStatusTransitions() map[api.ItemCoverageStatus][]api.ItemCoverageStatus {
 	return map[api.ItemCoverageStatus][]api.ItemCoverageStatus{
 		api.ItemCoverageStatusDraft: {

--- a/application/models/policy.go
+++ b/application/models/policy.go
@@ -221,7 +221,7 @@ func (p *Policy) LoadEntityCode(tx *pop.Connection, reload bool) {
 	}
 }
 
-func (p *Policy) ConvertToAPI(tx *pop.Connection, hydrate, calcTotals bool) api.Policy {
+func (p *Policy) ConvertToAPI(tx *pop.Connection, hydrate bool) api.Policy {
 	p.LoadEntityCode(tx, true)
 	p.LoadMembers(tx, true)
 
@@ -239,18 +239,12 @@ func (p *Policy) ConvertToAPI(tx *pop.Connection, hydrate, calcTotals bool) api.
 		UpdatedAt:     p.UpdatedAt,
 	}
 
-	if hydrate || calcTotals {
-		p.LoadClaims(tx, true)
-	}
-
 	if hydrate {
+		p.LoadItems(tx, true)
+		p.LoadClaims(tx, true)
 		p.LoadDependents(tx, true)
 		apiPolicy.Claims = p.Claims.ConvertToAPI(tx)
 		apiPolicy.Dependents = p.Dependents.ConvertToAPI()
-	}
-
-	if calcTotals {
-		p.LoadItems(tx, true)
 
 		apiPolicy.Totals.Items = p.Items.CalcTotals()
 		apiPolicy.Totals.Claims = p.Claims.CalcTotals()
@@ -262,7 +256,7 @@ func (p *Policy) ConvertToAPI(tx *pop.Connection, hydrate, calcTotals bool) api.
 func (p *Policies) ConvertToAPI(tx *pop.Connection) api.Policies {
 	policies := make(api.Policies, len(*p))
 	for i, pp := range *p {
-		policies[i] = pp.ConvertToAPI(tx, false, false)
+		policies[i] = pp.ConvertToAPI(tx, false)
 	}
 
 	return policies


### PR DESCRIPTION
still needs a little work. tell me why it sucks @Schparky 

Still needs 
* Ability to specify `GET /policies?totals` to include totals on that request
* Set the 'totals' object to null or something else when totals is not being populated