### PR TITLE
change S3 ACL to private

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ with many / most of the common features needed in a web application / API.
 The only system requirement for running this application is Docker. Once the source is cloned, all you have 
 to do to get it running is:
 
-1. Copy `.env.example` to `local.env` and update values as described in the file. Secrets may be provided by another team member via Signal or other secure communication tool.
+1. Copy `local-example.env` to `local.env` and update values as described in the file. Secrets may be provided by another team member via Signal or other secure communication tool.
 1. Add `127.0.0.1 minio` to `/etc/hosts` (or equivalent for your OS)
 1. Run `make`
 

--- a/application/actions/upload.go
+++ b/application/actions/upload.go
@@ -4,12 +4,11 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/silinternational/cover-api/api"
-	"github.com/silinternational/cover-api/domain"
-
 	"github.com/gobuffalo/buffalo"
 	"github.com/gobuffalo/buffalo/render"
 
+	"github.com/silinternational/cover-api/api"
+	"github.com/silinternational/cover-api/domain"
 	"github.com/silinternational/cover-api/models"
 )
 
@@ -69,7 +68,9 @@ func uploadHandler(c buffalo.Context) error {
 	if fErr := fileObject.Store(models.Tx(c)); fErr != nil {
 		return reportError(c, &api.AppError{
 			HttpStatus: fErr.HttpStatus,
-			Message:    fmt.Sprintf("error storing uploaded file ... %v", fErr.Message),
+			Key:        fErr.ErrorCode,
+			DebugMsg:   fErr.Message,
+			Message:    fmt.Sprintf("error storing uploaded file"),
 		})
 	}
 

--- a/application/api/ledger.go
+++ b/application/api/ledger.go
@@ -52,8 +52,10 @@ type LedgerEntry struct {
 	CostCenter       string          `json:"cost_center"`
 	AccountNumber    string          `json:"account_number"`
 	IncomeAccount    string          `json:"income_account"`
-	Name             string          `json:"name"`
-	Amount           Currency        `json:"amount"`
+
+	// name of accountable person if available, otherwise the policy name
+	Name   string   `json:"name"`
+	Amount Currency `json:"amount"`
 
 	// date added to ledger
 	//

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -165,14 +165,18 @@ var Env struct {
 	SamlRequireEncryptedAssertion   bool   `default:"true" split_words:"true"`
 
 	AwsRegion          string `split_words:"true"`
-	AwsS3Endpoint      string `split_words:"true"`
-	AwsS3DisableSSL    bool   `split_words:"true"`
-	AwsS3Bucket        string `split_words:"true"`
 	AwsAccessKeyID     string `split_words:"true"`
 	AwsSecretAccessKey string `split_words:"true"`
-	EmailFromAddress   string `required:"true" split_words:"true"`
-	EmailService       string `default:"ses" split_words:"true"`
-	SupportEmail       string `default:"" split_words:"true"`
+
+	AwsS3Endpoint       string `split_words:"true"`
+	AwsS3DisableSSL     bool   `split_words:"true"`
+	AwsS3Bucket         string `split_words:"true"`
+	AwsS3ACL            string `default:"private" split_words:"true"`
+	AwsS3URLLifeMinutes int    `default:"10" split_words:"true"`
+
+	EmailFromAddress string `required:"true" split_words:"true"`
+	EmailService     string `default:"ses" split_words:"true"`
+	SupportEmail     string `default:"" split_words:"true"`
 
 	InviteLifetimeDays int `default:"14" split_words:"true"`
 	MaxFileDelete      int `default:"10" split_words:"true"`

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -172,7 +172,7 @@ var Env struct {
 	AwsS3DisableSSL     bool   `split_words:"true"`
 	AwsS3Bucket         string `split_words:"true"`
 	AwsS3ACL            string `default:"private" split_words:"true"`
-	AwsS3URLLifeMinutes int    `default:"10" split_words:"true"`
+	AwsS3UrlLifeMinutes int    `default:"10" split_words:"true"`
 
 	EmailFromAddress string `required:"true" split_words:"true"`
 	EmailService     string `default:"ses" split_words:"true"`

--- a/application/models/file.go
+++ b/application/models/file.go
@@ -104,7 +104,7 @@ func (f *File) Store(tx *pop.Connection) *FileUploadError {
 		e := FileUploadError{
 			HttpStatus: http.StatusInternalServerError,
 			ErrorCode:  api.ErrorUnableToStoreFile,
-			Message:    fmt.Sprintf("error %s storing file: %+v", err, f),
+			Message:    fmt.Sprintf("error storing file %s: %s", f.ID, err),
 		}
 		return &e
 	}

--- a/application/storage/storage.go
+++ b/application/storage/storage.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -48,7 +49,7 @@ func getS3ConfigFromEnv() awsConfig {
 	}
 
 	// a non-empty endpoint means minIO is in use, which doesn't support the S3 object URL scheme
-	if domain.Env.AwsS3ACL != "public" || len(a.awsEndpoint) > 0 {
+	if !strings.HasPrefix(domain.Env.AwsS3ACL, "public") || len(a.awsEndpoint) > 0 {
 		a.getPresignedUrl = true
 	}
 	return a

--- a/application/storage/storage.go
+++ b/application/storage/storage.go
@@ -82,7 +82,7 @@ func getObjectURL(config awsConfig, svc *s3.S3, key string) (ObjectUrl, error) {
 		Key:    aws.String(key),
 	})
 
-	urlLifespan := time.Duration(domain.Env.AwsS3URLLifeMinutes) * time.Minute
+	urlLifespan := time.Duration(domain.Env.AwsS3UrlLifeMinutes) * time.Minute
 	if newUrl, err := req.Presign(urlLifespan); err == nil {
 		objectUrl.Url = newUrl
 		// return a time slightly before the actual url expiration to account for delays

--- a/application/storage/storage.go
+++ b/application/storage/storage.go
@@ -33,9 +33,6 @@ type awsConfig struct {
 	getPresignedUrl    bool
 }
 
-// presigned URL expiration
-const urlLifespan = 10 * time.Minute
-
 func getS3ConfigFromEnv() awsConfig {
 	var a awsConfig
 	a.awsAccessKeyID = domain.Env.AwsAccessKeyID
@@ -50,8 +47,8 @@ func getS3ConfigFromEnv() awsConfig {
 		a.awsSecretAccessKey = "abcd1234"
 	}
 
-	if len(a.awsEndpoint) > 0 {
-		// a non-empty endpoint means minIO is in use, which doesn't support the S3 object URL scheme
+	// a non-empty endpoint means minIO is in use, which doesn't support the S3 object URL scheme
+	if domain.Env.AwsS3ACL != "public" || len(a.awsEndpoint) > 0 {
 		a.getPresignedUrl = true
 	}
 	return a
@@ -84,6 +81,7 @@ func getObjectURL(config awsConfig, svc *s3.S3, key string) (ObjectUrl, error) {
 		Key:    aws.String(key),
 	})
 
+	urlLifespan := time.Duration(domain.Env.AwsS3URLLifeMinutes) * time.Minute
 	if newUrl, err := req.Presign(urlLifespan); err == nil {
 		objectUrl.Url = newUrl
 		// return a time slightly before the actual url expiration to account for delays
@@ -106,7 +104,7 @@ func StoreFile(key, contentType string, content []byte) (ObjectUrl, error) {
 
 	acl := ""
 	if !config.getPresignedUrl {
-		acl = "public-read"
+		acl = domain.Env.AwsS3ACL
 	}
 	if _, err := svc.PutObject(&s3.PutObjectInput{
 		Bucket:      aws.String(config.awsS3Bucket),

--- a/local-example.env
+++ b/local-example.env
@@ -17,7 +17,11 @@ AWS_REGION=us-east-1
 AWS_S3_ENDPOINT=http://minio:9000
 AWS_S3_DISABLE_SSL=true
 AWS_S3_BUCKET=cover-test-bucket
+
+# S3 Canned ACL -- See https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl
 AWS_S3_ACL=private
+
+# S3 presigned URL life in minutes. Must be 2 minutes or greater.
 AWS_S3_URL_LIFE_MINUTES=10
 
 EMAIL_FROM_ADDRESS=no_reply@example.com

--- a/local-example.env
+++ b/local-example.env
@@ -17,6 +17,8 @@ AWS_REGION=us-east-1
 AWS_S3_ENDPOINT=http://minio:9000
 AWS_S3_DISABLE_SSL=true
 AWS_S3_BUCKET=cover-test-bucket
+AWS_S3_ACL=private
+AWS_S3_URL_LIFE_MINUTES=10
 
 EMAIL_FROM_ADDRESS=no_reply@example.com
 EMAIL_SERVICE=ses


### PR DESCRIPTION
Previously, the S3 ACL was only being set to `private` for dev and test. It is now configurable, with `private` as the default. If set to a value other than `public-read` or `public-read-write`, pre-signed URLs with a configurable lifetime will be provided to the API consumer. The default lifetime is 10 minutes.