### PR TITLE
clean up use of transaction helper function

### DIFF
--- a/application/actions/actions.go
+++ b/application/actions/actions.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"runtime"
 
 	"github.com/gobuffalo/buffalo"
 	"github.com/gobuffalo/buffalo/render"
@@ -52,7 +51,7 @@ func reportError(c buffalo.Context, err error) error {
 	}
 
 	appErr.Extras = domain.MergeExtras([]map[string]interface{}{getExtras(c), appErr.Extras})
-	appErr.Extras["function"] = GetFunctionName(2)
+	appErr.Extras["function"] = domain.GetFunctionName(2)
 	appErr.Extras["key"] = appErr.Key
 	appErr.Extras["status"] = appErr.HttpStatus
 	appErr.Extras["redirectURL"] = appErr.RedirectURL
@@ -114,18 +113,6 @@ func newExtra(c buffalo.Context, key string, e interface{}) {
 	extras := getExtras(c)
 	extras[key] = e
 	c.Set(domain.ContextKeyExtras, extras)
-}
-
-// GetFunctionName provides the filename, line number, and function name of the caller, skipping the top `skip`
-// functions on the stack.
-func GetFunctionName(skip int) string {
-	pc, file, line, ok := runtime.Caller(skip)
-	if !ok {
-		return "?"
-	}
-
-	fn := runtime.FuncForPC(pc)
-	return fmt.Sprintf("%s:%d %s", file, line, fn.Name())
 }
 
 func renderOk(c buffalo.Context, v interface{}) error {

--- a/application/actions/authn.go
+++ b/application/actions/authn.go
@@ -20,13 +20,12 @@ func AuthN(next buffalo.Handler) buffalo.Handler {
 		}
 
 		var userAccessToken models.UserAccessToken
-		tx := models.Tx(c)
-		if err := userAccessToken.FindByBearerToken(tx, bearerToken); err != nil {
+		if err := userAccessToken.FindByBearerToken(models.DB, bearerToken); err != nil {
 			err := errors.New("invalid bearer token")
 			return reportError(c, api.NewAppError(err, api.ErrorNotAuthorized, api.CategoryUnauthorized))
 		}
 
-		isExpired, err := userAccessToken.DeleteIfExpired(tx)
+		isExpired, err := userAccessToken.DeleteIfExpired(models.DB)
 		if err != nil {
 			return reportError(c, err)
 		}
@@ -36,7 +35,7 @@ func AuthN(next buffalo.Handler) buffalo.Handler {
 			return reportError(c, api.NewAppError(err, api.ErrorNotAuthorized, api.CategoryUnauthorized))
 		}
 
-		user, err := userAccessToken.GetUser(tx)
+		user, err := userAccessToken.GetUser(models.DB)
 		if err != nil {
 			err = fmt.Errorf("error finding user by access token, %s", err.Error())
 			return reportError(c, err)

--- a/application/actions/authz.go
+++ b/application/actions/authz.go
@@ -46,14 +46,13 @@ func AuthZ(next buffalo.Handler) buffalo.Handler {
 			return reportError(c, fmt.Errorf("resource expected to be authable but isn't"))
 		}
 
-		tx := models.Tx(c)
-		if tx == nil {
+		if models.DB == nil {
 			err := fmt.Errorf("failed to intialize db connection")
 			return reportError(c, err)
 		}
 
 		if rID != uuid.Nil {
-			if err := resource.FindByID(tx, rID); err != nil {
+			if err := resource.FindByID(models.DB, rID); err != nil {
 				err = fmt.Errorf("failed to load resource: %s", err)
 				appErr := api.NewAppError(err, api.ErrorResourceNotFound, api.CategoryNotFound)
 				if domain.IsOtherThanNoRows(err) {
@@ -81,7 +80,7 @@ func AuthZ(next buffalo.Handler) buffalo.Handler {
 			p = models.PermissionDenied
 		}
 
-		if !resource.IsActorAllowedTo(tx, actor, p, models.SubResource(rSub), limitedRequest(c.Request())) {
+		if !resource.IsActorAllowedTo(models.DB, actor, p, models.SubResource(rSub), limitedRequest(c.Request())) {
 			err := fmt.Errorf("actor not allowed to perform that action on this resource")
 			return reportError(c, api.NewAppError(err, api.ErrorNotAuthorized, api.CategoryForbidden))
 		}

--- a/application/domain/warnerror.go
+++ b/application/domain/warnerror.go
@@ -2,6 +2,8 @@ package domain
 
 import (
 	"encoding/json"
+	"fmt"
+	"runtime"
 
 	"github.com/gobuffalo/buffalo"
 	"github.com/rollbar/rollbar-go"
@@ -58,4 +60,16 @@ func rollbarMessage(c buffalo.Context, level string, msg string, extras map[stri
 	if ok {
 		rc.MessageWithExtras(level, msg, extras)
 	}
+}
+
+// GetFunctionName provides the filename, line number, and function name of the caller, skipping the top `skip`
+// functions on the stack.
+func GetFunctionName(skip int) string {
+	pc, file, line, ok := runtime.Caller(skip)
+	if !ok {
+		return "?"
+	}
+
+	fn := runtime.FuncForPC(pc)
+	return fmt.Sprintf("%s:%d %s", file, line, fn.Name())
 }

--- a/application/models/models.go
+++ b/application/models/models.go
@@ -221,6 +221,7 @@ func CurrentUser(ctx context.Context) User {
 func Tx(ctx context.Context) *pop.Connection {
 	tx, ok := ctx.Value("tx").(*pop.Connection)
 	if !ok {
+		domain.Logger.Print("no transaction found in context, called from: " + domain.GetFunctionName(2))
 		return DB
 	}
 	return tx


### PR DESCRIPTION
In a different project, I discovered that the transaction middleware prevented deletion of expired tokens. Then, in this project, I discovered it was only working because the AuthN middleware runs before the transaction middleware. This is just a code cleanup to make it a bit more clear what's actually happening.