### PR TITLE
csv encoding for ledger reports

### DIFF
--- a/application/api/policies.go
+++ b/application/api/policies.go
@@ -114,8 +114,8 @@ type PolicyUpdate struct {
 // swagger:model
 type PolicyLedgerReportCreateInput struct {
 	// Report types:
-	// + `monthly` - Return all ledger entries not yet reconciled, up to the beginning of the given date.
-	// + `annual` - Return the policy renewal entries for the year of the given date.
+	// + `Monthly` - Return all ledger entries not yet reconciled, up to the beginning of the given date.
+	// + `Annual` - Return the policy renewal entries for the year of the given date.
 	//
 	Type string `json:"type"`
 

--- a/application/fin/fin.go
+++ b/application/fin/fin.go
@@ -19,7 +19,7 @@ type Transaction struct {
 
 type Provider interface {
 	AppendToBatch(Transaction)
-	BatchToCSV() []byte
+	BatchToCSV() ([]byte, error)
 }
 
 func NewBatch(providerType string, date time.Time) Provider {

--- a/application/fin/sage_test.go
+++ b/application/fin/sage_test.go
@@ -2,6 +2,7 @@ package fin
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -26,10 +27,10 @@ func TestSage_BatchToCSV(t *testing.T) {
 		Transactions:       []Transaction{transaction},
 	}
 
-	summaryRow := fmt.Sprintf(`"1","000000","00001","","GL","JE","%d","%02d",0,"%s","00",0,0,0,2`+"\n",
+	summaryRow := fmt.Sprintf(`1,000000,00001,,GL,JE,%d,%02d,0,%s,00,0,0,0,2`+"\n",
 		s.Year, s.Period, s.JournalDescription)
 
-	transactionRow := fmt.Sprintf(`"2","000000","00001","0000000020","",0,"%s","",%s,"2","%s","%s",%s,"GL","JE"`+"\n",
+	transactionRow := fmt.Sprintf(`2,000000,00001,0000000020,,0,%s,,%s,2,%s,%s,%s,GL,JE`+"\n",
 		transaction.Account,
 		api.Currency(transaction.Amount).String(),
 		transaction.Description,
@@ -37,9 +38,13 @@ func TestSage_BatchToCSV(t *testing.T) {
 		transaction.Date.Format("20060102"),
 	)
 
-	want := header1 + header2 + summaryRow + transactionRow
+	want := strings.Join(header1, ",") + "\n" +
+		strings.Join(header2, ",") + "\n" +
+		summaryRow +
+		transactionRow
 
-	got := s.BatchToCSV()
+	got, err := s.BatchToCSV()
+	require.NoError(t, err)
 
 	require.Equal(t, want, string(got))
 }

--- a/application/grifts/db.go
+++ b/application/grifts/db.go
@@ -445,6 +445,7 @@ func createLedgerEntryFixtures(tx *pop.Connection, items []*models.Item, claims 
 	if err := items[0].CreateLedgerEntry(tx, models.LedgerEntryTypeNewCoverage, 1021); err != nil {
 		return err
 	}
+
 	if err := items[2].CreateLedgerEntry(tx, models.LedgerEntryTypeCoverageChange, 519); err != nil {
 		return err
 	}
@@ -472,6 +473,18 @@ func createLedgerEntryFixtures(tx *pop.Connection, items []*models.Item, claims 
 		return err
 	}
 	if err := claims[4].CreateLedgerEntry(tx); err != nil {
+		return err
+	}
+
+	var lEntries models.LedgerEntries
+	if err := tx.All(&lEntries); err != nil {
+		return err
+	}
+
+	// Make one ledger entry already dealt with, in order to
+	// create ledger entry reports
+	lEntries[0].DateEntered = nulls.NewTime(time.Now().UTC())
+	if err := tx.Update(&lEntries[0]); err != nil {
 		return err
 	}
 

--- a/application/models/ledgerentry.go
+++ b/application/models/ledgerentry.go
@@ -136,7 +136,7 @@ func (le *LedgerEntries) ToCsvForPolicy() ([]byte, error) {
 
 type TransactionBlocks map[string]LedgerEntries // keyed by account
 
-func (le *LedgerEntries) ToCsv(date time.Time) []byte {
+func (le *LedgerEntries) ToCsv(date time.Time) ([]byte, error) {
 	sage := fin.NewBatch(fin.ProviderTypeSage, date)
 
 	blocks := le.MakeBlocks()

--- a/application/models/ledgerentry.go
+++ b/application/models/ledgerentry.go
@@ -16,7 +16,7 @@ import (
 )
 
 const accountSeparator = " / "
-const csvPolicyHeader = `"Amount","Description","Reference","Date Entered"`
+const csvPolicyHeader = `"Amount","Description","Reference","Date Entered"` + "\n"
 
 type LedgerEntryType string
 

--- a/application/models/ledgerentry_test.go
+++ b/application/models/ledgerentry_test.go
@@ -160,14 +160,14 @@ func (ms *ModelSuite) TestLedgerEntries_ToCsv() {
 			batchDate: date,
 			want: []string{
 				summaryLine,
-				fmt.Sprintf(`"2","000000","00001","0000000020","",0,"%s","",%s,"2","%s","%s",%s,"GL","JE"`,
+				fmt.Sprintf(`2,000000,00001,0000000020,,0,%s,,%s,2,%s,%s,%s,GL,JE`,
 					domain.Env.ExpenseAccount,
 					api.Currency(-entry.Amount).String(),
 					entry.transactionDescription(),
 					entry.transactionReference(),
 					date.Format("20060102"),
 				),
-				fmt.Sprintf(`"2","000000","00001","0000000040","",0,"%s","",%s,"2","%s","",%s,"GL","JE"`,
+				fmt.Sprintf(`2,000000,00001,0000000040,,0,%s,,%s,2,%s,,%s,GL,JE`,
 					entry.IncomeAccount+entry.RiskCategoryCC,
 					entry.Amount.String(),
 					entry.balanceDescription(),
@@ -178,7 +178,8 @@ func (ms *ModelSuite) TestLedgerEntries_ToCsv() {
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			got := tt.entries.ToCsv(tt.batchDate)
+			got, err := tt.entries.ToCsv(tt.batchDate)
+			ms.NoError(err)
 			for _, w := range tt.want {
 				ms.Contains(string(got), w)
 			}

--- a/application/models/ledgerentry_test.go
+++ b/application/models/ledgerentry_test.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -82,6 +83,9 @@ func (ms *ModelSuite) TestLedgerEntries_ToCsvForPolicy() {
 		CostCenter:       "CostCenter",
 	}
 
+	csvHeader := strings.Join(csvPolicyHeader, ",")
+	csvHeader = csvHeader + "\n"
+
 	tests := []struct {
 		name    string
 		entries LedgerEntries
@@ -90,14 +94,14 @@ func (ms *ModelSuite) TestLedgerEntries_ToCsvForPolicy() {
 		{
 			name:    "no data",
 			entries: LedgerEntries{},
-			want:    []string{csvPolicyHeader},
+			want:    []string{csvHeader},
 		},
 		{
 			name:    "1 entry",
 			entries: LedgerEntries{entry},
 			want: []string{
-				csvPolicyHeader,
-				fmt.Sprintf(`%s,"%s","%s",%s`,
+				csvHeader,
+				fmt.Sprintf(`%s,%s,%s,%s`,
 					entry.Amount.String(),
 					entry.transactionDescription(),
 					entry.transactionReference(),
@@ -108,7 +112,8 @@ func (ms *ModelSuite) TestLedgerEntries_ToCsvForPolicy() {
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			got := tt.entries.ToCsvForPolicy()
+			got, err := tt.entries.ToCsvForPolicy()
+			ms.NoError(err)
 			for _, w := range tt.want {
 				ms.Contains(string(got), w)
 			}

--- a/application/models/ledgerreport.go
+++ b/application/models/ledgerreport.go
@@ -235,7 +235,12 @@ func NewPolicyLedgerReport(ctx context.Context, policy Policy, reportType string
 
 	report.File.Name = fmt.Sprintf("%s_policy_%s_%s_%d-%d.csv",
 		domain.Env.AppName, policy.ID.String(), reportType, year, month)
-	report.File.Content = le.ToCsvForPolicy()
+
+	csvContent, err := le.ToCsvForPolicy()
+	if err != nil {
+		return LedgerReport{}, err
+	}
+	report.File.Content = csvContent
 	report.File.CreatedByID = CurrentUser(ctx).ID
 	report.File.ContentType = domain.ContentCSV
 	report.LedgerEntries = le

--- a/application/models/ledgerreport.go
+++ b/application/models/ledgerreport.go
@@ -190,7 +190,13 @@ func NewLedgerReport(ctx context.Context, reportType string, date time.Time) (Le
 
 	report.File.Name = fmt.Sprintf("%s_%s_%s.csv",
 		domain.Env.AppName, reportType, report.Date.Format(domain.DateFormat))
-	report.File.Content = le.ToCsv(report.Date)
+
+	content, err := le.ToCsv(report.Date)
+	if err != nil {
+		return LedgerReport{}, err
+	}
+
+	report.File.Content = content
 	report.File.CreatedByID = CurrentUser(ctx).ID
 	report.File.ContentType = domain.ContentCSV
 	report.LedgerEntries = le


### PR DESCRIPTION
I'm not sure if this is an improvement.
Does it matter that multiple 0's at the beginning of a value don't get double quotes around them? 

Steve, if you think this looks OK, can you test the admin ledger entries manually?