### PR TITLE
increment policy invite's email_sent_count

### DIFF
--- a/application/messages/policy.go
+++ b/application/messages/policy.go
@@ -39,4 +39,12 @@ func PolicyUserInviteQueueMessage(tx *pop.Connection, invite models.PolicyUserIn
 	}
 
 	notn.CreateNotificationUser(tx, nulls.UUID{}, invite.Email, invite.InviteeName)
+
+	// This won't know that the email was sent, but it's close enough, since
+	// the Notification sender doesn't have access to the invite
+	invite.EmailSendCount = invite.EmailSendCount + 1
+	if err := tx.UpdateColumns(&invite, "email_send_count"); err != nil {
+		panic("error updating EmailSendCount on Policy User Invite: " + err.Error())
+	}
+
 }

--- a/application/messages/policy_test.go
+++ b/application/messages/policy_test.go
@@ -38,6 +38,9 @@ func (ts *TestSuite) Test_PolicyUserInviteQueueMessage() {
 		t.Run(tt.name, func(t *testing.T) {
 			PolicyUserInviteQueueMessage(db, invite0)
 			validateNotificationUsers(ts, db, tt)
+
+			ts.NoError(invite0.FindByID(db, invite0.ID), "could not retrieve invite from db")
+			ts.Equal(1, invite0.EmailSendCount, "incorrect EmailSendCount")
 		})
 	}
 }


### PR DESCRIPTION
Does this cover https://trello.com/c/Nr7XiovY/474-update-emailsendcount-on-policyuserinvites
