### PR TITLE
add support url to emails

### DIFF
--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -185,6 +185,7 @@ var Env struct {
 	EmailFromAddress string `required:"true" split_words:"true"`
 	EmailService     string `default:"ses" split_words:"true"`
 	SupportEmail     string `default:"" split_words:"true"`
+	SupportURL       string `default:"" split_words:"true"`
 
 	InviteLifetimeDays int `default:"14" split_words:"true"`
 	MaxFileDelete      int `default:"10" split_words:"true"`

--- a/application/messages/item_test.go
+++ b/application/messages/item_test.go
@@ -1,6 +1,7 @@
 package messages
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/silinternational/cover-api/api"
@@ -188,6 +189,7 @@ func (ts *TestSuite) Test_ItemDeniedQueueMessage() {
 				domain.Env.UIURL,
 				deniedItem.Name,
 				deniedItem.StatusReason,
+				fmt.Sprintf(`href="%s"`, domain.Env.SupportURL),
 			},
 		},
 	}

--- a/application/messages/messages.go
+++ b/application/messages/messages.go
@@ -61,6 +61,7 @@ func newEmailMessageData() MessageData {
 	m["uiURL"] = domain.Env.UIURL
 	m["appName"] = domain.Env.AppName
 	m["premiumPercentage"] = fmt.Sprintf("%.2g%%", domain.Env.PremiumFactor*100)
+	m["supportURL"] = domain.Env.SupportURL
 
 	return m
 }

--- a/application/templates/mail/_customer_footer.plush.html
+++ b/application/templates/mail/_customer_footer.plush.html
@@ -32,7 +32,12 @@
 			SIL International, 7500 W Camp Wisdom Rd, Dallas, TX 75236, USA
 		</div>
 		<div style="margin-bottom: 8px">
+			<%= if ( supportURL != "" ) { %>
 			<span style="margin-right: 10px;">
+				<a href="<%= supportURL %>">Support</a>
+			</span> ·
+			<% } %>
+			<span style="margin-left: 10px;margin-right: 10px;">
 				<a href="<%= uiURL %>/terms">Terms of Use</a>
 			</span> ·
 			<span style="margin-left: 10px;">

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -26,6 +26,7 @@ app:
     AWS_S3_BUCKET: cover-test-bucket
     EMAIL_FROM_ADDRESS: no_reply@example.com
     EMAIL_SERVICE: dummy
+    SUPPORT_URL: https://help.example.com
     SAML_SP_ENTITY_ID: http://example.local:3000
     SAML_AUDIENCE_URI: http://example.local:3000
     SAML_IDP_ENTITY_ID: our.idp.net

--- a/local-example.env
+++ b/local-example.env
@@ -28,6 +28,7 @@ EMAIL_FROM_ADDRESS=no_reply@example.com
 EMAIL_SERVICE=ses
 SUPPORT_EMAIL=support@example.com
 SANDBOX_EMAIL_ADDRESS=catchall@example.com
+SUPPORT_URL=https://help.example.com
 
 INVITE_LIFETIME_DAYS=14
 

--- a/test.env
+++ b/test.env
@@ -14,6 +14,7 @@ AWS_S3_BUCKET=cover-test-bucket
 
 EMAIL_FROM_ADDRESS=no_reply@example.com
 EMAIL_SERVICE=dummy
+SUPPORT_URL=https://help.example.com
 
 SAML_SP_ENTITY_ID=http://example.local:3000
 SAML_AUDIENCE_URI=http://example.local:3000


### PR DESCRIPTION
This is for this Trello card (I don't know why Alex archived it)

https://trello.com/c/OoNjLJkB/360-add-support-link-to-email-footer