### PR TITLE
Release - no zero-dollar transactions

### DIFF
--- a/application/fin/sage.go
+++ b/application/fin/sage.go
@@ -27,7 +27,9 @@ type Sage struct {
 }
 
 func (s *Sage) AppendToBatch(t Transaction) {
-	s.Transactions = append(s.Transactions, t)
+	if t.Amount != 0 {
+		s.Transactions = append(s.Transactions, t)
+	}
 }
 
 func (s *Sage) BatchToCSV() []byte {


### PR DESCRIPTION
In ledger report, don't include transactions that have a zero amount.