### PR TITLE
use the final error message instead of the AppError message

### DIFF
--- a/application/actions/actions.go
+++ b/application/actions/actions.go
@@ -67,7 +67,7 @@ func reportError(c buffalo.Context, err error) error {
 	case api.CategoryUnauthorized, api.CategoryUser:
 		level = rollbar.WARN
 	}
-	domain.LogErrorMessage(c, appErr.Error(), level, appErr.Extras)
+	domain.LogErrorMessage(c, err.Error(), level, appErr.Extras)
 
 	appErr.LoadTranslatedMessage(c)
 


### PR DESCRIPTION
### Fixed
- When an `AppError` is embedded in a simple error, the later details were lost. Change to log the final error message. Typically, the embedded message will also be included in the final error message.