### PR TITLE
bugfix: policy refund amount miscalculation

### DIFF
--- a/application/models/claim.go
+++ b/application/models/claim.go
@@ -917,6 +917,11 @@ func (c *Claim) CreateLedgerEntry(tx *pop.Connection) error {
 		return nil
 	}
 
+	adjustedAmount, err := adjustLedgerAmount(c.TotalPayout, LedgerEntryTypeClaim)
+	if err != nil {
+		return err
+	}
+
 	c.LoadClaimItems(tx, false)
 	c.LoadPolicy(tx, false)
 	c.Policy.LoadEntityCode(tx, false)
@@ -929,7 +934,7 @@ func (c *Claim) CreateLedgerEntry(tx *pop.Connection) error {
 
 		le := NewLedgerEntry(name, c.Policy, &item, c)
 		le.Type = LedgerEntryTypeClaim
-		le.Amount = c.TotalPayout
+		le.Amount = adjustedAmount
 
 		le.RiskCategoryName = item.RiskCategory.Name
 		le.RiskCategoryCC = item.RiskCategory.CostCenter

--- a/application/models/ledgerentry_test.go
+++ b/application/models/ledgerentry_test.go
@@ -573,3 +573,69 @@ func (ms *ModelSuite) TestLedgerEntries_Reconcile() {
 		})
 	}
 }
+
+func (ms *ModelSuite) Test_AdjustLedgerAmount() {
+	tests := []struct {
+		name       string
+		entryType  LedgerEntryType
+		amount     api.Currency
+		wantAmount api.Currency
+	}{
+		{
+			name:       "new coverage, over $1",
+			entryType:  LedgerEntryTypeNewCoverage,
+			amount:     500,
+			wantAmount: 500,
+		},
+		{
+			name:       "new coverage, under $1",
+			entryType:  LedgerEntryTypeNewCoverage,
+			amount:     50,
+			wantAmount: 100,
+		},
+		{
+			name:       "refund, over $1",
+			entryType:  LedgerEntryTypeCoverageRefund,
+			amount:     -500,
+			wantAmount: -500,
+		},
+		{
+			name:       "refund, under $1",
+			entryType:  LedgerEntryTypeCoverageRefund,
+			amount:     -50,
+			wantAmount: -0,
+		},
+		{
+			name:       "coverage change, positive, over $1",
+			entryType:  LedgerEntryTypeCoverageChange,
+			amount:     600,
+			wantAmount: 600,
+		},
+		{
+			name:       "coverage change, positive, under $1",
+			entryType:  LedgerEntryTypeCoverageChange,
+			amount:     50,
+			wantAmount: 100,
+		},
+		{
+			name:       "coverage change, negative, over $1",
+			entryType:  LedgerEntryTypeCoverageChange,
+			amount:     -700,
+			wantAmount: -700,
+		},
+		{
+			name:       "coverage change, negative, under $1",
+			entryType:  LedgerEntryTypeCoverageChange,
+			amount:     -30,
+			wantAmount: -0,
+		},
+	}
+	for _, tt := range tests {
+		ms.T().Run(tt.name, func(t *testing.T) {
+			got, err := adjustLedgerAmount(tt.amount, tt.entryType)
+			ms.NoError(err)
+
+			ms.Equal(tt.wantAmount, got, "adjustment is incorrect")
+		})
+	}
+}


### PR DESCRIPTION
All refunds over $1 were being converted to a $1 charge

This code contained bad logic:
```go
	if entryType == LedgerEntryTypeCoverageRefund && amount > -100 {
		amount = 0
	} else if amount < 100 { // Charge at least $1
		amount = 100
	}
```
The first conditional worked correctly for refunds under a dollar. If over a dollar, the second conditional (the `else if`) caused all other refunds (`LedgerEntryTypeCoverageRefund` and `LedgerEntryTypeCoverageChange`) to be set to `100` which is a $1 charge. It could be rewritten as
```go
	if entryType == LedgerEntryTypeCoverageRefund {
		if amount > -100 {
			amount = 0
		}
	} else if amount < 100 { // Charge at least $1
		amount = 100
	}
```
This might still contain an undetected error, however. Instead of a nested `if` I opted for a separate function to adjust the amount. This way I could easily write a unit test for a variety of conditions.