### PR TITLE
move files to a new path: {id}/{filename}

### DIFF
--- a/application/job/job.go
+++ b/application/job/job.go
@@ -124,7 +124,7 @@ func migrateFilesHandler(args worker.Args) error {
 		return errors.New("failed to query files for migration job: " + err.Error())
 	}
 
-	for i, file := range files {
+	for _, file := range files {
 		oldPath := file.ID.String()
 		newPath := file.Path()
 
@@ -150,7 +150,8 @@ func migrateFilesHandler(args worker.Args) error {
 		}
 		file.URL = url.Url
 
-		if err = models.DB.Update(&files[i]); err != nil {
+		f := file // a little workaround for gosec warning
+		if err = models.DB.Update(&f); err != nil {
 			domain.Logger.Printf("file write error, key='%s': %s", file.ID, err)
 		} else {
 			domain.Logger.Printf("moved file '%s' to '%s'", oldPath, newPath)

--- a/application/job/job.go
+++ b/application/job/job.go
@@ -124,7 +124,7 @@ func migrateFilesHandler(args worker.Args) error {
 		return errors.New("failed to query files for migration job: " + err.Error())
 	}
 
-	for _, file := range files {
+	for i, file := range files {
 		oldPath := file.ID.String()
 		newPath := file.Path()
 
@@ -150,7 +150,7 @@ func migrateFilesHandler(args worker.Args) error {
 		}
 		file.URL = url.Url
 
-		if err = models.DB.Update(&file); err != nil {
+		if err = models.DB.Update(&files[i]); err != nil {
 			domain.Logger.Printf("file write error, key='%s': %s", file.ID, err)
 		}
 		domain.Logger.Printf("moved file '%s' to '%s'", oldPath, newPath)

--- a/application/job/job.go
+++ b/application/job/job.go
@@ -152,8 +152,9 @@ func migrateFilesHandler(args worker.Args) error {
 
 		if err = models.DB.Update(&files[i]); err != nil {
 			domain.Logger.Printf("file write error, key='%s': %s", file.ID, err)
+		} else {
+			domain.Logger.Printf("moved file '%s' to '%s'", oldPath, newPath)
 		}
-		domain.Logger.Printf("moved file '%s' to '%s'", oldPath, newPath)
 	}
 	return nil
 }

--- a/application/main.go
+++ b/application/main.go
@@ -40,6 +40,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	// temporary job to migrate S3 files to new path
+	if err := job.SubmitDelayed(job.MigrateFiles, delay+time.Second, map[string]interface{}{}); err != nil {
+		domain.ErrLogger.Printf("error initializing MigrateFiles job: " + err.Error())
+		os.Exit(1)
+	}
+
 	// init rollbar
 	rollbar.SetToken(domain.Env.RollbarToken)
 	rollbar.SetEnvironment(domain.Env.GoEnv)

--- a/application/models/file.go
+++ b/application/models/file.go
@@ -87,7 +87,7 @@ func (f *File) Store(tx *pop.Connection) error {
 
 	f.ID = domain.GetUUID()
 
-	url, err := storage.StoreFile(f.ID.String(), f.ContentType, f.Content)
+	url, err := storage.StoreFile(f.Path(), f.ContentType, f.Content)
 	if err != nil {
 		err = fmt.Errorf("error storing file %s: %w", f.ID, err)
 		return api.NewAppError(err, api.ErrorUnableToStoreFile, api.CategoryInternal)
@@ -159,7 +159,7 @@ func (f *File) RefreshURL(tx *pop.Connection) error {
 		return nil
 	}
 
-	newURL, err := storage.GetFileURL(f.ID.String())
+	newURL, err := storage.GetFileURL(f.Path())
 	if err != nil {
 		return err
 	}
@@ -272,4 +272,9 @@ func (f *File) ConvertToAPI(tx *pop.Connection) api.File {
 		ContentType:   f.ContentType,
 		CreatedByID:   f.CreatedByID,
 	}
+}
+
+// Path combines the ID and the filename to make the complete file path
+func (f *File) Path() string {
+	return fmt.Sprintf("%s/%s", f.ID.String(), f.Name)
 }


### PR DESCRIPTION
This helps the UI/UX because the browser offers the default filename, when downloading, as the filename in the URL. There's a cumbersome workaround available on the UI, but this  will be a cleaner solution.