### PR TITLE
implement LedgerReport

### DIFF
--- a/application/actions/app.go
+++ b/application/actions/app.go
@@ -54,7 +54,7 @@ const idRegex = `/{id:[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5][a-fA-F0-9]{3}-[8|9|aA|
 
 const (
 	stewardPath         = "/steward"
-	ledgerPath          = "/ledger"
+	ledgerReportPath    = "/" + domain.TypeLedgerReport
 	claimsPath          = "/" + domain.TypeClaim
 	claimFilesPath      = "/" + domain.TypeClaimFile
 	claimItemsPath      = "/" + domain.TypeClaimItem
@@ -148,12 +148,14 @@ func App() *buffalo.App {
 		auth.GET("/logout", authDestroy)
 
 		// accounting ledger
-		ledgerGroup := app.Group(ledgerPath)
+		ledgerReportGroup := app.Group(ledgerReportPath)
 		// AuthZ is implemented in the handlers
-		ledgerGroup.Middleware.Skip(AuthZ, ledgerAnnualProcess)
-		ledgerGroup.GET("/", ledgerList)
-		ledgerGroup.POST("/", ledgerReconcile)
-		ledgerGroup.POST("/annual", ledgerAnnualProcess)
+		ledgerReportGroup.Middleware.Skip(AuthZ, ledgerAnnualProcess)
+		ledgerReportGroup.GET("/", ledgerReportList)
+		ledgerReportGroup.GET(idRegex, ledgerReportView)
+		ledgerReportGroup.POST("/", ledgerReportCreate)
+		ledgerReportGroup.PUT("/", ledgerReportReconcile)
+		ledgerReportGroup.POST("/annual", ledgerAnnualProcess)
 
 		stewardGroup := app.Group(stewardPath)
 		stewardGroup.Middleware.Skip(AuthZ, stewardListRecentObjects) // AuthZ is implemented in the handler

--- a/application/actions/app.go
+++ b/application/actions/app.go
@@ -54,12 +54,12 @@ const idRegex = `/{id:[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5][a-fA-F0-9]{3}-[8|9|aA|
 
 const (
 	stewardPath         = "/steward"
-	ledgerReportPath    = "/" + domain.TypeLedgerReport
 	claimsPath          = "/" + domain.TypeClaim
 	claimFilesPath      = "/" + domain.TypeClaimFile
 	claimItemsPath      = "/" + domain.TypeClaimItem
 	filesPath           = "/" + domain.TypeFile
 	itemsPath           = "/" + domain.TypeItem
+	ledgerReportPath    = "/" + domain.TypeLedgerReport
 	policiesPath        = "/" + domain.TypePolicy
 	policyDependentPath = "/" + domain.TypePolicyDependent
 )

--- a/application/actions/authz.go
+++ b/application/actions/authz.go
@@ -20,7 +20,7 @@ func AuthZ(next buffalo.Handler) buffalo.Handler {
 			domain.TypeClaimFile:       &models.ClaimFile{},
 			domain.TypeClaimItem:       &models.ClaimItem{},
 			domain.TypeItem:            &models.Item{},
-			domain.TypeLedger:          &models.LedgerEntry{},
+			domain.TypeLedgerReport:    &models.LedgerReport{},
 			domain.TypePolicy:          &models.Policy{},
 			domain.TypePolicyDependent: &models.PolicyDependent{},
 			domain.TypePolicyUser:      &models.PolicyUser{},

--- a/application/actions/ledger.go
+++ b/application/actions/ledger.go
@@ -12,11 +12,6 @@ import (
 	"github.com/silinternational/cover-api/models"
 )
 
-const (
-	reportTypeMonthly = "monthly"
-	reportTypeAnnual  = "annual"
-)
-
 // swagger:operation GET /ledger-report LedgerReport LedgerReportList
 //
 // LedgerReportList
@@ -73,12 +68,12 @@ func ledgerReportView(c buffalo.Context) error {
 //
 // LedgerReportCreate
 //
-// Return the ledger entries as specified by the `report-type` parameter. The returned object contains a list of
-// LedgerEntries and a File containing a CSV file suitable for use with Sage Accounting.
+// Return the ledger entries as specified by the input object. The returned object contains a File object pointing to
+// a CSV file suitable for use with Sage Accounting.
 //
 // ### Report types:
-// + `monthly` - Return all ledger entries not yet reconciled, up to the beginning of the current day (0:00 UTC).
-// + `annual` - Return the billing detail for current year's policy renewals.
+// + `monthly` - Return all ledger entries not yet reconciled, up to the beginning of the given day (0:00 UTC).
+// + `annual` - Return the billing detail for given year's policy renewals.
 //
 // ---
 // parameters:
@@ -128,9 +123,8 @@ func ledgerReportCreate(c buffalo.Context) error {
 //
 // LedgerReportReconcile
 //
-// Mark ledger entries as reconciled as of today. Call this only after all transactions returned by
-// LedgerList have been fully loaded into the accounting record. Today's transactions
-// (entered after 0:00 UTC) are not marked as reconciled.
+// Mark ledger entries in the report reconciled as of today. Call this only after all transactions in the report
+// have been fully loaded into the accounting record.
 //
 // ---
 // parameters:

--- a/application/actions/ledger.go
+++ b/application/actions/ledger.go
@@ -12,7 +12,7 @@ import (
 	"github.com/silinternational/cover-api/models"
 )
 
-// swagger:operation GET /ledger-report LedgerReport LedgerReportList
+// swagger:operation GET /ledger-reports LedgerReport LedgerReportList
 //
 // LedgerReportList
 //
@@ -37,7 +37,7 @@ func ledgerReportList(c buffalo.Context) error {
 	return renderOk(c, list.ConvertToAPI(tx))
 }
 
-// swagger:operation GET /ledger-report/{id} LedgerReport LedgerReportView
+// swagger:operation GET /ledger-reports/{id} LedgerReport LedgerReportView
 //
 // LedgerReportView
 //
@@ -64,7 +64,7 @@ func ledgerReportView(c buffalo.Context) error {
 	return renderOk(c, ledgerReport.ConvertToAPI(tx))
 }
 
-// swagger:operation POST /ledger-report LedgerReport LedgerReportCreate
+// swagger:operation POST /ledger-reports LedgerReport LedgerReportCreate
 //
 // LedgerReportCreate
 //
@@ -119,7 +119,7 @@ func ledgerReportCreate(c buffalo.Context) error {
 	return renderOk(c, report.ConvertToAPI(tx))
 }
 
-// swagger:operation PUT /ledger-report LedgerReport LedgerReportReconcile
+// swagger:operation PUT /ledger-reports LedgerReport LedgerReportReconcile
 //
 // LedgerReportReconcile
 //
@@ -164,7 +164,7 @@ func ledgerReportReconcile(c buffalo.Context) error {
 	return renderOk(c, api.BatchApproveResponse{NumberOfRecordsApproved: len(le)})
 }
 
-// swagger:operation POST /ledger/annual Ledger LedgerAnnualProcess
+// swagger:operation POST /ledger-reports/annual Ledger LedgerAnnualProcess
 //
 // LedgerAnnualProcess
 //

--- a/application/actions/ledger_test.go
+++ b/application/actions/ledger_test.go
@@ -14,64 +14,104 @@ import (
 	"github.com/silinternational/cover-api/models"
 )
 
-func (as *ActionSuite) Test_LedgerList() {
+func (as *ActionSuite) Test_LedgerReportList() {
 	f := as.createFixturesForLedger()
 	normalUser := f.Users[0]
 	stewardUser := models.CreateAdminUsers(as.DB)[models.AppRoleSteward]
 
+	lr, err := models.NewLedgerReport(models.CreateTestContext(stewardUser), models.ReportTypeMonthly, time.Now())
+	as.NoError(err)
+	as.NoError(lr.Create(as.DB))
+
 	tests := []struct {
 		name        string
 		actor       models.User
-		reportType  string
-		format      string
-		wantEntries int
+		wantReports int
 		wantStatus  int
 		wantInBody  []string
 	}{
 		{
 			name:       "unauthenticated",
 			actor:      models.User{},
-			reportType: reportTypeMonthly,
 			wantStatus: http.StatusUnauthorized,
 			wantInBody: []string{`"key":"` + api.ErrorNotAuthorized.String()},
 		},
 		{
 			name:       "insufficient privileges",
 			actor:      normalUser,
-			reportType: reportTypeMonthly,
 			wantStatus: http.StatusNotFound,
 			wantInBody: []string{`"key":"` + api.ErrorNotAuthorized.String()},
 		},
 		{
-			name:       "invalid report type",
-			actor:      stewardUser,
-			reportType: "not-a-real-report-type",
-			wantStatus: http.StatusBadRequest,
-			wantInBody: []string{`"key":"` + api.ErrorInvalidReportType.String()},
-		},
-		{
-			name:        "monthly report",
+			name:        "ok",
 			actor:       stewardUser,
-			reportType:  reportTypeMonthly,
-			format:      "text/csv",
 			wantStatus:  http.StatusOK,
-			wantEntries: 1,
-		},
-		{
-			name:        "annual report",
-			actor:       stewardUser,
-			reportType:  reportTypeAnnual,
-			format:      "text/csv",
-			wantStatus:  http.StatusOK,
-			wantEntries: 1,
+			wantReports: 1,
 		},
 	}
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			req := as.JSON(fmt.Sprintf("%s?%s=%s", ledgerPath, reportTypeParam, tt.reportType))
+			req := as.JSON(ledgerReportPath)
 			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
-			req.Headers["Accept"] = tt.format
+			res := req.Get()
+
+			body := res.Body.String()
+			as.Equal(tt.wantStatus, res.Code, "incorrect status code returned, body: %s", body)
+
+			for _, s := range tt.wantInBody {
+				as.Contains(body, s)
+			}
+
+			if res.Code != http.StatusOK {
+				return
+			}
+
+			var reports []api.LedgerReport
+			as.NoError(json.Unmarshal([]byte(body), &reports))
+			as.Equal(tt.wantReports, len(reports))
+		})
+	}
+}
+
+func (as *ActionSuite) Test_LedgerReportView() {
+	f := as.createFixturesForLedger()
+	normalUser := f.Users[0]
+	stewardUser := models.CreateAdminUsers(as.DB)[models.AppRoleSteward]
+
+	lr, err := models.NewLedgerReport(models.CreateTestContext(stewardUser), models.ReportTypeMonthly, time.Now())
+	as.NoError(err)
+	as.NoError(lr.Create(as.DB))
+
+	tests := []struct {
+		name       string
+		actor      models.User
+		wantStatus int
+		wantInBody []string
+	}{
+		{
+			name:       "unauthenticated",
+			actor:      models.User{},
+			wantStatus: http.StatusUnauthorized,
+			wantInBody: []string{`"key":"` + api.ErrorNotAuthorized.String()},
+		},
+		{
+			name:       "insufficient privileges",
+			actor:      normalUser,
+			wantStatus: http.StatusNotFound,
+			wantInBody: []string{`"key":"` + api.ErrorNotAuthorized.String()},
+		},
+		{
+			name:       "ok",
+			actor:      stewardUser,
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		as.T().Run(tt.name, func(t *testing.T) {
+			req := as.JSON(fmt.Sprintf("%s/%s", ledgerReportPath, lr.ID))
+			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
 			res := req.Get()
 
 			body := res.Body.String()
@@ -87,8 +127,73 @@ func (as *ActionSuite) Test_LedgerList() {
 
 			var report api.LedgerReport
 			as.NoError(json.Unmarshal([]byte(body), &report))
+			as.Equal(lr.ID, report.ID)
+		})
+	}
+}
 
-			as.Equal(tt.wantEntries, len(report.LedgerEntries), "incorrect number of records in JSON")
+func (as *ActionSuite) Test_LedgerReportCreate() {
+	f := as.createFixturesForLedger()
+	normalUser := f.Users[0]
+	stewardUser := models.CreateAdminUsers(as.DB)[models.AppRoleSteward]
+
+	tests := []struct {
+		name       string
+		actor      models.User
+		reportType string
+		wantStatus int
+		wantInBody []string
+	}{
+		{
+			name:       "unauthenticated",
+			actor:      models.User{},
+			wantStatus: http.StatusUnauthorized,
+			wantInBody: []string{`"key":"` + api.ErrorNotAuthorized.String()},
+		},
+		{
+			name:       "insufficient privileges",
+			actor:      normalUser,
+			wantStatus: http.StatusNotFound,
+			wantInBody: []string{`"key":"` + api.ErrorNotAuthorized.String()},
+		},
+		{
+			name:       "invalid report type",
+			actor:      stewardUser,
+			reportType: "not-a-real-report-type",
+			wantStatus: http.StatusBadRequest,
+			wantInBody: []string{`"key":"` + api.ErrorInvalidReportType.String()},
+		},
+		{
+			name:       "monthly report",
+			actor:      stewardUser,
+			reportType: models.ReportTypeMonthly,
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		as.T().Run(tt.name, func(t *testing.T) {
+			req := as.JSON(ledgerReportPath)
+			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			res := req.Post(api.LedgerReportCreateInput{
+				Type: tt.reportType,
+				Date: time.Now().UTC().Format(domain.DateFormat),
+			})
+
+			body := res.Body.String()
+			as.Equal(tt.wantStatus, res.Code, "incorrect status code returned, body: %s", body)
+
+			for _, s := range tt.wantInBody {
+				as.Contains(body, s)
+			}
+
+			if res.Code != http.StatusOK {
+				return
+			}
+
+			var report api.LedgerReport
+			as.NoError(json.Unmarshal([]byte(body), &report))
+			as.Equal(tt.reportType, report.Type)
 		})
 	}
 }
@@ -136,9 +241,9 @@ func (as *ActionSuite) Test_LedgerReconcile() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			req := as.JSON(ledgerPath)
+			req := as.JSON(ledgerReportPath)
 			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
-			res := req.Post(api.LedgerReconcileInput{EndDate: tt.date})
+			res := req.Put(api.LedgerReconcileInput{EndDate: tt.date})
 
 			body := res.Body.String()
 			as.Equal(tt.wantStatus, res.Code, "incorrect status code returned, body: %s", body)
@@ -210,7 +315,7 @@ func (as *ActionSuite) Test_LedgerAnnualProcess() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			req := as.JSON(ledgerPath + "/annual")
+			req := as.JSON(ledgerReportPath + "/annual")
 			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
 			res := req.Post(nil)
 

--- a/application/actions/ledger_test.go
+++ b/application/actions/ledger_test.go
@@ -169,6 +169,12 @@ func (as *ActionSuite) Test_LedgerReportCreate() {
 			reportType: models.ReportTypeMonthly,
 			wantStatus: http.StatusOK,
 		},
+		{
+			name:       "annual report",
+			actor:      stewardUser,
+			reportType: models.ReportTypeAnnual,
+			wantStatus: http.StatusOK,
+		},
 	}
 
 	for _, tt := range tests {

--- a/application/actions/upload.go
+++ b/application/actions/upload.go
@@ -66,12 +66,7 @@ func uploadHandler(c buffalo.Context) error {
 		CreatedByID: models.CurrentUser(c).ID,
 	}
 	if fErr := fileObject.Store(models.Tx(c)); fErr != nil {
-		return reportError(c, &api.AppError{
-			HttpStatus: fErr.HttpStatus,
-			Key:        fErr.ErrorCode,
-			DebugMsg:   fErr.Message,
-			Message:    fmt.Sprintf("error storing uploaded file"),
-		})
+		return reportError(c, err)
 	}
 
 	resp := UploadResponse{

--- a/application/api/errorcodes.go
+++ b/application/api/errorcodes.go
@@ -52,6 +52,7 @@ const (
 
 	// File
 	ErrorFileAlreadyLinked       = ErrorKey("ErrorFileAlreadyLinked")
+	ErrorFilenameRequired        = ErrorKey("ErrorFilenameRequired")
 	ErrorReceivingFile           = ErrorKey("ErrorReceivingFile")
 	ErrorStoreFileBadContentType = ErrorKey("ErrorStoreFileBadContentType")
 	ErrorStoreFileTooLarge       = ErrorKey("ErrorStoreFileTooLarge")
@@ -73,9 +74,11 @@ const (
 	ErrorItemHasActiveClaim           = ErrorKey("ErrorItemHasActiveClaim")
 
 	// Ledger
-	ErrorItemInvalidEndDate = ErrorKey("ErrorItemInvalidEndDate")
-	ErrorInvalidReportType  = ErrorKey("ErrorInvalidReportType")
 	ErrorCreateRenewalEntry = ErrorKey("ErrorCreateRenewalEntry")
+	ErrorInvalidDate        = ErrorKey("ErrorInvalidDate")
+	ErrorInvalidReportType  = ErrorKey("ErrorInvalidReportType")
+	ErrorItemInvalidEndDate = ErrorKey("ErrorItemInvalidEndDate")
+	ErrorNoLedgerEntries    = ErrorKey("ErrorNoLedgerEntries")
 
 	// Policy
 	ErrorPolicyFromContext                    = ErrorKey("ErrorPolicyFromContext")

--- a/application/api/ledger.go
+++ b/application/api/ledger.go
@@ -20,9 +20,16 @@ type LedgerReconcileInput struct {
 }
 
 // swagger:model
+type LedgerReports []LedgerReport
+
+// swagger:model
 type LedgerReport struct {
-	File          File          `json:"file"`
-	LedgerEntries LedgerEntries `json:"ledger_entries"`
+	ID        uuid.UUID `json:"id"`
+	File      File      `json:"file"`
+	Type      string    `json:"type"`
+	Date      time.Time `json:"date"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // swagger:model

--- a/application/api/ledger.go
+++ b/application/api/ledger.go
@@ -33,6 +33,18 @@ type LedgerReport struct {
 }
 
 // swagger:model
+type LedgerReportCreateInput struct {
+	// Report types:
+	// + `monthly` - Return all ledger entries not yet reconciled, up to the beginning of the given date.
+	// + `annual` - Return the policy renewal entries for the year of the given date.
+	//
+	Type string `json:"type"`
+
+	// Report date, e.g. return the ledger entries prior to the given date. Details vary by the report type.
+	Date string `json:"date"`
+}
+
+// swagger:model
 type LedgerEntries []LedgerEntry
 
 // swagger:model

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -52,6 +52,7 @@ var AllowedFileUploadTypes = []string{
 	"image/webp",
 	"application/pdf",
 	"text/plain",
+	"text/plain; charset=utf-8",
 	"text/csv",
 }
 
@@ -78,7 +79,7 @@ const (
 	TypeClaimFile       = "claim-files"
 	TypeFile            = "files"
 	TypeItem            = "items"
-	TypeLedger          = "ledger"
+	TypeLedgerReport    = "ledger-reports"
 	TypePolicy          = "policies"
 	TypePolicyDependent = "policy-dependents"
 	TypePolicyUser      = "policy-users"

--- a/application/migrations/20220126231701_create_ledger_report_table.down.fizz
+++ b/application/migrations/20220126231701_create_ledger_report_table.down.fizz
@@ -1,0 +1,2 @@
+drop_table("ledger_reports")
+drop_table("ledger_report_entries")

--- a/application/migrations/20220126231701_create_ledger_report_table.up.fizz
+++ b/application/migrations/20220126231701_create_ledger_report_table.up.fizz
@@ -1,0 +1,19 @@
+create_table("ledger_reports") {
+	t.Column("id", "uuid", {primary: true})
+	t.Column("file_id", "uuid", {})
+	t.Column("type", "string", {})
+	t.Column("date", "date", {})
+	t.Timestamps()
+
+	t.ForeignKey("file_id", {"files": ["id"]}, {"on_delete": "restrict"})
+}
+
+create_table("ledger_report_entries") {
+	t.Column("id", "uuid", {primary: true})
+	t.Column("ledger_report_id", "uuid", {})
+	t.Column("ledger_entry_id", "uuid", {})
+	t.Timestamps()
+
+	t.ForeignKey("ledger_report_id", {"ledger_reports": ["id"]}, {"on_delete": "cascade"})
+	t.ForeignKey("ledger_entry_id", {"ledger_entries": ["id"]}, {"on_delete": "restrict"})
+}

--- a/application/models/ledgerentry.go
+++ b/application/models/ledgerentry.go
@@ -264,12 +264,12 @@ func (le *LedgerEntry) LoadClaim(tx *pop.Connection) {
 	}
 }
 
-// FindCurrentRenewals finds the coverage renewal ledger entries for the given year
-func (le *LedgerEntries) FindCurrentRenewals(tx *pop.Connection, year int) error {
+// FindRenewals finds the coverage renewal ledger entries for the given year
+func (le *LedgerEntries) FindRenewals(tx *pop.Connection, year int) error {
 	if err := tx.Where("type = ?", LedgerEntryTypeCoverageRenewal).
 		Where("EXTRACT(YEAR FROM date_submitted) = ?", year).
 		All(le); err != nil {
-		return api.NewAppError(err, api.ErrorQueryFailure, api.CategoryInternal)
+		return appErrorFromDB(err, api.ErrorQueryFailure)
 	}
 	return nil
 }

--- a/application/models/ledgerentry.go
+++ b/application/models/ledgerentry.go
@@ -3,7 +3,6 @@ package models
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/gobuffalo/nulls"
@@ -77,21 +76,6 @@ type LedgerEntry struct {
 	UpdatedAt time.Time `db:"updated_at"`
 
 	Claim *Claim `belongs_to:"claims" validate:"-"`
-}
-
-func (le *LedgerEntry) GetID() uuid.UUID {
-	return le.ID
-}
-
-func (le *LedgerEntry) FindByID(tx *pop.Connection, id uuid.UUID) error {
-	return tx.Find(le, id)
-}
-
-func (le *LedgerEntry) IsActorAllowedTo(tx *pop.Connection, user User, perm Permission, sub SubResource, req *http.Request) bool {
-	if user.IsAdmin() {
-		return true
-	}
-	return false
 }
 
 func (le *LedgerEntry) Create(tx *pop.Connection) error {

--- a/application/models/ledgerreport.go
+++ b/application/models/ledgerreport.go
@@ -121,6 +121,11 @@ func NewLedgerReport(ctx context.Context, reportType string, date time.Time) (Le
 
 	report := LedgerReport{Type: reportType}
 
+	if date.After(time.Now().UTC()) {
+		err := errors.New("future date requested for ledger report: " + date.Format(domain.DateFormat))
+		return report, api.NewAppError(err, api.ErrorInvalidDate, api.CategoryUser)
+	}
+
 	var le LedgerEntries
 	switch reportType {
 	case ReportTypeMonthly:

--- a/application/models/ledgerreport.go
+++ b/application/models/ledgerreport.go
@@ -16,13 +16,13 @@ import (
 )
 
 const (
-	reportTypeMonthly = "monthly"
-	reportTypeAnnual  = "annual"
+	ReportTypeMonthly = "monthly"
+	ReportTypeAnnual  = "annual"
 )
 
 var ValidLedgerReportTypes = map[string]struct{}{
-	reportTypeMonthly: {},
-	reportTypeAnnual:  {},
+	ReportTypeMonthly: {},
+	ReportTypeAnnual:  {},
 }
 
 type LedgerReports []LedgerReport
@@ -123,12 +123,12 @@ func NewLedgerReport(ctx context.Context, reportType string, date time.Time) (Le
 
 	var le LedgerEntries
 	switch reportType {
-	case reportTypeMonthly:
+	case ReportTypeMonthly:
 		report.Date = domain.BeginningOfDay(date)
 		if err := le.AllNotEntered(tx, report.Date); err != nil {
 			return report, err
 		}
-	case reportTypeAnnual:
+	case ReportTypeAnnual:
 		year := date.Year()
 		report.Date = time.Date(year, 1, 1, 0, 0, 0, 0, time.UTC)
 		if err := le.FindRenewals(tx, year); err != nil {

--- a/application/models/ledgerreport.go
+++ b/application/models/ledgerreport.go
@@ -149,7 +149,8 @@ func NewLedgerReport(ctx context.Context, reportType string, date time.Time) (Le
 		return LedgerReport{}, api.NewAppError(err, api.ErrorNoLedgerEntries, api.CategoryNotFound)
 	}
 
-	report.File.Name = fmt.Sprintf("cover_%s_%s.csv", reportType, report.Date.Format(domain.DateFormat))
+	report.File.Name = fmt.Sprintf("%s_%s_%s.csv",
+		domain.Env.AppName, reportType, report.Date.Format(domain.DateFormat))
 	report.File.Content = le.ToCsv(report.Date)
 	report.File.CreatedByID = CurrentUser(ctx).ID
 	report.File.ContentType = "text/csv"

--- a/application/models/ledgerreport.go
+++ b/application/models/ledgerreport.go
@@ -140,7 +140,7 @@ func NewLedgerReport(ctx context.Context, reportType string, date time.Time) (Le
 			return report, err
 		}
 	default:
-		err := errors.New("invalid report type")
+		err := errors.New("invalid report type: " + reportType)
 		return report, api.NewAppError(err, api.ErrorInvalidReportType, api.CategoryUser)
 	}
 

--- a/application/models/ledgerreport.go
+++ b/application/models/ledgerreport.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	ReportTypeMonthly = "monthly"
-	ReportTypeAnnual  = "annual"
+	ReportTypeMonthly = "Monthly"
+	ReportTypeAnnual  = "Annual"
 )
 
 var ValidLedgerReportTypes = map[string]struct{}{

--- a/application/models/ledgerreport.go
+++ b/application/models/ledgerreport.go
@@ -1,0 +1,154 @@
+package models
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gobuffalo/pop/v5"
+	"github.com/gobuffalo/validate/v3"
+	"github.com/gofrs/uuid"
+
+	"github.com/silinternational/cover-api/api"
+	"github.com/silinternational/cover-api/domain"
+)
+
+const (
+	reportTypeMonthly = "monthly"
+	reportTypeAnnual  = "annual"
+)
+
+var ValidLedgerReportTypes = map[string]struct{}{
+	reportTypeMonthly: {},
+	reportTypeAnnual:  {},
+}
+
+type LedgerReports []LedgerReport
+
+func (lr *LedgerReports) All(tx *pop.Connection) error {
+	return appErrorFromDB(tx.All(lr), api.ErrorQueryFailure)
+}
+
+func (lr *LedgerReports) ConvertToAPI(tx *pop.Connection) interface{} {
+	ledgerReports := make(api.LedgerReports, len(*lr))
+	for i, l := range *lr {
+		ledgerReports[i] = l.ConvertToAPI(tx)
+	}
+	return ledgerReports
+}
+
+type LedgerReport struct {
+	ID        uuid.UUID `db:"id"`
+	FileID    uuid.UUID `db:"file_id" validate:"required"`
+	Type      string    `db:"type"`
+	Date      time.Time `db:"date"`
+	CreatedAt time.Time `db:"created_at"`
+	UpdatedAt time.Time `db:"updated_at"`
+
+	File          File          `belongs_to:"files" validate:"-"`
+	LedgerEntries LedgerEntries `many_to_many:"ledger_report_entries" validate:"-"`
+}
+
+// Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
+func (lr *LedgerReport) Validate(tx *pop.Connection) (*validate.Errors, error) {
+	return validateModel(lr), nil
+}
+
+// Create the LedgerReport, the File, and LedgerEntry junction table records
+func (lr *LedgerReport) Create(tx *pop.Connection) error {
+	lr.File.Linked = true
+	if err := lr.File.Store(tx); err != nil {
+		return err
+	}
+	lr.FileID = lr.File.ID
+
+	// Pop will create junction table records for all connected LedgerEntries
+	if err := create(tx, lr); err != nil {
+		return appErrorFromDB(err, api.ErrorCreateFailure)
+	}
+
+	return nil
+}
+
+func (lr *LedgerReport) GetID() uuid.UUID {
+	return lr.ID
+}
+
+func (lr *LedgerReport) FindByID(tx *pop.Connection, id uuid.UUID) error {
+	return tx.Find(lr, id)
+}
+
+// IsActorAllowedTo ensure the actor is either an admin, or a member of this policy to perform any permission
+func (lr *LedgerReport) IsActorAllowedTo(tx *pop.Connection, actor User, perm Permission, sub SubResource, r *http.Request) bool {
+	if actor.IsAdmin() {
+		return true
+	}
+	return false
+}
+
+// ConvertToAPI converts a LedgerReport to api.LedgerReport
+func (lr *LedgerReport) ConvertToAPI(tx *pop.Connection) api.LedgerReport {
+	lr.LoadFile(tx, false)
+
+	return api.LedgerReport{
+		ID:        lr.ID,
+		File:      lr.File.ConvertToAPI(tx),
+		Type:      lr.Type,
+		Date:      lr.Date,
+		CreatedAt: lr.CreatedAt,
+		UpdatedAt: lr.UpdatedAt,
+	}
+}
+
+// LoadFile hydrates the File property if necessary or if `reload` is true. The file URL is refreshed
+// in any case.
+func (lr *LedgerReport) LoadFile(tx *pop.Connection, reload bool) {
+	if lr.File.ID == uuid.Nil || reload {
+		if err := tx.Load(lr, "File"); err != nil {
+			panic("database error loading Claim.File, " + err.Error())
+		}
+	}
+	if err := lr.File.RefreshURL(tx); err != nil {
+		panic("failed to refresh Claim.File URL, " + err.Error())
+	}
+}
+
+// NewLedgerReport creates a new report by querying the database according to the requested report type
+func NewLedgerReport(ctx context.Context, reportType string, date time.Time) (LedgerReport, error) {
+	tx := Tx(ctx)
+
+	report := LedgerReport{Type: reportType}
+
+	var le LedgerEntries
+	switch reportType {
+	case reportTypeMonthly:
+		report.Date = domain.BeginningOfDay(date)
+		if err := le.AllNotEntered(tx, report.Date); err != nil {
+			return report, err
+		}
+	case reportTypeAnnual:
+		year := date.Year()
+		report.Date = time.Date(year, 1, 1, 0, 0, 0, 0, time.UTC)
+		if err := le.FindRenewals(tx, year); err != nil {
+			return report, err
+		}
+	default:
+		err := errors.New("invalid report type")
+		return report, api.NewAppError(err, api.ErrorInvalidReportType, api.CategoryUser)
+	}
+
+	if len(le) == 0 {
+		err := errors.New("no LedgerEntries found")
+		return LedgerReport{}, api.NewAppError(err, api.ErrorNoLedgerEntries, api.CategoryNotFound)
+	}
+
+	report.File.Name = fmt.Sprintf("cover_%s_%s.csv", reportType, report.Date.Format(domain.DateFormat))
+	report.File.Content = le.ToCsv(report.Date)
+	report.File.CreatedByID = CurrentUser(ctx).ID
+	report.File.ContentType = "text/csv"
+	report.LedgerEntries = le
+
+	return report, nil
+}

--- a/application/models/ledgerreport_test.go
+++ b/application/models/ledgerreport_test.go
@@ -159,6 +159,12 @@ func (ms *ModelSuite) TestNewLedgerReport() {
 			wantErr:    &api.AppError{Key: api.ErrorNoLedgerEntries, Category: api.CategoryNotFound},
 		},
 		{
+			name:       "future date",
+			date:       time.Now().UTC().AddDate(0, 0, 1),
+			reportType: ReportTypeMonthly,
+			wantErr:    &api.AppError{Key: api.ErrorInvalidDate, Category: api.CategoryUser},
+		},
+		{
 			name:       "one entry",
 			date:       may,
 			reportType: ReportTypeMonthly,

--- a/application/models/ledgerreport_test.go
+++ b/application/models/ledgerreport_test.go
@@ -1,0 +1,191 @@
+package models
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gobuffalo/nulls"
+	"github.com/gofrs/uuid"
+
+	"github.com/silinternational/cover-api/api"
+	"github.com/silinternational/cover-api/domain"
+)
+
+func (ms *ModelSuite) TestLedgerReport_Create() {
+	f := CreateLedgerFixtures(ms.DB, FixturesConfig{ItemsPerPolicy: 2})
+	user := f.Users[0]
+	leFixtures := f.LedgerEntries
+
+	date1 := time.Date(2022, 1, 28, 0, 0, 0, 0, time.UTC)
+	date2 := time.Date(2022, 1, 29, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name         string
+		ledgerReport LedgerReport
+		wantErr      *api.AppError
+	}{
+		{
+			name: "validation error, missing filename",
+			ledgerReport: LedgerReport{
+				Type: reportTypeAnnual,
+				Date: date1,
+				File: File{
+					ContentType: "text/csv",
+					CreatedByID: user.ID,
+					Content:     []byte("a,b\n1,2"),
+				},
+				LedgerEntries: LedgerEntries{leFixtures[0]},
+			},
+			wantErr: &api.AppError{Key: api.ErrorFilenameRequired, Category: api.CategoryUser},
+		},
+		{
+			name: "one LedgerEntry",
+			ledgerReport: LedgerReport{
+				Type: reportTypeAnnual,
+				Date: date1,
+				File: File{
+					Name:        "report1.csv",
+					ContentType: "text/csv",
+					CreatedByID: user.ID,
+					Content:     []byte("a,b\n1,2"),
+				},
+				LedgerEntries: LedgerEntries{leFixtures[0]},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "two LedgerEntries",
+			ledgerReport: LedgerReport{
+				Type: reportTypeAnnual,
+				Date: date2,
+				File: File{
+					Name:        "report2.csv",
+					ContentType: "text/csv",
+					CreatedByID: user.ID,
+					Content:     []byte("a,b\n1,2"),
+				},
+				LedgerEntries: leFixtures,
+			},
+			wantErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		ms.T().Run(tt.name, func(t *testing.T) {
+			// pop.Debug = true
+			err := tt.ledgerReport.Create(ms.DB)
+			if tt.wantErr != nil {
+				ms.Error(err, "test should have produced an error")
+				ms.EqualAppError(*tt.wantErr, err)
+				return
+			}
+
+			ms.NoError(err)
+
+			var lr LedgerReport
+			err = ms.DB.Where("date = ?", tt.ledgerReport.Date).Eager().First(&lr)
+			ms.NoError(err, "no report created")
+			ms.Len(lr.LedgerEntries, len(tt.ledgerReport.LedgerEntries), "wrong number of ledger entries")
+			ms.False(lr.File.ID == uuid.Nil, "file wasn't created")
+			ms.Equal(tt.ledgerReport.File.Name, lr.File.Name, "incorrect filename")
+			ms.True(lr.File.Linked, "incorrect Linked")
+		})
+	}
+}
+
+func (ms *ModelSuite) TestLedgerReport_ConvertToAPI() {
+	id := domain.GetUUID()
+	user := CreateUserFixtures(ms.DB, 1).Users[0]
+	fileID := CreateFileFixtures(ms.DB, 1, user.ID).Files[0].ID
+	date := time.Date(2022, 1, 28, 0, 0, 0, 0, time.UTC)
+	updatedAt := time.Now()
+	createdAt := updatedAt.Add(-1 * time.Hour)
+	c := &LedgerReport{
+		ID:        id,
+		FileID:    fileID,
+		Type:      reportTypeMonthly,
+		Date:      date,
+		CreatedAt: createdAt,
+		UpdatedAt: updatedAt,
+	}
+
+	got := c.ConvertToAPI(ms.DB)
+
+	ms.Equal(id, got.ID, "ID is incorrect")
+	ms.Equal(fileID, got.File.ID, "File ID is incorrect")
+	ms.Equal(c.Type, got.Type, "Type is incorrect")
+	ms.Equal(c.Date, got.Date, "Date is incorrect")
+	ms.Equal(createdAt, got.CreatedAt, "CreatedAt is incorrect")
+	ms.Equal(updatedAt, got.UpdatedAt, "UpdatedAt is incorrect")
+
+	// At least make sure the URL expiration is updated. The File.ConvertToAPI test should cover the rest.
+	ms.WithinDuration(updatedAt.Add(time.Minute*10), got.File.URLExpiration, time.Minute*2)
+}
+
+func (ms *ModelSuite) TestNewLedgerReport() {
+	f := CreateLedgerFixtures(ms.DB, FixturesConfig{ItemsPerPolicy: 2})
+	user := f.Users[0]
+	ctx := CreateTestContext(user)
+
+	march := time.Date(2021, 3, 1, 0, 0, 0, 0, time.UTC)
+	april := time.Date(2021, 4, 1, 0, 0, 0, 0, time.UTC)
+	may := time.Date(2021, 5, 1, 0, 0, 0, 0, time.UTC)
+
+	datesSubmitted := []time.Time{march, april}
+	datesEntered := []nulls.Time{nulls.NewTime(april), {}}
+	entries := f.LedgerEntries
+	for i := range entries {
+		entries[i].DateSubmitted = datesSubmitted[i]
+		entries[i].DateEntered = datesEntered[i]
+		Must(ms.DB.Update(&entries[i]))
+	}
+
+	tests := []struct {
+		name       string
+		date       time.Time
+		reportType string
+		want       LedgerReport
+		wantErr    *api.AppError
+	}{
+		{
+			name:       "invalid report type",
+			date:       may,
+			reportType: "invalid",
+			wantErr:    &api.AppError{Key: api.ErrorInvalidReportType, Category: api.CategoryUser},
+		},
+		{
+			name:       "none found",
+			date:       april,
+			reportType: reportTypeMonthly,
+			wantErr:    &api.AppError{Key: api.ErrorNoLedgerEntries, Category: api.CategoryNotFound},
+		},
+		{
+			name:       "one entry",
+			date:       may,
+			reportType: reportTypeMonthly,
+			want: LedgerReport{
+				Type:          reportTypeMonthly,
+				Date:          may,
+				File:          File{},
+				LedgerEntries: nil,
+			},
+		},
+	}
+	for _, tt := range tests {
+		ms.T().Run(tt.name, func(t *testing.T) {
+			got, err := NewLedgerReport(ctx, tt.reportType, tt.date)
+			if tt.wantErr != nil {
+				ms.Error(err, "test should have produced an error")
+				ms.EqualAppError(*tt.wantErr, err)
+				return
+			}
+
+			ms.NoError(err)
+
+			ms.Equal(tt.want.Type, got.Type, "incorrect report Type")
+			ms.Equal(tt.want.Date, got.Date, "incorrect report Date")
+			ms.Equal("text/csv", got.File.ContentType, "incorrect ContentType")
+			ms.Equal(user.ID, got.File.CreatedByID, "incorrect CreatedByID")
+			ms.Equal(1, len(got.LedgerEntries), "incorrect number of LedgerEntries")
+		})
+	}
+}

--- a/application/models/ledgerreport_test.go
+++ b/application/models/ledgerreport_test.go
@@ -27,7 +27,7 @@ func (ms *ModelSuite) TestLedgerReport_Create() {
 		{
 			name: "validation error, missing filename",
 			ledgerReport: LedgerReport{
-				Type: reportTypeAnnual,
+				Type: ReportTypeAnnual,
 				Date: date1,
 				File: File{
 					ContentType: "text/csv",
@@ -41,7 +41,7 @@ func (ms *ModelSuite) TestLedgerReport_Create() {
 		{
 			name: "one LedgerEntry",
 			ledgerReport: LedgerReport{
-				Type: reportTypeAnnual,
+				Type: ReportTypeAnnual,
 				Date: date1,
 				File: File{
 					Name:        "report1.csv",
@@ -56,7 +56,7 @@ func (ms *ModelSuite) TestLedgerReport_Create() {
 		{
 			name: "two LedgerEntries",
 			ledgerReport: LedgerReport{
-				Type: reportTypeAnnual,
+				Type: ReportTypeAnnual,
 				Date: date2,
 				File: File{
 					Name:        "report2.csv",
@@ -102,7 +102,7 @@ func (ms *ModelSuite) TestLedgerReport_ConvertToAPI() {
 	c := &LedgerReport{
 		ID:        id,
 		FileID:    fileID,
-		Type:      reportTypeMonthly,
+		Type:      ReportTypeMonthly,
 		Date:      date,
 		CreatedAt: createdAt,
 		UpdatedAt: updatedAt,
@@ -155,15 +155,15 @@ func (ms *ModelSuite) TestNewLedgerReport() {
 		{
 			name:       "none found",
 			date:       april,
-			reportType: reportTypeMonthly,
+			reportType: ReportTypeMonthly,
 			wantErr:    &api.AppError{Key: api.ErrorNoLedgerEntries, Category: api.CategoryNotFound},
 		},
 		{
 			name:       "one entry",
 			date:       may,
-			reportType: reportTypeMonthly,
+			reportType: ReportTypeMonthly,
 			want: LedgerReport{
-				Type:          reportTypeMonthly,
+				Type:          ReportTypeMonthly,
 				Date:          may,
 				File:          File{},
 				LedgerEntries: nil,

--- a/application/models/policy_test.go
+++ b/application/models/policy_test.go
@@ -648,7 +648,7 @@ func (ms *ModelSuite) TestPolicy_ProcessAnnualCoverage() {
 	ms.NoError(err)
 
 	var l LedgerEntries
-	ms.NoError(l.FindCurrentRenewals(ms.DB, year))
+	ms.NoError(l.FindRenewals(ms.DB, year))
 
 	// should be one for each risk category
 	ms.Equal(2, len(l))
@@ -658,6 +658,6 @@ func (ms *ModelSuite) TestPolicy_ProcessAnnualCoverage() {
 	ms.NoError(err)
 
 	var l2 LedgerEntries
-	ms.NoError(l2.FindCurrentRenewals(ms.DB, year))
+	ms.NoError(l2.FindRenewals(ms.DB, year))
 	ms.Equal(2, len(l2))
 }


### PR DESCRIPTION
This provides the assurance that when reconciling, only the transactions included in the report will be reconciled. Previously, the client was trusted to pass in the same date that was used to create the report originally. 

Note: the reconcile endpoint isn't finished yet, so it still works as if the LedgerReport type doesn't exist.