### PR TITLE
add new endpoints to edit entity codes

### DIFF
--- a/application/actions/actions_test.go
+++ b/application/actions/actions_test.go
@@ -105,3 +105,9 @@ func newSessionStore() sessions.Store {
 		sessions: map[string]*sessions.Session{},
 	}
 }
+
+func (as *ActionSuite) decodeBody(body []byte, v interface{}) error {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	return decoder.Decode(v)
+}

--- a/application/actions/app.go
+++ b/application/actions/app.go
@@ -62,6 +62,7 @@ const (
 	ledgerReportPath    = "/" + domain.TypeLedgerReport
 	policiesPath        = "/" + domain.TypePolicy
 	policyDependentPath = "/" + domain.TypePolicyDependent
+	entityCodesPath     = "/" + domain.TypeEntityCode
 	policyMemberPath    = "/" + domain.TypePolicyMember
 	strikesPath         = "/" + domain.TypeStrike
 )
@@ -186,12 +187,18 @@ func App() *buffalo.App {
 		configGroup.GET("/countries", countries)
 		configGroup.GET("/claim-incident-types", claimIncidentTypes)
 		configGroup.GET("/item-categories", itemCategoriesList)
-		configGroup.GET("/entity-codes", entityCodesList)
+		configGroup.GET("/entity-codes", entityCodesList) // DEPRECATED, use GET /entity-codes
 
 		// dependent
 		depsGroup := app.Group(policyDependentPath)
 		depsGroup.PUT(idRegex, dependentsUpdate)
 		depsGroup.DELETE(idRegex, dependentsDelete)
+
+		// entity codes
+		entityCodesGroup := app.Group(entityCodesPath)
+		entityCodesGroup.GET("", entityCodesList)
+		entityCodesGroup.PUT(idRegex, entityCodesUpdate)
+		entityCodesGroup.GET(idRegex, entityCodesView)
 
 		// item
 		itemsGroup := app.Group(itemsPath)

--- a/application/actions/authz.go
+++ b/application/actions/authz.go
@@ -19,6 +19,7 @@ func AuthZ(next buffalo.Handler) buffalo.Handler {
 			domain.TypeClaim:           &models.Claim{},
 			domain.TypeClaimFile:       &models.ClaimFile{},
 			domain.TypeClaimItem:       &models.ClaimItem{},
+			domain.TypeEntityCode:      &models.EntityCode{},
 			domain.TypeItem:            &models.Item{},
 			domain.TypeLedgerReport:    &models.LedgerReport{},
 			domain.TypePolicy:          &models.Policy{},
@@ -141,7 +142,6 @@ func getResourceIDSubresource(path string) (string, uuid.UUID, string, int) {
 }
 
 func getPathParts(path string) []string {
-
 	if path == "" {
 		return []string{}
 	}

--- a/application/actions/entitycodes.go
+++ b/application/actions/entitycodes.go
@@ -2,11 +2,12 @@ package actions
 
 import (
 	"github.com/gobuffalo/buffalo"
-
+	"github.com/silinternational/cover-api/api"
+	"github.com/silinternational/cover-api/domain"
 	"github.com/silinternational/cover-api/models"
 )
 
-// swagger:operation GET /config/entity-codes Config EntityCodesList
+// swagger:operation GET /entity-codes EntityCodes EntityCodesList
 //
 // EntityCodesList
 //
@@ -22,10 +23,89 @@ import (
 //         "$ref": "#/definitions/EntityCodes"
 func entityCodesList(c buffalo.Context) error {
 	tx := models.Tx(c)
+	actor := models.CurrentUser(c)
 	var entityCodes models.EntityCodes
-	if err := entityCodes.AllActive(tx); err != nil {
+	var err error
+	if actor.IsAdmin() {
+		err = entityCodes.All(tx)
+	} else {
+		err = entityCodes.AllActive(tx)
+	}
+	if err != nil {
 		return reportError(c, err)
 	}
+	return renderOk(c, entityCodes.ConvertToAPI(tx, actor.IsAdmin()))
+}
 
-	return renderOk(c, entityCodes.ConvertToAPI(tx))
+// swagger:operation GET /entity-codes/{id} EntityCodes EntityCodesView
+//
+// EntityCodesView
+//
+// get a single Entity Code
+//
+// ---
+// parameters:
+//   - name: id
+//     in: path
+//     required: true
+//     description: entity code ID
+// responses:
+//  '200':
+//    description: an Entity Code record
+//    schema:
+//      "$ref": "#/definitions/EntityCode"
+func entityCodesView(c buffalo.Context) error {
+	e := getReferencedEntityCodeFromCtx(c)
+	return renderEntityCode(c, *e)
+}
+
+// swagger:operation PUT /entity-codes/{id} EntityCodes EntityCodesUpdate
+//
+// EntityCodesUpdate
+//
+// update a Entity Code
+//
+// ---
+// parameters:
+//   - name: id
+//     in: path
+//     required: true
+//     description: entity code ID
+//   - name: entity code update input
+//     in: body
+//     description: entity code update input object
+//     required: true
+//     schema:
+//       "$ref": "#/definitions/EntityCodeInput"
+// responses:
+//  '200':
+//    description: an Entity Code record
+//    schema:
+//      "$ref": "#/definitions/EntityCode"
+func entityCodesUpdate(c buffalo.Context) error {
+	e := getReferencedEntityCodeFromCtx(c)
+	var input api.EntityCodeInput
+	if err := StrictBind(c, &input); err != nil {
+		return reportError(c, err)
+	}
+	if err := e.UpdateFromAPI(models.Tx(c), input); err != nil {
+		return err
+	}
+	return renderEntityCode(c, *e)
+}
+
+// getReferencedEntityCodeFromCtx pulls the models.EntityCode resource from context that was put there
+// by the AuthZ middleware
+func getReferencedEntityCodeFromCtx(c buffalo.Context) *models.EntityCode {
+	entityCode, ok := c.Value(domain.TypeEntityCode).(*models.EntityCode)
+	if !ok {
+		panic("entityCode not found in context")
+	}
+	return entityCode
+}
+
+func renderEntityCode(c buffalo.Context, e models.EntityCode) error {
+	tx := models.Tx(c)
+	user := models.CurrentUser(c)
+	return renderOk(c, e.ConvertToAPI(tx, user.IsAdmin()))
 }

--- a/application/actions/entitycodes_test.go
+++ b/application/actions/entitycodes_test.go
@@ -1,0 +1,199 @@
+package actions
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/silinternational/cover-api/api"
+	"github.com/silinternational/cover-api/models"
+)
+
+func (as *ActionSuite) Test_entityCodesList() {
+	inactiveCode := models.EntityCode{Code: "ABC", Name: "ABC Code", Active: false, IncomeAccount: "67890"}
+	as.NoError(as.DB.Create(&inactiveCode))
+	activeCode := models.EntityCode{Code: "XYZ", Name: "XYZ Code", Active: true, IncomeAccount: "12345"}
+	as.NoError(as.DB.Create(&activeCode))
+
+	user := models.CreateUserFixtures(as.DB, 1).Users[0]
+	admin := models.CreateAdminUsers(as.DB)[models.AppRoleSteward]
+
+	tests := []struct {
+		name       string
+		actor      models.User
+		wantStatus int
+		wantError  api.ErrorKey
+		wantCodes  []string
+	}{
+		{
+			name:       "must be authenticated",
+			actor:      models.User{},
+			wantStatus: http.StatusUnauthorized,
+			wantError:  api.ErrorNotAuthorized,
+		},
+		{
+			name:       "any user can list",
+			actor:      user,
+			wantStatus: http.StatusOK,
+			wantCodes:  []string{"XYZ"},
+		},
+		{
+			name:       "admin sees all",
+			actor:      admin,
+			wantStatus: http.StatusOK,
+			wantCodes:  []string{"ABC", "XYZ"},
+		},
+	}
+	for _, tt := range tests {
+		req := as.JSON(entityCodesPath)
+		req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+		res := req.Get()
+		body := res.Body.Bytes()
+
+		as.Equal(tt.wantStatus, res.Code, "incorrect status code returned: %d\n%s", res.Code, body)
+		if tt.wantError != "" {
+			var err api.AppError
+			as.NoError(as.decodeBody(body, &err), "response data is not as expected")
+			as.Equal(tt.wantError, err.Key, "error key is incorrect")
+		} else {
+			var codes api.EntityCodes
+			as.NoError(as.decodeBody(body, &codes), "response data is not as expected %s", body)
+
+			as.Len(codes, len(tt.wantCodes))
+			var gotCodes []string
+			for _, c := range codes {
+				gotCodes = append(gotCodes, c.Code)
+			}
+			as.ElementsMatch(tt.wantCodes, gotCodes)
+
+			if tt.actor.IsAdmin() {
+				as.NotNil(codes[0].IncomeAccount)
+				as.NotNil(codes[0].Active)
+				as.NotNil(codes[0].ParentEntity)
+			} else {
+				as.Nil(codes[0].IncomeAccount)
+				as.Nil(codes[0].Active)
+				as.Nil(codes[0].ParentEntity)
+			}
+		}
+
+	}
+}
+
+func (as *ActionSuite) Test_entityCodesUpdate() {
+	inactiveCode := models.EntityCode{Code: "ABC", Name: "ABC Code", Active: false, IncomeAccount: "67890"}
+	as.NoError(as.DB.Create(&inactiveCode))
+	activeCode := models.EntityCode{Code: "XYZ", Name: "XYZ Code", Active: true, IncomeAccount: "12345"}
+	as.NoError(as.DB.Create(&activeCode))
+
+	user := models.CreateUserFixtures(as.DB, 1).Users[0]
+	admin := models.CreateAdminUsers(as.DB)[models.AppRoleSteward]
+
+	tests := []struct {
+		name       string
+		actor      models.User
+		wantStatus int
+		wantError  api.ErrorKey
+	}{
+		{
+			name:       "must be authenticated",
+			actor:      models.User{},
+			wantStatus: http.StatusUnauthorized,
+			wantError:  api.ErrorNotAuthorized,
+		},
+		{
+			name:       "regular user cannot update codes",
+			actor:      user,
+			wantStatus: http.StatusNotFound,
+			wantError:  api.ErrorNotAuthorized,
+		},
+		{
+			name:       "admin can update",
+			actor:      admin,
+			wantStatus: http.StatusOK,
+		},
+	}
+	for _, tt := range tests {
+		req := as.JSON("%s/%s", entityCodesPath, inactiveCode.ID)
+		req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+		input := api.EntityCodeInput{
+			Active:        true,
+			IncomeAccount: "newacct",
+			ParentEntity:  activeCode.Code,
+		}
+		res := req.Put(input)
+		body := res.Body.Bytes()
+
+		as.Equal(tt.wantStatus, res.Code, "incorrect status code returned: %d\n%s", res.Code, body)
+		if tt.wantError != "" {
+			var err api.AppError
+			as.NoError(as.decodeBody(body, &err), "response data is not as expected", body)
+			as.Equal(tt.wantError, err.Key, "error key is incorrect")
+		} else {
+			var code api.EntityCode
+			as.NoError(as.decodeBody(body, &code), "response data is not as expected %s", body)
+			as.NotNil(code.Active)
+			as.NotNil(code.IncomeAccount)
+			as.NotNil(code.ParentEntity)
+			as.Equal(input.Active, *code.Active)
+			as.Equal(input.IncomeAccount, *code.IncomeAccount)
+			as.Equal(input.ParentEntity, *code.ParentEntity)
+		}
+	}
+}
+
+func (as *ActionSuite) Test_entityCodesView() {
+	inactiveCode := models.EntityCode{Code: "ABC", Name: "ABC Code", Active: false, IncomeAccount: "67890"}
+	as.NoError(as.DB.Create(&inactiveCode))
+	activeCode := models.EntityCode{Code: "XYZ", Name: "XYZ Code", Active: true, IncomeAccount: "12345"}
+	as.NoError(as.DB.Create(&activeCode))
+
+	user := models.CreateUserFixtures(as.DB, 1).Users[0]
+	admin := models.CreateAdminUsers(as.DB)[models.AppRoleSteward]
+
+	tests := []struct {
+		name       string
+		actor      models.User
+		wantStatus int
+		wantError  api.ErrorKey
+	}{
+		{
+			name:       "must be authenticated",
+			actor:      models.User{},
+			wantStatus: http.StatusUnauthorized,
+			wantError:  api.ErrorNotAuthorized,
+		},
+		{
+			name:       "regular user cannot view",
+			actor:      user,
+			wantStatus: http.StatusNotFound,
+			wantError:  api.ErrorNotAuthorized,
+		},
+		{
+			name:       "admin can view",
+			actor:      admin,
+			wantStatus: http.StatusOK,
+		},
+	}
+	for _, tt := range tests {
+		req := as.JSON("%s/%s", entityCodesPath, inactiveCode.ID)
+		req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+		res := req.Get()
+		body := res.Body.Bytes()
+
+		as.Equal(tt.wantStatus, res.Code, "incorrect status code returned: %d\n%s", res.Code, body)
+		if tt.wantError != "" {
+			var err api.AppError
+			as.NoError(as.decodeBody(body, &err), "response data is not as expected", body)
+			as.Equal(tt.wantError, err.Key, "error key is incorrect")
+		} else {
+			var code api.EntityCode
+			as.NoError(as.decodeBody(body, &code), "response data is not as expected %s", body)
+			as.NotNil(code.Active)
+			as.NotNil(code.IncomeAccount)
+			as.NotNil(code.ParentEntity)
+			as.Equal(inactiveCode.Active, *code.Active)
+			as.Equal(inactiveCode.IncomeAccount, *code.IncomeAccount)
+			as.Equal(inactiveCode.ParentEntity, *code.ParentEntity)
+		}
+	}
+}

--- a/application/api/entitycodes.go
+++ b/application/api/entitycodes.go
@@ -12,7 +12,35 @@ type EntityCode struct {
 	// unique ID
 	//
 	// swagger:strfmt uuid4
-	ID   uuid.UUID `json:"id"`
-	Code string    `json:"code"`
-	Name string    `json:"name"`
+	ID uuid.UUID `json:"id"`
+
+	// Code is a unique three-letter identifier for an accounting entity
+	Code string `json:"code"`
+
+	// Name is a succinct description of the entity code.
+	Name string `json:"name"`
+
+	// Active set to true allows it to be displayed in the selection list for policies. Only visible to admins.
+	Active *bool `json:"active,omitempty"`
+
+	// IncomeAccount is the account use for income transactions. Only visible to admins.
+	IncomeAccount *string `json:"income_account,omitempty"`
+
+	// ParentEntity is the parent entity code for grouping in reports. Only visible to admins.
+	ParentEntity *string `json:"parent_entity,omitempty"`
+}
+
+// swagger:model
+type EntityCodeInput struct {
+	// Name is a succinct description of the entity code.
+	Name string `json:"name"`
+
+	// Active set to true allows it to be displayed in the selection list for policies. Only visible to admins.
+	Active bool `json:"active"`
+
+	// IncomeAccount is the account use for income transactions. Only visible to admins.
+	IncomeAccount string `json:"income_account"`
+
+	// ParentEntity is the parent entity code for grouping in reports. Only visible to admins.
+	ParentEntity string `json:"parent_entity"`
 }

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -69,6 +69,7 @@ const (
 	TypeClaim           = "claims"
 	TypeClaimItem       = "claim-items"
 	TypeClaimFile       = "claim-files"
+	TypeEntityCode      = "entity-codes"
 	TypeFile            = "files"
 	TypeItem            = "items"
 	TypeLedgerReport    = "ledger-reports"

--- a/application/models/entitycode.go
+++ b/application/models/entitycode.go
@@ -2,11 +2,11 @@ package models
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gofrs/uuid"
-
 	"github.com/silinternational/cover-api/api"
 )
 
@@ -33,6 +33,26 @@ func (ec *EntityCode) Create(tx *pop.Connection) error {
 	return create(tx, ec)
 }
 
+func (ec *EntityCode) Update(tx *pop.Connection) error {
+	return update(tx, ec)
+}
+
+// GetID returns the EntityCode ID. For Authable interface.
+func (ec *EntityCode) GetID() uuid.UUID {
+	return ec.ID
+}
+
+// FindByID returns the EntityCode identified by the id given. For Authable interface.
+func (ec *EntityCode) FindByID(tx *pop.Connection, id uuid.UUID) error {
+	err := tx.Find(ec, id)
+	return appErrorFromDB(err, api.ErrorQueryFailure)
+}
+
+// IsActorAllowedTo returns true if the given actor is allowed the given permission. For Authable interface.
+func (ec *EntityCode) IsActorAllowedTo(tx *pop.Connection, actor User, perm Permission, res SubResource, request *http.Request) bool {
+	return actor.IsAdmin() || perm == PermissionList
+}
+
 func (ec *EntityCode) FindByCode(tx *pop.Connection) error {
 	err := tx.Where("code = ?", ec.Code).First(ec)
 	if err != nil {
@@ -45,12 +65,17 @@ func EntityCodeID(code string) uuid.UUID {
 	return GetV5UUID(code)
 }
 
-func (ec *EntityCodes) ConvertToAPI(tx *pop.Connection) []api.EntityCode {
+func (ec *EntityCodes) ConvertToAPI(tx *pop.Connection, admin bool) []api.EntityCode {
 	entityCodes := make([]api.EntityCode, len(*ec))
 	for i, cc := range *ec {
-		entityCodes[i] = cc.ConvertToAPI(tx)
+		entityCodes[i] = cc.ConvertToAPI(tx, admin)
 	}
 	return entityCodes
+}
+
+func (ec *EntityCodes) All(tx *pop.Connection) error {
+	err := tx.All(ec)
+	return appErrorFromDB(err, api.ErrorQueryFailure)
 }
 
 func (ec *EntityCodes) AllActive(tx *pop.Connection) error {
@@ -58,14 +83,29 @@ func (ec *EntityCodes) AllActive(tx *pop.Connection) error {
 	return appErrorFromDB(err, api.ErrorQueryFailure)
 }
 
-func (ec *EntityCode) ConvertToAPI(tx *pop.Connection) api.EntityCode {
-	return api.EntityCode{
+// ConvertToAPI adapts an EntityCode model record to API model. If admin is true, all fields are hydrated.
+func (ec *EntityCode) ConvertToAPI(tx *pop.Connection, admin bool) api.EntityCode {
+	code := api.EntityCode{
 		ID:   ec.ID,
 		Code: ec.Code,
 		Name: fmt.Sprintf("%s - %s", ec.Code, ec.Name),
 	}
+	if admin {
+		code.IncomeAccount = &ec.IncomeAccount
+		code.Active = &ec.Active
+		code.ParentEntity = &ec.ParentEntity
+	}
+	return code
 }
 
 func HouseholdEntityID() uuid.UUID {
 	return householdEntityID
+}
+
+func (ec *EntityCode) UpdateFromAPI(tx *pop.Connection, input api.EntityCodeInput) error {
+	ec.Name = input.Name
+	ec.Active = input.Active
+	ec.IncomeAccount = input.IncomeAccount
+	ec.ParentEntity = input.ParentEntity
+	return ec.Update(tx)
 }

--- a/application/models/policy.go
+++ b/application/models/policy.go
@@ -285,7 +285,7 @@ func (p *Policy) ConvertToAPI(tx *pop.Connection, hydrate bool) api.Policy {
 		CostCenter:    p.CostCenter,
 		Account:       p.Account,
 		AccountDetail: p.AccountDetail,
-		EntityCode:    p.EntityCode.ConvertToAPI(tx),
+		EntityCode:    p.EntityCode.ConvertToAPI(tx, false),
 		Members:       p.Members.ConvertToPolicyMembers(polUserIDs),
 		CreatedAt:     p.CreatedAt,
 		UpdatedAt:     p.UpdatedAt,

--- a/application/models/policy_test.go
+++ b/application/models/policy_test.go
@@ -235,7 +235,6 @@ func idsInOrder(id1, id2 uuid.UUID) string {
 	}
 
 	return fmt.Sprintf(template, id2S, id1S)
-
 }
 
 func (ms *ModelSuite) TestPolicy_GetPolicyUserIDs() {
@@ -549,7 +548,7 @@ func (ms *ModelSuite) TestPolicy_ConvertToAPI() {
 	ms.Equal(policy.CostCenter, got.CostCenter, "CostCenter is not correct")
 	ms.Equal(policy.Account, got.Account, "Account is not correct")
 	ms.Equal(policy.AccountDetail, got.AccountDetail, "AccountDetail is not correct")
-	ms.Equal(policy.EntityCode.ConvertToAPI(ms.DB), got.EntityCode, "EntityCode is not correct")
+	ms.Equal(policy.EntityCode.ConvertToAPI(ms.DB, false), got.EntityCode, "EntityCode is not correct")
 	ms.Equal(policy.CreatedAt, got.CreatedAt, "CreatedAt is not correct")
 	ms.Equal(policy.UpdatedAt, got.UpdatedAt, "UpdatedAt is not correct")
 	ms.Equal(0, len(got.Dependents), "Dependents should not be hydrated")

--- a/application/models/testutils.go
+++ b/application/models/testutils.go
@@ -1,3 +1,4 @@
+//go:build development
 // +build development
 
 // This build tag ensures that this file will not be included unless
@@ -657,6 +658,10 @@ func DestroyAll() {
 	// delete all Invites
 	var invites PolicyUserInvites
 	destroyTable(&invites)
+
+	// delete all EntityCodes
+	var entityCodes EntityCodes
+	destroyTable(&entityCodes)
 }
 
 func destroyTable(i interface{}) {
@@ -895,7 +900,6 @@ func ConvertPolicyType(tx *pop.Connection, policy Policy) Policy {
 
 // CreateStrikeFixtures generates any number of strike records per policy provided
 func CreateStrikeFixtures(tx *pop.Connection, policies Policies, dates [][]*time.Time) Strikes {
-
 	if len(dates) > len(policies) {
 		log.Panicf("Not enough policies (%d) for the dates provided (%d)", len(policies), len(dates))
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,9 @@ services:
     image: postgres:11.6
     volumes:
       - ./db-init.sh:/docker-entrypoint-initdb.d/db-init.sh
+    ports:
+      # expose the database port so testing can run locally, e.g. in Goland
+      - "5432:5432"
     environment:
       POSTGRES_USER: cover
       POSTGRES_PASSWORD: cover


### PR DESCRIPTION
### Added
- New endpoint: `GET /entity-codes` - list entity codes. Can be called by any user. Admins get all codes including inactive ones, and more fields.
- New endpoint: `GET /entity-codes/{id}` - view entity code. Can only be called by an admin.
- New endpoint: `PUT /entity-codes/{id}` - update entity code. Can only be called by an admin.
### Deprecated
- Endpoint `GET /config/entity-codes` is now redundant and may be removed in the future.