### PR TITLE
new endpoint to run a repair on items incorrectly renewed

### DIFF
--- a/application/actions/app.go
+++ b/application/actions/app.go
@@ -66,6 +66,7 @@ const (
 	policyDependentPath = "/" + domain.TypePolicyDependent
 	entityCodesPath     = "/" + domain.TypeEntityCode
 	policyMemberPath    = "/" + domain.TypePolicyMember
+	repairsPath         = "/repairs"
 	strikesPath         = "/" + domain.TypeStrike
 )
 
@@ -236,6 +237,11 @@ func App() *buffalo.App {
 		// policy-members
 		policyMembersGroup := app.Group(policyMemberPath)
 		policyMembersGroup.DELETE(idRegex, policiesMembersDelete)
+
+		// repairs
+		repairsGroup := app.Group(repairsPath)
+		repairsGroup.Middleware.Skip(AuthZ, repairsRun) // AuthZ is implemented in the handler
+		repairsGroup.POST("/", repairsRun)
 
 		// strikes
 		strikesGroup := app.Group(strikesPath)

--- a/application/actions/repairs.go
+++ b/application/actions/repairs.go
@@ -1,0 +1,87 @@
+package actions
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/gobuffalo/buffalo"
+	"github.com/silinternational/cover-api/api"
+	"github.com/silinternational/cover-api/domain"
+	"github.com/silinternational/cover-api/models"
+)
+
+// swagger:operation POST /repairs Repairs RepairsRun
+//
+// RepairsRun
+//
+// Run a repair
+//
+// ### Repair types:
+// + `renewal` - Repair all items that were incorrectly renewed and billed for another year of coverage. Also issues premium refunds for the incorrect renewal charges.
+//
+// ---
+// parameters:
+//   - name: input
+//     in: body
+//     description: parameters for the Repair Run
+//     required: true
+//     schema:
+//       "$ref": "#/definitions/RepairRunInput"
+// responses:
+//   '200':
+//     description: the repair result
+//     schema:
+//       "$ref": "#/definitions/RepairResult"
+func repairsRun(c buffalo.Context) error {
+	actor := models.CurrentUser(c)
+	if !actor.IsAdmin() {
+		err := fmt.Errorf("user not allowed to run repair")
+		return reportError(c, api.NewAppError(err, api.ErrorNotAuthorized, api.CategoryForbidden))
+	}
+
+	var input api.RepairRunInput
+	if err := StrictBind(c, &input); err != nil {
+		return reportError(c, err)
+	}
+
+	date, err := time.Parse(domain.DateFormat, input.Date)
+	if err != nil {
+		return reportError(c, api.NewAppError(err, api.ErrorInvalidDate, api.CategoryUser))
+	}
+
+	var result api.RepairResult
+
+	switch input.RepairType {
+	case api.RepairTypeRenewal:
+		result, err = runRenewalRepair(c, date)
+
+	default:
+		err = errors.New("unrecognized repair type, must be " + api.RepairTypeRenewal)
+		return reportError(c, api.NewAppError(err, api.ErrorUnrecognizedRepairType, api.CategoryUser))
+	}
+
+	if err != nil {
+		return reportError(c, err)
+	}
+	return renderOk(c, result)
+}
+
+func runRenewalRepair(c buffalo.Context, date time.Time) (api.RepairResult, error) {
+	tx := models.Tx(c)
+
+	var result api.RepairResult
+	var items models.Items
+	if err := items.RepairItemsIncorrectlyRenewed(c, date); err != nil {
+		return result, err
+	}
+
+	if len(items) > MaxResultSize {
+		err := errors.New("too many rows in the result set")
+		return result, api.NewAppError(err, api.ErrorTooManyRows, api.CategoryInternal)
+	}
+
+	result.Items = items.ConvertToAPI(tx)
+	result.RepairType = api.RepairTypeRenewal
+	return result, nil
+}

--- a/application/actions/repairs_test.go
+++ b/application/actions/repairs_test.go
@@ -1,0 +1,74 @@
+package actions
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/silinternational/cover-api/api"
+	"github.com/silinternational/cover-api/domain"
+	"github.com/silinternational/cover-api/models"
+)
+
+func (as *ActionSuite) Test_repairsRun() {
+	user := models.CreateUserFixtures(as.DB, 1).Users[0]
+	admin := models.CreateAdminUsers(as.DB)[models.AppRoleSteward]
+	date := time.Now().UTC().Format(domain.DateFormat)
+
+	tests := []struct {
+		name       string
+		actor      models.User
+		input      api.RepairRunInput
+		wantStatus int
+		wantError  api.ErrorKey
+	}{
+		{
+			name:       "Unauthorized (401)",
+			actor:      models.User{},
+			input:      api.RepairRunInput{Date: date, RepairType: api.RepairTypeRenewal},
+			wantStatus: http.StatusUnauthorized,
+			wantError:  api.ErrorNotAuthorized,
+		},
+		{
+			name:       "normal users can't do this",
+			actor:      user,
+			input:      api.RepairRunInput{Date: date, RepairType: api.RepairTypeRenewal},
+			wantStatus: http.StatusNotFound,
+			wantError:  api.ErrorNotAuthorized,
+		},
+		{
+			name:       "invalid date format",
+			actor:      admin,
+			input:      api.RepairRunInput{Date: time.Now().String(), RepairType: api.RepairTypeRenewal},
+			wantStatus: http.StatusBadRequest,
+			wantError:  api.ErrorInvalidDate,
+		},
+		{
+			name:       "admins can do this",
+			actor:      admin,
+			input:      api.RepairRunInput{Date: date, RepairType: api.RepairTypeRenewal},
+			wantStatus: http.StatusOK,
+		},
+	}
+	for _, tt := range tests {
+		as.T().Run(tt.name, func(t *testing.T) {
+			req := as.JSON(repairsPath)
+			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["content-type"] = domain.ContentJson
+			res := req.Post(tt.input)
+			body := res.Body.Bytes()
+
+			as.Equal(tt.wantStatus, res.Code, "incorrect status code returned: %d\n%s", res.Code, body)
+			if tt.wantStatus != http.StatusOK {
+				var err api.AppError
+				as.NoError(as.decodeBody(body, &err), "response data is not as expected")
+				as.Equal(tt.wantError, err.Key, "error key is incorrect")
+			} else {
+				var repairResult api.RepairResult
+				as.NoError(as.decodeBody(body, &repairResult), "response data is not as expected")
+				as.Equal(tt.input.RepairType, repairResult.RepairType, "repair_type is incorrect")
+			}
+		})
+	}
+}

--- a/application/api/errorcodes.go
+++ b/application/api/errorcodes.go
@@ -121,4 +121,9 @@ const (
 	ErrorClaimItemMissingFMV             = ErrorKey("ClaimItemMissingFMV")
 	ErrorClaimItemInvalidPayoutOption    = ErrorKey("ClaimItemInvalidPayoutOption")
 	ErrorClaimInvalidApprover            = ErrorKey("ClaimInvalidApprover")
+
+	// Repairs
+
+	ErrorItemNeedsCoverageEndDate = ErrorKey("ErrorItemNeedsCoverageEndDate")
+	ErrorUnrecognizedRepairType   = ErrorKey("ErrorUnrecognizedRepairType")
 )

--- a/application/api/repairs.go
+++ b/application/api/repairs.go
@@ -1,0 +1,15 @@
+package api
+
+const RepairTypeRenewal = "renewal"
+
+// swagger:model
+type RepairRunInput struct {
+	RepairType string `json:"repair_type"`
+	Date       string `json:"date"`
+}
+
+// swagger:model
+type RepairResult struct {
+	RepairType string `json:"repair_type"`
+	Items      Items  `json:"items"`
+}


### PR DESCRIPTION
### Added
- New endpoint, `POST /repairs`, to repair policy items that were processed during an annual renewal but should not have been.

_Background: some time in 2022, the background "inactivate items" process stopped running. This left a number of items in an incorrect state where they were marked for deactivation (`coverage_end_date` not null) but not inactive (`coverage_status` was still "Approved"). The renewal process in February 2023 included these items, which created renewal ledger entries for each of them and set their `paid_through_year` to 2023._