### PR TITLE
don't modify the Entity Code name for the UI

### DIFF
--- a/application/actions/entitycodes.go
+++ b/application/actions/entitycodes.go
@@ -20,7 +20,7 @@ import (
 //     schema:
 //       type: array
 //       items:
-//         "$ref": "#/definitions/EntityCodes"
+//         "$ref": "#/definitions/EntityCode"
 func entityCodesList(c buffalo.Context) error {
 	tx := models.Tx(c)
 	actor := models.CurrentUser(c)

--- a/application/models/entitycode.go
+++ b/application/models/entitycode.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"fmt"
 	"net/http"
 	"time"
 
@@ -88,7 +87,7 @@ func (ec *EntityCode) ConvertToAPI(tx *pop.Connection, admin bool) api.EntityCod
 	code := api.EntityCode{
 		ID:   ec.ID,
 		Code: ec.Code,
-		Name: fmt.Sprintf("%s - %s", ec.Code, ec.Name),
+		Name: ec.Name,
 	}
 	if admin {
 		code.IncomeAccount = &ec.IncomeAccount

--- a/application/models/policy_test.go
+++ b/application/models/policy_test.go
@@ -548,7 +548,7 @@ func (ms *ModelSuite) TestPolicy_ConvertToAPI() {
 	ms.Equal(policy.CostCenter, got.CostCenter, "CostCenter is not correct")
 	ms.Equal(policy.Account, got.Account, "Account is not correct")
 	ms.Equal(policy.AccountDetail, got.AccountDetail, "AccountDetail is not correct")
-	ms.Equal(policy.EntityCode.ConvertToAPI(ms.DB, false), got.EntityCode, "EntityCode is not correct")
+	ms.Equal(policy.EntityCode, got.EntityCode, "EntityCode is not correct")
 	ms.Equal(policy.CreatedAt, got.CreatedAt, "CreatedAt is not correct")
 	ms.Equal(policy.UpdatedAt, got.UpdatedAt, "UpdatedAt is not correct")
 	ms.Equal(0, len(got.Dependents), "Dependents should not be hydrated")

--- a/application/models/policy_test.go
+++ b/application/models/policy_test.go
@@ -548,7 +548,7 @@ func (ms *ModelSuite) TestPolicy_ConvertToAPI() {
 	ms.Equal(policy.CostCenter, got.CostCenter, "CostCenter is not correct")
 	ms.Equal(policy.Account, got.Account, "Account is not correct")
 	ms.Equal(policy.AccountDetail, got.AccountDetail, "AccountDetail is not correct")
-	ms.Equal(policy.EntityCode, got.EntityCode, "EntityCode is not correct")
+	ms.Equal(policy.EntityCode.ConvertToAPI(ms.DB, false), got.EntityCode, "EntityCode is not correct")
 	ms.Equal(policy.CreatedAt, got.CreatedAt, "CreatedAt is not correct")
 	ms.Equal(policy.UpdatedAt, got.UpdatedAt, "UpdatedAt is not correct")
 	ms.Equal(0, len(got.Dependents), "Dependents should not be hydrated")


### PR DESCRIPTION
### Changed
- Don't prefix the entity code name with "XXX - ". Let the UI do it so the API can be symmetric.
### Fixed
- Fix the response data type for EntityCodesList