### PR TITLE
return ledger report as a File object

### DIFF
--- a/application/api/ledger.go
+++ b/application/api/ledger.go
@@ -20,6 +20,12 @@ type LedgerReconcileInput struct {
 }
 
 // swagger:model
+type LedgerReport struct {
+	File          File          `json:"file"`
+	LedgerEntries LedgerEntries `json:"ledger_entries"`
+}
+
+// swagger:model
 type LedgerEntries []LedgerEntry
 
 // swagger:model

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -51,6 +51,8 @@ var AllowedFileUploadTypes = []string{
 	"image/png",
 	"image/webp",
 	"application/pdf",
+	"text/plain",
+	"text/csv",
 }
 
 // BuffaloContextType is a custom type used as a value key passed to context.WithValue as per the recommendations

--- a/application/models/file.go
+++ b/application/models/file.go
@@ -83,23 +83,25 @@ func (f *File) Store(tx *pop.Connection) *FileUploadError {
 		return &e
 	}
 
-	contentType, err := validateContentType(f.Content)
-	if err != nil {
-		e := FileUploadError{
-			HttpStatus: http.StatusBadRequest,
-			ErrorCode:  api.ErrorStoreFileBadContentType,
-			Message:    err.Error(),
+	if f.ContentType == "" {
+		contentType, err := validateContentType(f.Content)
+		if err != nil {
+			e := FileUploadError{
+				HttpStatus: http.StatusBadRequest,
+				ErrorCode:  api.ErrorStoreFileBadContentType,
+				Message:    err.Error(),
+			}
+			return &e
 		}
-		return &e
+		f.ContentType = contentType
 	}
 
-	f.ContentType = contentType
 	f.removeMetadata()
 	f.changeFileExtension()
 
 	f.ID = domain.GetUUID()
 
-	url, err := storage.StoreFile(f.ID.String(), contentType, f.Content)
+	url, err := storage.StoreFile(f.ID.String(), f.ContentType, f.Content)
 	if err != nil {
 		e := FileUploadError{
 			HttpStatus: http.StatusInternalServerError,


### PR DESCRIPTION
For consistency with the handling of other files, this will return the report CSV as a File object. The client can then download the actual file from S3.