### PR TITLE
Ledger endpoint changes

### DIFF
--- a/application/actions/app.go
+++ b/application/actions/app.go
@@ -149,10 +149,12 @@ func App() *buffalo.App {
 
 		// accounting ledger
 		ledgerGroup := app.Group(ledgerPath)
-		ledgerGroup.Middleware.Skip(AuthZ, ledgerAnnual) // AuthZ is implemented in the handlers
+		// AuthZ is implemented in the handlers
+		ledgerGroup.Middleware.Skip(AuthZ, ledgerAnnualList, ledgerAnnualProcess)
 		ledgerGroup.GET("/", ledgerList)
 		ledgerGroup.POST("/", ledgerReconcile)
-		ledgerGroup.GET("/annual", ledgerAnnual)
+		ledgerGroup.GET("/annual", ledgerAnnualList)
+		ledgerGroup.POST("/annual", ledgerAnnualProcess)
 
 		stewardGroup := app.Group(stewardPath)
 		stewardGroup.Middleware.Skip(AuthZ, stewardListRecentObjects) // AuthZ is implemented in the handler

--- a/application/actions/app.go
+++ b/application/actions/app.go
@@ -149,7 +149,7 @@ func App() *buffalo.App {
 
 		// accounting ledger
 		ledgerGroup := app.Group(ledgerPath)
-		ledgerGroup.Middleware.Skip(AuthZ, ledgerList, ledgerReconcile, ledgerAnnual) // AuthZ is implemented in the handler
+		ledgerGroup.Middleware.Skip(AuthZ, ledgerAnnual) // AuthZ is implemented in the handlers
 		ledgerGroup.GET("/", ledgerList)
 		ledgerGroup.POST("/", ledgerReconcile)
 		ledgerGroup.GET("/annual", ledgerAnnual)

--- a/application/actions/authz.go
+++ b/application/actions/authz.go
@@ -20,6 +20,7 @@ func AuthZ(next buffalo.Handler) buffalo.Handler {
 			domain.TypeClaimFile:       &models.ClaimFile{},
 			domain.TypeClaimItem:       &models.ClaimItem{},
 			domain.TypeItem:            &models.Item{},
+			domain.TypeLedger:          &models.LedgerEntry{},
 			domain.TypePolicy:          &models.Policy{},
 			domain.TypePolicyDependent: &models.PolicyDependent{},
 			domain.TypePolicyUser:      &models.PolicyUser{},

--- a/application/actions/ledger.go
+++ b/application/actions/ledger.go
@@ -92,11 +92,12 @@ func ledgerReconcile(c buffalo.Context) error {
 	return renderOk(c, api.BatchApproveResponse{NumberOfRecordsApproved: len(le)})
 }
 
-// swagger:operation GET /ledger/annual Ledger LedgerAnnual
+// swagger:operation GET /ledger/annual Ledger LedgerAnnualList
 //
-// LedgerAnnual
+// LedgerAnnualList
 //
-// Get the billing detail for current year's policy renewals
+// Get the billing detail for current year's policy renewals. Header `Accept` can be either
+// `application/json` or `text/csv`.
 //
 // ---
 // responses:
@@ -107,7 +108,47 @@ func ledgerReconcile(c buffalo.Context) error {
 //         schema:
 //           type: string
 //           format: text
-func ledgerAnnual(c buffalo.Context) error {
+func ledgerAnnualList(c buffalo.Context) error {
+	actor := models.CurrentUser(c)
+	if !actor.IsAdmin() {
+		err := fmt.Errorf("user not allowed to list annual batch data")
+		return reportError(c, api.NewAppError(err, api.ErrorNotAuthorized, api.CategoryForbidden))
+	}
+
+	tx := models.Tx(c)
+
+	currentYear := time.Now().UTC().Year()
+
+	var le models.LedgerEntries
+	if err := le.FindCurrentRenewals(tx, currentYear); err != nil {
+		return reportError(c, err)
+	}
+
+	if domain.IsStringInSlice("text/csv", c.Request().Header["Accept"]) {
+		if len(le) == 0 {
+			return c.Render(http.StatusNoContent, nil)
+		}
+
+		date := time.Date(currentYear, 1, 1, 0, 0, 0, 0, time.UTC)
+		csvData := le.ToCsv(date)
+		filename := fmt.Sprintf("renewal_%d.csv", currentYear)
+		return renderCsv(c, filename, csvData)
+	}
+
+	return renderOk(c, le.ConvertToAPI(tx))
+}
+
+// swagger:operation POST /ledger/annual Ledger LedgerAnnualProcess
+//
+// LedgerAnnualProcess
+//
+// Process billing for current year's policy renewals.
+//
+// ---
+// responses:
+//   '204':
+//     description: OK but no content in response
+func ledgerAnnualProcess(c buffalo.Context) error {
 	actor := models.CurrentUser(c)
 	if !actor.IsAdmin() {
 		err := fmt.Errorf("user not allowed to process annual batch data")
@@ -122,19 +163,7 @@ func ledgerAnnual(c buffalo.Context) error {
 		return reportError(c, err)
 	}
 
-	var le models.LedgerEntries
-	if err := le.FindCurrentRenewals(tx, currentYear); err != nil {
-		return reportError(c, err)
-	}
-
-	if len(le) == 0 {
-		return c.Render(http.StatusNoContent, nil)
-	}
-
-	date := time.Date(currentYear, 1, 1, 0, 0, 0, 0, time.UTC)
-	csvData := le.ToCsv(date)
-	filename := fmt.Sprintf("renewal_%d.csv", currentYear)
-	return renderCsv(c, filename, csvData)
+	return c.Render(http.StatusNoContent, nil)
 }
 
 func renderCsv(c buffalo.Context, filename string, csvData []byte) error {

--- a/application/actions/ledger.go
+++ b/application/actions/ledger.go
@@ -28,12 +28,6 @@ import (
 //           type: string
 //           format: text
 func ledgerList(c buffalo.Context) error {
-	actor := models.CurrentUser(c)
-	if !actor.IsAdmin() {
-		err := fmt.Errorf("user not allowed to get monthly batch data")
-		return reportError(c, api.NewAppError(err, api.ErrorNotAuthorized, api.CategoryForbidden))
-	}
-
 	tx := models.Tx(c)
 
 	date := domain.BeginningOfDay(time.Now().UTC())
@@ -74,12 +68,6 @@ func ledgerList(c buffalo.Context) error {
 //     schema:
 //       "$ref": "#/definitions/BatchApproveResponse"
 func ledgerReconcile(c buffalo.Context) error {
-	actor := models.CurrentUser(c)
-	if !actor.IsAdmin() {
-		err := fmt.Errorf("user not allowed to reconcile ledger data")
-		return reportError(c, api.NewAppError(err, api.ErrorNotAuthorized, api.CategoryForbidden))
-	}
-
 	var input api.LedgerReconcileInput
 	if err := StrictBind(c, &input); err != nil {
 		return reportError(c, err)

--- a/application/actions/ledger_test.go
+++ b/application/actions/ledger_test.go
@@ -148,7 +148,7 @@ func (as *ActionSuite) Test_LedgerReconcile() {
 	}
 }
 
-func (as *ActionSuite) Test_LedgerAnnual() {
+func (as *ActionSuite) Test_LedgerAnnualList() {
 	year := time.Now().UTC().Year()
 
 	f := models.CreateItemFixtures(as.DB, models.FixturesConfig{ItemsPerPolicy: 3})
@@ -189,8 +189,11 @@ func (as *ActionSuite) Test_LedgerAnnual() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			as.NoError(models.ProcessAnnualCoverage(as.DB, year), "failed to process renewals")
+
 			req := as.JSON(ledgerPath + "/annual")
 			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Accept"] = "text/csv"
 			res := req.Get()
 
 			body := res.Body.String()
@@ -206,6 +209,59 @@ func (as *ActionSuite) Test_LedgerAnnual() {
 
 			rows := len(strings.Split(res.Body.String(), "\n")) - 1 // don't count empty row at end
 			as.Equal(tt.wantRows, rows, "incorrect count of CSV rows")
+		})
+	}
+}
+
+func (as *ActionSuite) Test_LedgerAnnualProcess() {
+	year := time.Now().UTC().Year()
+
+	f := models.CreateItemFixtures(as.DB, models.FixturesConfig{ItemsPerPolicy: 3})
+
+	f.Items[0].PaidThroughYear = year
+	models.UpdateItemStatus(as.DB, f.Items[0], api.ItemCoverageStatusApproved, "")
+	models.UpdateItemStatus(as.DB, f.Items[1], api.ItemCoverageStatusApproved, "")
+
+	normalUser := f.Users[0]
+	stewardUser := models.CreateAdminUsers(as.DB)[models.AppRoleSteward]
+
+	tests := []struct {
+		name       string
+		actor      models.User
+		wantStatus int
+		wantInBody []string
+	}{
+		{
+			name:       "unauthenticated",
+			actor:      models.User{},
+			wantStatus: http.StatusUnauthorized,
+			wantInBody: []string{api.ErrorNotAuthorized.String()},
+		},
+		{
+			name:       "insufficient privileges",
+			actor:      normalUser,
+			wantStatus: http.StatusNotFound,
+			wantInBody: []string{`"key":"` + api.ErrorNotAuthorized.String()},
+		},
+		{
+			name:       "steward user good results",
+			actor:      stewardUser,
+			wantStatus: http.StatusNoContent,
+		},
+	}
+
+	for _, tt := range tests {
+		as.T().Run(tt.name, func(t *testing.T) {
+			req := as.JSON(ledgerPath + "/annual")
+			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			res := req.Post(nil)
+
+			body := res.Body.String()
+			as.Equal(tt.wantStatus, res.Code, "incorrect status code returned, body: %s", body)
+
+			for _, s := range tt.wantInBody {
+				as.Contains(body, s)
+			}
 		})
 	}
 }

--- a/application/actions/ledger_test.go
+++ b/application/actions/ledger_test.go
@@ -40,7 +40,7 @@ func (as *ActionSuite) Test_LedgerList() {
 			wantInBody: []string{`"key":"` + api.ErrorNotAuthorized.String()},
 		},
 		{
-			name:       "normal user good results",
+			name:       "steward user good results",
 			actor:      stewardUser,
 			wantStatus: http.StatusOK,
 			wantRows:   5, // 2 header rows, 1 summary row, 1 transaction row, 1 balance row
@@ -103,7 +103,7 @@ func (as *ActionSuite) Test_LedgerReconcile() {
 			want:       0,
 		},
 		{
-			name:       "normal user good results",
+			name:       "steward user good results",
 			actor:      stewardUser,
 			date:       time.Now().Format(domain.DateFormat),
 			wantStatus: http.StatusOK,
@@ -180,7 +180,7 @@ func (as *ActionSuite) Test_LedgerAnnual() {
 			wantInBody: []string{`"key":"` + api.ErrorNotAuthorized.String()},
 		},
 		{
-			name:       "normal user good results",
+			name:       "steward user good results",
 			actor:      stewardUser,
 			wantStatus: http.StatusOK,
 			wantRows:   5, // 2 header rows, 1 summary row, 1 transaction row, 1 balance row

--- a/application/api/ledger.go
+++ b/application/api/ledger.go
@@ -1,5 +1,14 @@
 package api
 
+import (
+	"time"
+
+	"github.com/gobuffalo/nulls"
+	"github.com/gofrs/uuid"
+)
+
+type LedgerEntryType string
+
 // swagger:model
 type BatchApproveResponse struct {
 	NumberOfRecordsApproved int `json:"number_of_records_approved"`
@@ -8,4 +17,54 @@ type BatchApproveResponse struct {
 // swagger:model
 type LedgerReconcileInput struct {
 	EndDate string `json:"end_date"`
+}
+
+// swagger:model
+type LedgerEntries []LedgerEntry
+
+// swagger:model
+type LedgerEntry struct {
+	// unique ID
+	//
+	// swagger:strfmt uuid4
+	ID uuid.UUID `json:"id"`
+
+	// policy ID
+	//
+	// swagger:strfmt uuid4
+	PolicyID uuid.UUID `json:"policy_id"`
+
+	// item ID
+	//
+	// swagger:strfmt uuid4
+	ItemID nulls.UUID `json:"item_id"`
+
+	// claim ID
+	//
+	// swagger:strfmt uuid4
+	ClaimID          nulls.UUID      `json:"claim_id"`
+	EntityCode       string          `json:"entity_code"`
+	RiskCategoryName string          `json:"risk_category_name"`
+	RiskCategoryCC   string          `json:"risk_category_cc"` // Risk Category Cost Center
+	Type             LedgerEntryType `json:"type"`
+	PolicyType       PolicyType      `json:"policy_type"`
+	HouseholdID      string          `json:"household_id"`
+	CostCenter       string          `json:"cost_center"`
+	AccountNumber    string          `json:"account_number"`
+	IncomeAccount    string          `json:"income_account"`
+	Name             string          `json:"name"`
+	Amount           Currency        `json:"amount"`
+
+	// date added to ledger
+	//
+	// swagger:strfmt date-time
+	DateSubmitted time.Time `json:"date_submitted"`
+
+	// date entered into accounting system
+	//
+	// swagger:strfmt date-time
+	DateEntered *time.Time `json:"date_entered"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -76,6 +76,7 @@ const (
 	TypeClaimFile       = "claim-files"
 	TypeFile            = "files"
 	TypeItem            = "items"
+	TypeLedger          = "ledger"
 	TypePolicy          = "policies"
 	TypePolicyDependent = "policy-dependents"
 	TypePolicyUser      = "policy-users"

--- a/application/models/ledgerentry.go
+++ b/application/models/ledgerentry.go
@@ -78,6 +78,21 @@ type LedgerEntry struct {
 	Claim *Claim `belongs_to:"claims" validate:"-"`
 }
 
+func (le *LedgerEntry) GetID() uuid.UUID {
+	return le.ID
+}
+
+func (le *LedgerEntry) FindByID(tx *pop.Connection, id uuid.UUID) error {
+	return tx.Find(le, id)
+}
+
+func (le *LedgerEntry) IsActorAllowedTo(tx *pop.Connection, user User, perm Permission, sub SubResource, req *http.Request) bool {
+	if user.IsAdmin() {
+		return true
+	}
+	return false
+}
+
 func (le *LedgerEntry) Create(tx *pop.Connection) error {
 	return create(tx, le)
 }

--- a/application/models/ledgerentry.go
+++ b/application/models/ledgerentry.go
@@ -295,11 +295,11 @@ func (le *LedgerEntries) FindCurrentRenewals(tx *pop.Connection, year int) error
 }
 
 func (le *LedgerEntries) ConvertToAPI(tx *pop.Connection) api.LedgerEntries {
-	claims := make(api.LedgerEntries, len(*le))
-	for i, cc := range *le {
-		claims[i] = cc.ConvertToAPI(tx)
+	ledgerEntries := make(api.LedgerEntries, len(*le))
+	for i, l := range *le {
+		ledgerEntries[i] = l.ConvertToAPI(tx)
 	}
-	return claims
+	return ledgerEntries
 }
 
 func (le *LedgerEntry) ConvertToAPI(tx *pop.Connection) api.LedgerEntry {

--- a/application/models/ledgerentry.go
+++ b/application/models/ledgerentry.go
@@ -3,6 +3,7 @@ package models
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/gobuffalo/nulls"
@@ -291,4 +292,36 @@ func (le *LedgerEntries) FindCurrentRenewals(tx *pop.Connection, year int) error
 		return api.NewAppError(err, api.ErrorQueryFailure, api.CategoryInternal)
 	}
 	return nil
+}
+
+func (le *LedgerEntries) ConvertToAPI(tx *pop.Connection) api.LedgerEntries {
+	claims := make(api.LedgerEntries, len(*le))
+	for i, cc := range *le {
+		claims[i] = cc.ConvertToAPI(tx)
+	}
+	return claims
+}
+
+func (le *LedgerEntry) ConvertToAPI(tx *pop.Connection) api.LedgerEntry {
+	return api.LedgerEntry{
+		ID:               le.ID,
+		PolicyID:         le.PolicyID,
+		ItemID:           le.ItemID,
+		ClaimID:          le.ClaimID,
+		EntityCode:       le.EntityCode,
+		RiskCategoryName: le.RiskCategoryName,
+		RiskCategoryCC:   le.RiskCategoryCC,
+		Type:             api.LedgerEntryType(le.Type),
+		PolicyType:       le.PolicyType,
+		HouseholdID:      le.HouseholdID,
+		CostCenter:       le.CostCenter,
+		AccountNumber:    le.AccountNumber,
+		IncomeAccount:    le.IncomeAccount,
+		Name:             le.Name,
+		Amount:           le.Amount,
+		DateSubmitted:    le.DateSubmitted,
+		DateEntered:      convertTimeToAPI(le.DateEntered),
+		CreatedAt:        le.CreatedAt,
+		UpdatedAt:        le.UpdatedAt,
+	}
 }


### PR DESCRIPTION
- use AuthZ middleware for `/ledger` endpoints
- split `/ledger/annual` into two endpoints, one for listing ledger entries, and one for processing renewals
- add json as a response type, in addition to CSV