### PR TITLE
replace interface{} with any

### DIFF
--- a/application/Dockerfile-api-docs
+++ b/application/Dockerfile-api-docs
@@ -1,5 +1,4 @@
-FROM quay.io/goswagger/swagger:latest
-
+FROM quay.io/goswagger/swagger:v0.30.0
 
 # install redoc-cli to bundle html
 RUN apk add --no-cache --no-progress npm

--- a/application/actions/actions.go
+++ b/application/actions/actions.go
@@ -28,7 +28,7 @@ func init() {
 // StrictBind hydrates a struct with values from a POST
 // REMEMBER the request body must have *exported* fields.
 //  Otherwise, this will give an empty result without an error.
-func StrictBind(c buffalo.Context, dest interface{}) error {
+func StrictBind(c buffalo.Context, dest any) error {
 	dec := json.NewDecoder(c.Request().Body)
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(dest); err != nil {
@@ -47,10 +47,10 @@ func reportError(c buffalo.Context, err error) error {
 	appErr.SetHttpStatusFromCategory()
 
 	if appErr.Extras == nil {
-		appErr.Extras = map[string]interface{}{}
+		appErr.Extras = map[string]any{}
 	}
 
-	appErr.Extras = domain.MergeExtras([]map[string]interface{}{getExtras(c), appErr.Extras})
+	appErr.Extras = domain.MergeExtras([]map[string]any{getExtras(c), appErr.Extras})
 	appErr.Extras["function"] = domain.GetFunctionName(2)
 	appErr.Extras["key"] = appErr.Key
 	appErr.Extras["status"] = appErr.HttpStatus
@@ -74,7 +74,7 @@ func reportError(c buffalo.Context, err error) error {
 			appErr.DebugMsg = appErr.Err.Error()
 		}
 	} else {
-		appErr.Extras = map[string]interface{}{}
+		appErr.Extras = map[string]any{}
 	}
 
 	if appErr.HttpStatus >= 300 && appErr.HttpStatus <= 399 {
@@ -101,21 +101,21 @@ func appErrorFromErr(err error) *api.AppError {
 	}
 }
 
-func getExtras(c buffalo.Context) map[string]interface{} {
-	extras, _ := c.Value(domain.ContextKeyExtras).(map[string]interface{})
+func getExtras(c buffalo.Context) map[string]any {
+	extras, _ := c.Value(domain.ContextKeyExtras).(map[string]any)
 	if extras == nil {
-		extras = map[string]interface{}{}
+		extras = map[string]any{}
 	}
 	return extras
 }
 
-func newExtra(c buffalo.Context, key string, e interface{}) {
+func newExtra(c buffalo.Context, key string, e any) {
 	extras := getExtras(c)
 	extras[key] = e
 	c.Set(domain.ContextKeyExtras, extras)
 }
 
-func renderOk(c buffalo.Context, v interface{}) error {
+func renderOk(c buffalo.Context, v any) error {
 	return c.Render(http.StatusOK, r.JSON(v))
 }
 

--- a/application/actions/actions_test.go
+++ b/application/actions/actions_test.go
@@ -30,12 +30,12 @@ type ActionSuite struct {
 }
 
 // HTML creates an httptest.Request with HTML content type.
-func (as *ActionSuite) HTML(u string, args ...interface{}) *httptest.Request {
+func (as *ActionSuite) HTML(u string, args ...any) *httptest.Request {
 	return httptest.New(as.app).HTML(u, args...)
 }
 
 // JSON creates an httptest.JSON request
-func (as *ActionSuite) JSON(u string, args ...interface{}) *httptest.JSON {
+func (as *ActionSuite) JSON(u string, args ...any) *httptest.JSON {
 	return httptest.New(as.app).JSON(u, args...)
 }
 
@@ -106,7 +106,7 @@ func newSessionStore() sessions.Store {
 	}
 }
 
-func (as *ActionSuite) decodeBody(body []byte, v interface{}) error {
+func (as *ActionSuite) decodeBody(body []byte, v any) error {
 	decoder := json.NewDecoder(bytes.NewReader(body))
 	decoder.DisallowUnknownFields()
 	return decoder.Decode(v)

--- a/application/actions/claimitems_test.go
+++ b/application/actions/claimitems_test.go
@@ -62,7 +62,7 @@ func (as *ActionSuite) Test_ClaimItemsUpdate() {
 		name        string
 		actor       models.User
 		claimItem   models.ClaimItem
-		input       interface{}
+		input       any
 		addReviewer bool
 		wantStatus  int
 		wantInBody  string

--- a/application/actions/dependents_test.go
+++ b/application/actions/dependents_test.go
@@ -141,7 +141,7 @@ func (as *ActionSuite) Test_DependentsCreate() {
 	tests := []struct {
 		name          string
 		actor         models.User
-		reqBody       interface{}
+		reqBody       any
 		policy        models.Policy
 		wantCount     int
 		wantStatus    int

--- a/application/api/api.go
+++ b/application/api/api.go
@@ -29,7 +29,7 @@ type ListResponse struct {
 	Meta Meta `json:"meta"`
 
 	// Data containing the relevant list type
-	Data interface{} `json:"data"`
+	Data any `json:"data"`
 }
 
 // TODO: implement Meta type to provide pagination properties
@@ -67,7 +67,7 @@ type AppError struct {
 	Message string `json:"message"`
 
 	// Extra data providing detail about the error condition, only provided in development mode
-	Extras map[string]interface{} `json:"extras,omitempty"`
+	Extras map[string]any `json:"extras,omitempty"`
 
 	// URL to redirect, if HttpStatus is in 300-series
 	RedirectURL string `json:"-"`

--- a/application/auth/oauthstate.go
+++ b/application/auth/oauthstate.go
@@ -162,7 +162,7 @@ func Logout(res http.ResponseWriter, req *http.Request) error {
 		return err
 	}
 	session.Options.MaxAge = -1
-	session.Values = make(map[interface{}]interface{})
+	session.Values = make(map[any]any)
 	err = session.Save(req, res)
 	if err != nil {
 		return errors.New("Could not delete user session ")

--- a/application/auth/saml/provider.go
+++ b/application/auth/saml/provider.go
@@ -197,7 +197,7 @@ func getRsaPrivateKey(privateKey, publicCert string) (*rsa.PrivateKey, error) {
 	}
 
 	var err error
-	var parsedKey interface{}
+	var parsedKey any
 	if parsedKey, err = x509.ParsePKCS8PrivateKey(privPem.Bytes); err != nil {
 		if parsedKey, err = x509.ParsePKCS1PrivateKey(privPem.Bytes); err != nil {
 			return rsaKey, fmt.Errorf("unable to parse RSA private key: %s", err)

--- a/application/cmd/app/main.go
+++ b/application/cmd/app/main.go
@@ -35,7 +35,7 @@ func main() {
 		delay = randMins * time.Minute
 	}
 
-	if err := job.SubmitDelayed(job.InactivateItems, delay, map[string]interface{}{}); err != nil {
+	if err := job.SubmitDelayed(job.InactivateItems, delay, map[string]any{}); err != nil {
 		domain.ErrLogger.Printf("error initializing InactivateItems job: " + err.Error())
 		os.Exit(1)
 	}

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -252,7 +252,7 @@ func (e *ErrLogProxy) SetOutput(w io.Writer) {
 	e.LocalLog.SetOutput(w)
 }
 
-func (e *ErrLogProxy) Printf(format string, a ...interface{}) {
+func (e *ErrLogProxy) Printf(format string, a ...any) {
 	// Send to local logger
 	e.LocalLog.Printf(format, a...)
 
@@ -273,7 +273,7 @@ func (e *ErrLogProxy) InitRollbar() {
 }
 
 // NewExtra Sets a new key-value pair in the `extras` entry of the context
-func NewExtra(c buffalo.Context, key string, e interface{}) {
+func NewExtra(c buffalo.Context, key string, e any) {
 	extras := getExtras(c)
 
 	extrasLock.Lock()
@@ -283,10 +283,10 @@ func NewExtra(c buffalo.Context, key string, e interface{}) {
 	c.Set(ContextKeyExtras, extras)
 }
 
-func getExtras(c buffalo.Context) map[string]interface{} {
-	extras, _ := c.Value(ContextKeyExtras).(map[string]interface{})
+func getExtras(c buffalo.Context) map[string]any {
+	extras, _ := c.Value(ContextKeyExtras).(map[string]any)
 	if extras == nil {
-		extras = map[string]interface{}{}
+		extras = map[string]any{}
 	}
 
 	return extras
@@ -372,11 +372,11 @@ func RollbarSetPerson(c buffalo.Context, id, userFirst, userLast, email string) 
 	}
 }
 
-func MergeExtras(extras []map[string]interface{}) map[string]interface{} {
-	allExtras := map[string]interface{}{}
+func MergeExtras(extras []map[string]any) map[string]any {
+	allExtras := map[string]any{}
 
 	// I didn't think I would need this, but without it at least one test was failing
-	// The code allowed a map[string]interface{} to get through (i.e. not in a slice)
+	// The code allowed a map[string]any to get through (i.e. not in a slice)
 	// without the compiler complaining
 	if len(extras) == 1 {
 		return extras[0]

--- a/application/domain/warnerror.go
+++ b/application/domain/warnerror.go
@@ -10,7 +10,7 @@ import (
 )
 
 // LogErrorMessage logs a message and sends it to Rollbar
-func LogErrorMessage(c buffalo.Context, msg string, level string, extras ...map[string]interface{}) {
+func LogErrorMessage(c buffalo.Context, msg string, level string, extras ...map[string]any) {
 	// Avoid panics running tests when c doesn't have the necessary nested methods
 	logger := c.Logger()
 	if logger == nil {
@@ -19,7 +19,7 @@ func LogErrorMessage(c buffalo.Context, msg string, level string, extras ...map[
 
 	es := MergeExtras(extras)
 	if es == nil {
-		es = map[string]interface{}{}
+		es = map[string]any{}
 	}
 
 	rollbarMessage(c, level, msg, es)
@@ -27,23 +27,23 @@ func LogErrorMessage(c buffalo.Context, msg string, level string, extras ...map[
 	logger.Error(encodeLogMsg(msg, es))
 }
 
-func jsonMin(i interface{}) ([]byte, error) {
+func jsonMin(i any) ([]byte, error) {
 	return json.Marshal(i)
 }
 
-func jsonIndented(i interface{}) ([]byte, error) {
+func jsonIndented(i any) ([]byte, error) {
 	return json.MarshalIndent(i, "", "  ")
 }
 
 // encodeLogMsg adds the message as an "extra" and returns a json-encoded copy of the resulting extras map
-func encodeLogMsg(msg string, extras map[string]interface{}) string {
+func encodeLogMsg(msg string, extras map[string]any) string {
 	encoder := jsonMin
 	if Env.GoEnv == "development" {
 		encoder = jsonIndented
 	}
 
 	if extras == nil {
-		extras = map[string]interface{}{}
+		extras = map[string]any{}
 	}
 	extras["message"] = msg
 
@@ -55,7 +55,7 @@ func encodeLogMsg(msg string, extras map[string]interface{}) string {
 }
 
 // rollbarMessage is a wrapper function to call rollbar's client.MessageWithExtras function from client stored in context
-func rollbarMessage(c buffalo.Context, level string, msg string, extras map[string]interface{}) {
+func rollbarMessage(c buffalo.Context, level string, msg string, extras map[string]any) {
 	rc, ok := c.Value(ContextKeyRollbar).(*rollbar.Client)
 	if ok {
 		rc.MessageWithExtras(level, msg, extras)

--- a/application/job/job.go
+++ b/application/job/job.go
@@ -21,23 +21,23 @@ var w worker.Worker
 // jobBuffaloContext is a buffalo context for jobs
 type jobBuffaloContext struct {
 	buffalo.DefaultContext
-	params map[interface{}]interface{}
+	params map[any]any
 }
 
 // Value returns the value associated with the given key in the context
-func (j *jobBuffaloContext) Value(key interface{}) interface{} {
+func (j *jobBuffaloContext) Value(key any) any {
 	return j.params[key]
 }
 
 // Set sets the value to be associated with the given key in the context. CAUTION: this is not thread-safe
-func (j *jobBuffaloContext) Set(key string, val interface{}) {
+func (j *jobBuffaloContext) Set(key string, val any) {
 	j.params[key] = val
 }
 
 // createJobContext creates an empty context
 func createJobContext() buffalo.Context {
 	ctx := &jobBuffaloContext{
-		params: map[interface{}]interface{}{},
+		params: map[any]any{},
 	}
 
 	user := models.GetDefaultSteward(models.DB)
@@ -106,14 +106,14 @@ func resubmitInactivateJob() {
 	// uncomment this in development, if you want it to run more often for debugging
 	// delay = time.Duration(time.Second * 10)
 
-	if err := SubmitDelayed(InactivateItems, delay, map[string]interface{}{}); err != nil {
+	if err := SubmitDelayed(InactivateItems, delay, map[string]any{}); err != nil {
 		domain.ErrLogger.Printf("error resubmitting inactivateItemsHandler: " + err.Error())
 	}
 	return
 }
 
 // SubmitDelayed enqueues a new Worker job for the given handler. Arguments can be provided in `args`.
-func SubmitDelayed(handler string, delay time.Duration, args map[string]interface{}) error {
+func SubmitDelayed(handler string, delay time.Duration, args map[string]any) error {
 	job := worker.Job{
 		Queue:   "default",
 		Args:    args,

--- a/application/listeners/listeners.go
+++ b/application/listeners/listeners.go
@@ -89,7 +89,7 @@ func getID(p events.Payload) (uuid.UUID, error) {
 	}
 }
 
-func findObject(payload events.Payload, object interface{}, listenerName string) error {
+func findObject(payload events.Payload, object any, listenerName string) error {
 	id, err := getID(payload)
 	if err != nil {
 		err := errors.New("Failed to get object ID from event payload: " + err.Error())

--- a/application/listeners/listeners_test.go
+++ b/application/listeners/listeners_test.go
@@ -64,7 +64,7 @@ func (ts *TestSuite) Test_findObject() {
 	tests := []struct {
 		name            string
 		payload         events.Payload
-		object          interface{}
+		object          any
 		listenerName    string
 		wantErrContains string
 		wantContains    []string

--- a/application/messages/claim_test.go
+++ b/application/messages/claim_test.go
@@ -35,7 +35,7 @@ func (ts *TestSuite) Test_ClaimReview1QueueMessage() {
 	tests := []testData{
 		{
 			name:                  "submitted to review1",
-			wantToEmails:          []interface{}{steward.EmailOfChoice()},
+			wantToEmails:          []any{steward.EmailOfChoice()},
 			wantSubjectContains:   "New claim on " + review1Claim.ClaimItems[0].Item.Name,
 			wantInappTextContains: "A new claim is waiting for your approval",
 			wantBodyContains: []string{
@@ -70,7 +70,7 @@ func (ts *TestSuite) Test_ClaimRevisionQueueMessage() {
 	tests := []testData{
 		{
 			name:                  "revisions required",
-			wantToEmails:          []interface{}{member0.EmailOfChoice(), member1.EmailOfChoice()},
+			wantToEmails:          []any{member0.EmailOfChoice(), member1.EmailOfChoice()},
 			wantSubjectContains:   "Please provide more information",
 			wantInappTextContains: "Please provide more information on your new claim",
 			wantBodyContains: []string{
@@ -105,7 +105,7 @@ func (ts *TestSuite) Test_ClaimPreapprovedQueueMessage() {
 	tests := []testData{
 		{
 			name:                  "preapproved",
-			wantToEmails:          []interface{}{member0.EmailOfChoice(), member1.EmailOfChoice()},
+			wantToEmails:          []any{member0.EmailOfChoice(), member1.EmailOfChoice()},
 			wantSubjectContains:   "Claim Approved for Repair",
 			wantInappTextContains: "receipts are needed on your new claim",
 			wantBodyContains: []string{
@@ -139,7 +139,7 @@ func (ts *TestSuite) Test_ClaimReceiptQueueMessage() {
 	tests := []testData{
 		{
 			name:                  "receipts required again",
-			wantToEmails:          []interface{}{member0.EmailOfChoice(), member1.EmailOfChoice()},
+			wantToEmails:          []any{member0.EmailOfChoice(), member1.EmailOfChoice()},
 			wantSubjectContains:   "Claim Needs Receipt",
 			wantInappTextContains: "Please provide a receipt",
 			wantBodyContains: []string{
@@ -170,7 +170,7 @@ func (ts *TestSuite) Test_ClaimReview2QueueMessage() {
 	tests := []testData{
 		{
 			name:                  "submitted to review2",
-			wantToEmails:          []interface{}{steward.EmailOfChoice()},
+			wantToEmails:          []any{steward.EmailOfChoice()},
 			wantSubjectContains:   "Consider payout for claim on " + review2Claim.ClaimItems[0].Item.Name,
 			wantInappTextContains: "A claim is waiting for your approval",
 			wantBodyContains: []string{
@@ -201,7 +201,7 @@ func (ts *TestSuite) Test_ClaimReview3QueueMessage() {
 	tests := []testData{
 		{
 			name:                  "submitted to review3",
-			wantToEmails:          []interface{}{signator.EmailOfChoice()},
+			wantToEmails:          []any{signator.EmailOfChoice()},
 			wantSubjectContains:   "Final approval for claim on " + review3Claim.ClaimItems[0].Item.Name,
 			wantInappTextContains: "A claim is waiting for your approval",
 			wantBodyContains: []string{
@@ -235,7 +235,7 @@ func (ts *TestSuite) Test_ClaimApprovedQueueMessage() {
 	tests := []testData{
 		{
 			name:                  "coverage approved",
-			wantToEmails:          []interface{}{member0.EmailOfChoice(), member1.EmailOfChoice()},
+			wantToEmails:          []any{member0.EmailOfChoice(), member1.EmailOfChoice()},
 			wantSubjectContains:   "Claim Payout Approved",
 			wantInappTextContains: "your claim has been approved",
 			wantBodyContains: []string{
@@ -270,7 +270,7 @@ func (ts *TestSuite) Test_ClaimDeniedQueueMessage() {
 	tests := []testData{
 		{
 			name:                  "coverage denied",
-			wantToEmails:          []interface{}{member0.EmailOfChoice(), member1.EmailOfChoice()},
+			wantToEmails:          []any{member0.EmailOfChoice(), member1.EmailOfChoice()},
 			wantSubjectContains:   "An Update on Your Coverage Request",
 			wantInappTextContains: "your claim has been denied",
 			wantBodyContains: []string{

--- a/application/messages/item_test.go
+++ b/application/messages/item_test.go
@@ -36,7 +36,7 @@ func (ts *TestSuite) Test_ItemSubmittedQueueMessage() {
 		{
 			data: testData{
 				name:                  "just submitted, not approved",
-				wantToEmails:          []interface{}{steward0.EmailOfChoice(), steward1.EmailOfChoice()},
+				wantToEmails:          []any{steward0.EmailOfChoice(), steward1.EmailOfChoice()},
 				wantSubjectContains:   "Item Needs Review " + f.Items[0].Name,
 				wantInappTextContains: "A new policy item is waiting for your approval",
 				wantBodyContains: []string{
@@ -88,7 +88,7 @@ func (ts *TestSuite) Test_ItemAutoApprovedQueueMessage() {
 		{
 			data: testData{
 				name:                  "auto approved - stewards",
-				wantToEmails:          []interface{}{steward0.EmailOfChoice(), steward1.EmailOfChoice()},
+				wantToEmails:          []any{steward0.EmailOfChoice(), steward1.EmailOfChoice()},
 				wantSubjectContains:   "has been auto approved",
 				wantInappTextContains: "Coverage on a new policy item was just auto approved",
 				wantBodyContains: []string{
@@ -136,7 +136,7 @@ func (ts *TestSuite) Test_ItemRevisionQueueMessage() {
 	tests := []testData{
 		{
 			name:                  "revisions required",
-			wantToEmails:          []interface{}{member0.EmailOfChoice(), member1.EmailOfChoice()},
+			wantToEmails:          []any{member0.EmailOfChoice(), member1.EmailOfChoice()},
 			wantSubjectContains:   "Coverage Needs Attention",
 			wantInappTextContains: "Coverage needs attention",
 			wantBodyContains: []string{
@@ -185,7 +185,7 @@ func (ts *TestSuite) Test_ItemDeniedQueueMessage() {
 	tests := []testData{
 		{
 			name:                  "coverage denied",
-			wantToEmails:          []interface{}{member0.EmailOfChoice(), member1.EmailOfChoice()},
+			wantToEmails:          []any{member0.EmailOfChoice(), member1.EmailOfChoice()},
 			wantSubjectContains:   "An Update on Your Coverage Request",
 			wantInappTextContains: "coverage on your new policy item has been denied",
 			wantBodyContains: []string{

--- a/application/messages/messages.go
+++ b/application/messages/messages.go
@@ -71,7 +71,7 @@ func newEmailMessageData() MessageData {
 
 func (m MessageData) addClaimData(tx *pop.Connection, claim models.Claim) {
 	if m == nil {
-		m = map[string]interface{}{}
+		m = map[string]any{}
 	}
 
 	m.addStewardData(tx)
@@ -97,7 +97,7 @@ func (m MessageData) addClaimData(tx *pop.Connection, claim models.Claim) {
 
 func (m MessageData) addItemData(tx *pop.Connection, item models.Item) {
 	if m == nil {
-		m = map[string]interface{}{}
+		m = map[string]any{}
 	}
 	m.addStewardData(tx)
 
@@ -127,7 +127,7 @@ func (m MessageData) addItemData(tx *pop.Connection, item models.Item) {
 
 func (m MessageData) addStewardData(tx *pop.Connection) {
 	if m == nil {
-		m = map[string]interface{}{}
+		m = map[string]any{}
 	}
 
 	steward := models.GetDefaultSteward(tx)

--- a/application/messages/messages_test.go
+++ b/application/messages/messages_test.go
@@ -39,7 +39,7 @@ func Test_TestSuite(t *testing.T) {
 
 type testData struct {
 	name                  string
-	wantToEmails          []interface{}
+	wantToEmails          []any
 	wantSubjectContains   string
 	wantInappTextContains string
 	wantBodyContains      []string
@@ -108,20 +108,20 @@ func (ts *TestSuite) Test_SendQueuedNotifications() {
 	alreadySentTime := time.Now().UTC().Add(-1 * domain.DurationWeek).Truncate(time.Second)
 
 	notnFixtures := []notnFixture{
-		notnFixture{
+		{
 			name:      "AlreadySent",
 			sendAfter: time.Now().UTC().Add(-1 * domain.DurationWeek * 2),
 			sentAt:    nulls.NewTime(alreadySentTime),
 		},
-		notnFixture{
+		{
 			name:      "ToSend",
 			sendAfter: time.Now().UTC().Add(-1 * domain.DurationWeek),
 		},
-		notnFixture{
+		{
 			name:      "NotReady",
 			sendAfter: time.Now().UTC().Add(domain.DurationWeek),
 		},
-		notnFixture{
+		{
 			name:      "EmailError",
 			sendAfter: time.Now().UTC().Add(-1 * domain.DurationWeek),
 		},
@@ -159,7 +159,7 @@ func (ts *TestSuite) Test_SendQueuedNotifications() {
 	tests := []testData{
 		{
 			name:                "send one email",
-			wantToEmails:        []interface{}{user.EmailOfChoice()},
+			wantToEmails:        []any{user.EmailOfChoice()},
 			wantSubjectContains: "ToSend",
 			wantBodyContains:    []string{"Body of ToSend"},
 			// TODO test whether the username is in the greeting

--- a/application/messages/policy_test.go
+++ b/application/messages/policy_test.go
@@ -22,7 +22,7 @@ func (ts *TestSuite) Test_PolicyUserInviteQueueMessage() {
 	tests := []testData{
 		{
 			name:                "ok",
-			wantToEmails:        []interface{}{invite0.Email},
+			wantToEmails:        []any{invite0.Email},
 			wantSubjectContains: "Invitation",
 			wantBodyContains: []string{
 				domain.Env.UIURL,

--- a/application/models/models.go
+++ b/application/models/models.go
@@ -227,7 +227,7 @@ func Tx(ctx context.Context) *pop.Connection {
 	return tx
 }
 
-func fieldByName(i interface{}, name ...string) reflect.Value {
+func fieldByName(i any, name ...string) reflect.Value {
 	if len(name) < 1 {
 		return reflect.Value{}
 	}
@@ -238,7 +238,7 @@ func fieldByName(i interface{}, name ...string) reflect.Value {
 	return f
 }
 
-func create(tx *pop.Connection, m interface{}) error {
+func create(tx *pop.Connection, m any) error {
 	uuidField := fieldByName(m, "ID")
 	if uuidField.IsValid() && uuidField.Interface().(uuid.UUID).Version() == 0 {
 		uuidField.Set(reflect.ValueOf(domain.GetUUID()))
@@ -289,12 +289,12 @@ func appErrorFromDB(err error, defaultKey api.ErrorKey) error {
 	return appErr
 }
 
-func find(tx *pop.Connection, m interface{}, id uuid.UUID) error {
+func find(tx *pop.Connection, m any, id uuid.UUID) error {
 	err := tx.Find(m, id)
 	return appErrorFromDB(err, api.ErrorQueryFailure)
 }
 
-func save(tx *pop.Connection, m interface{}) error {
+func save(tx *pop.Connection, m any) error {
 	uuidField := fieldByName(m, "ID")
 	if uuidField.IsValid() && uuidField.Interface().(uuid.UUID).Version() == 0 {
 		uuidField.Set(reflect.ValueOf(domain.GetUUID()))
@@ -316,7 +316,7 @@ func save(tx *pop.Connection, m interface{}) error {
 	return nil
 }
 
-func update(tx *pop.Connection, m interface{}) error {
+func update(tx *pop.Connection, m any) error {
 	valErrs, err := tx.ValidateAndUpdate(m)
 	if err != nil {
 		return appErrorFromDB(err, api.ErrorUpdateFailure)
@@ -332,12 +332,12 @@ func update(tx *pop.Connection, m interface{}) error {
 	return nil
 }
 
-func destroy(tx *pop.Connection, m interface{}) error {
+func destroy(tx *pop.Connection, m any) error {
 	err := tx.Destroy(m)
 	return appErrorFromDB(err, api.ErrorDestroyFailure)
 }
 
-// This can include an event payload, which is a map[string]interface{}
+// This can include an event payload, which is a map[string]any
 func emitEvent(e events.Event) {
 	if err := events.Emit(e); err != nil {
 		domain.ErrLogger.Printf("error emitting event %s ... %v", e.Kind, err)

--- a/application/models/models_test.go
+++ b/application/models/models_test.go
@@ -56,7 +56,7 @@ func (ms *ModelSuite) Test_CurrentUser() {
 		},
 		{
 			name:     "empty context",
-			context:  &TestBuffaloContext{params: map[interface{}]interface{}{}},
+			context:  &TestBuffaloContext{params: map[any]any{}},
 			wantUser: User{},
 		},
 	}
@@ -80,7 +80,7 @@ func (ms *ModelSuite) EqualAppError(expected api.AppError, actual error) {
 	ms.Equal(expected.Category, appErr.Category, "error category does not match")
 }
 
-func (ms *ModelSuite) EqualNullTime(expected nulls.Time, actual *time.Time, msgAndArgs ...interface{}) {
+func (ms *ModelSuite) EqualNullTime(expected nulls.Time, actual *time.Time, msgAndArgs ...any) {
 	if actual == nil {
 		ms.False(expected.Valid, msgAndArgs...)
 	} else {
@@ -88,7 +88,7 @@ func (ms *ModelSuite) EqualNullTime(expected nulls.Time, actual *time.Time, msgA
 	}
 }
 
-func (ms *ModelSuite) EqualNullUUID(expected nulls.UUID, actual *uuid.UUID, msgAndArgs ...interface{}) {
+func (ms *ModelSuite) EqualNullUUID(expected nulls.UUID, actual *uuid.UUID, msgAndArgs ...any) {
 	if actual == nil {
 		ms.False(expected.Valid, msgAndArgs...)
 	} else {

--- a/application/models/testutils.go
+++ b/application/models/testutils.go
@@ -58,23 +58,23 @@ type Fixtures struct {
 // TestBuffaloContext is a buffalo context user in tests
 type TestBuffaloContext struct {
 	buffalo.DefaultContext
-	params map[interface{}]interface{}
+	params map[any]any
 }
 
 // Value returns the value associated with the given key in the test context
-func (b *TestBuffaloContext) Value(key interface{}) interface{} {
+func (b *TestBuffaloContext) Value(key any) any {
 	return b.params[key]
 }
 
 // Set sets the value to be associated with the given key in the test context
-func (b *TestBuffaloContext) Set(key string, val interface{}) {
+func (b *TestBuffaloContext) Set(key string, val any) {
 	b.params[key] = val
 }
 
 // CreateTestContext sets the domain.ContextKeyCurrentUser to the user param in the TestBuffaloContext
 func CreateTestContext(user User) buffalo.Context {
 	ctx := &TestBuffaloContext{
-		params: map[interface{}]interface{}{},
+		params: map[any]any{},
 	}
 	ctx.Set(domain.ContextKeyCurrentUser, user)
 	return ctx
@@ -664,7 +664,7 @@ func DestroyAll() {
 	destroyTable(&entityCodes)
 }
 
-func destroyTable(i interface{}) {
+func destroyTable(i any) {
 	if err := DB.All(i); err != nil {
 		panic(err.Error())
 	}

--- a/application/models/validation.go
+++ b/application/models/validation.go
@@ -28,7 +28,7 @@ var fieldValidators = map[string]func(validator.FieldLevel) bool{
 	"ledgerEntryRecordType":         validateLedgerEntryRecordType,
 }
 
-func validateModel(m interface{}) *validate.Errors {
+func validateModel(m any) *validate.Errors {
 	vErrs := validate.NewErrors()
 
 	if err := mValidate.Struct(m); err != nil {

--- a/application/notifications/messages.go
+++ b/application/notifications/messages.go
@@ -9,7 +9,7 @@ type Message struct {
 	Body      string
 	Subject   string
 	Template  string
-	Data      map[string]interface{}
+	Data      map[string]any
 	FromName  string
 	FromEmail string
 	FromPhone string
@@ -22,7 +22,7 @@ type Message struct {
 func NewEmailMessage() Message {
 	msg := Message{
 		FromEmail: domain.EmailFromAddress(nil),
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"appName": domain.Env.AppName,
 			"uiURL":   domain.Env.UIURL,
 		},


### PR DESCRIPTION
### Fixed
- Replace `interface{}` with `any`
- Specify version of goswagger to ensure it's current enough to handle `any` but also locked to prevent unexpected changes