### PR TITLE
add parent entity codes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
-dev: buffalo adminer migrate
+dev: buffalo adminer migrate grifts
 
 migrate: db
 	docker-compose run --rm buffalo whenavail db 5432 10 buffalo-pop pop migrate up
+
+grifts: db
 	docker-compose run --rm buffalo /bin/bash -c "grift db:seed && grift minio:seed"
 
 migratestatus: db

--- a/application/migrations/20220114203529_add_parent_entity_to_entity_table.down.fizz
+++ b/application/migrations/20220114203529_add_parent_entity_to_entity_table.down.fizz
@@ -1,0 +1,1 @@
+drop_column("entity_codes", "parent_entity")

--- a/application/migrations/20220114203529_add_parent_entity_to_entity_table.up.fizz
+++ b/application/migrations/20220114203529_add_parent_entity_to_entity_table.up.fizz
@@ -1,0 +1,1 @@
+add_column("entity_codes", "parent_entity", "string", {"default": ""})

--- a/application/models/entitycode.go
+++ b/application/models/entitycode.go
@@ -22,6 +22,7 @@ type EntityCode struct {
 	Name          string    `db:"name"`
 	Active        bool      `db:"active"`
 	IncomeAccount string    `db:"income_account"`
+	ParentEntity  string    `db:"parent_entity"`
 
 	CreatedAt time.Time `db:"created_at"`
 	UpdatedAt time.Time `db:"updated_at"`
@@ -30,6 +31,14 @@ type EntityCode struct {
 func (ec *EntityCode) Create(tx *pop.Connection) error {
 	ec.ID = GetV5UUID(ec.Code)
 	return create(tx, ec)
+}
+
+func (ec *EntityCode) FindByCode(tx *pop.Connection) error {
+	err := tx.Where("code = ?", ec.Code).First(ec)
+	if err != nil {
+		return appErrorFromDB(err, api.ErrorQueryFailure)
+	}
+	return nil
 }
 
 func EntityCodeID(code string) uuid.UUID {

--- a/application/models/entitycode_test.go
+++ b/application/models/entitycode_test.go
@@ -1,0 +1,49 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/silinternational/cover-api/api"
+)
+
+func (ms *ModelSuite) TestEntityCode_FindByCode() {
+	entityFixture := CreateEntityFixture(ms.DB)
+
+	tests := []struct {
+		name string
+		code string
+
+		appError *api.AppError
+	}{
+		{
+			name:     "empty string",
+			code:     "",
+			appError: &api.AppError{Category: api.CategoryUser, Key: api.ErrorNoRows},
+		},
+		{
+			name:     "not found",
+			code:     "not a real code",
+			appError: &api.AppError{Category: api.CategoryUser, Key: api.ErrorNoRows},
+		},
+		{
+			name:     "good",
+			code:     entityFixture.Code,
+			appError: nil,
+		},
+	}
+	for _, tt := range tests {
+		ms.T().Run(tt.name, func(t *testing.T) {
+			ec := &EntityCode{
+				Code: tt.code,
+			}
+			err := ec.FindByCode(ms.DB)
+			if tt.appError != nil {
+				// ms.Error(err, "test should have produced an error")
+				ms.EqualAppError(*tt.appError, err)
+				return
+			}
+			ms.NoError(err)
+			ms.Equal(entityFixture.ID, ec.ID, "found wrong entity code")
+		})
+	}
+}

--- a/application/models/entitycode_test.go
+++ b/application/models/entitycode_test.go
@@ -38,7 +38,6 @@ func (ms *ModelSuite) TestEntityCode_FindByCode() {
 			}
 			err := ec.FindByCode(ms.DB)
 			if tt.appError != nil {
-				// ms.Error(err, "test should have produced an error")
 				ms.EqualAppError(*tt.appError, err)
 				return
 			}

--- a/application/models/ledgerentry.go
+++ b/application/models/ledgerentry.go
@@ -198,10 +198,15 @@ func (le *LedgerEntry) balanceDescription() string {
 	if le.Type.IsClaim() {
 		premiumsOrClaims = "Claims"
 	}
+
 	entity := le.EntityCode
-	if le.PolicyType != api.PolicyTypeTeam {
-		entity = string(le.PolicyType)
+	e := EntityCode{Code: le.EntityCode}
+
+	// Don't need to use a transaction since entity codes shouldn't be changing during this operation.
+	if err := e.FindByCode(DB); err == nil && e.ParentEntity != "" {
+		entity = e.ParentEntity
 	}
+
 	return fmt.Sprintf("Total %s %s %s", entity, le.RiskCategoryName, premiumsOrClaims)
 }
 

--- a/application/models/models_test.go
+++ b/application/models/models_test.go
@@ -76,8 +76,8 @@ func (ms *ModelSuite) Test_CurrentUser() {
 func (ms *ModelSuite) EqualAppError(expected api.AppError, actual error) {
 	var appErr *api.AppError
 	ms.True(errors.As(actual, &appErr), "error does not contain an api.AppError")
-	ms.Equal(appErr.Key, expected.Key, "error key does not match")
-	ms.Equal(appErr.Category, expected.Category, "error category does not match")
+	ms.Equal(expected.Key, appErr.Key, "error key does not match")
+	ms.Equal(expected.Category, appErr.Category, "error category does not match")
 }
 
 func (ms *ModelSuite) EqualNullTime(expected nulls.Time, actual *time.Time, msgAndArgs ...interface{}) {


### PR DESCRIPTION
This is strictly for accounting documentation, to make the description on "total" lines read correctly.

Before:

> Total MXB Claims

After

> Total WBT Claims

Where WBT is the parent entity for MXB