### PR TITLE
process policy renewal in a background job

### DIFF
--- a/application/actions/actions.go
+++ b/application/actions/actions.go
@@ -72,7 +72,7 @@ func reportError(c buffalo.Context, err error) error {
 	appErr.LoadTranslatedMessage(c)
 
 	// clear out debugging info if not in development or test
-	if domain.Env.GoEnv == "development" || domain.Env.GoEnv == "test" {
+	if domain.Env.GoEnv == domain.EnvDevelopment || domain.Env.GoEnv == domain.EnvTest {
 		if appErr.Err != nil {
 			appErr.DebugMsg = appErr.Err.Error()
 		}

--- a/application/actions/app.go
+++ b/application/actions/app.go
@@ -247,7 +247,6 @@ func App() *buffalo.App {
 		strikesGroup := app.Group(strikesPath)
 		strikesGroup.PUT(idRegex, strikesUpdate)
 		strikesGroup.DELETE(idRegex, strikesDelete)
-	}
 
 		listeners.RegisterListener()
 

--- a/application/actions/app.go
+++ b/application/actions/app.go
@@ -249,9 +249,10 @@ func App() *buffalo.App {
 		strikesGroup.DELETE(idRegex, strikesDelete)
 	}
 
-	listeners.RegisterListener()
+		listeners.RegisterListener()
 
-	job.Init(&app.Worker)
+		job.Init(&app.Worker)
+	}
 
 	return app
 }

--- a/application/actions/auth.go
+++ b/application/actions/auth.go
@@ -366,7 +366,7 @@ func replaceNewLines(input string) string {
 }
 
 func checkSamlConfig() {
-	if domain.Env.GoEnv == "development" || domain.Env.GoEnv == "test" {
+	if domain.Env.GoEnv == domain.EnvDevelopment || domain.Env.GoEnv == domain.EnvTest {
 		return
 	}
 	if domain.Env.SamlIdpEntityId == "" {

--- a/application/actions/errorhandlers.go
+++ b/application/actions/errorhandlers.go
@@ -32,7 +32,7 @@ func customErrorHandler(status int, origErr error, c buffalo.Context) error {
 	c.Response().WriteHeader(status)
 	c.Response().Header().Set("content-type", domain.ContentJson)
 
-	if domain.Env.GoEnv == "development" {
+	if domain.Env.GoEnv == domain.EnvDevelopment {
 		debug.PrintStack()
 	}
 

--- a/application/api/errorcodes.go
+++ b/application/api/errorcodes.go
@@ -14,6 +14,7 @@ const (
 
 	ErrorCreateFailure            = ErrorKey("ErrorCreateFailure")
 	ErrorDestroyFailure           = ErrorKey("ErrorDestroyFailure")
+	ErrorFailedToSubmitJob        = ErrorKey("ErrorFailedToSubmitJob")
 	ErrorFailedToConvertToAPIType = ErrorKey("ErrorFailedToConvertToAPIType")
 	ErrorForeignKeyViolation      = ErrorKey("ErrorForeignKeyViolation")
 	ErrorInvalidRequestBody       = ErrorKey("ErrorInvalidRequestBody")

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -121,6 +121,15 @@ const (
 // redirect url for after logout
 var LogoutRedirectURL = "missing.ui.url/logged-out"
 
+// EnvDevelopment is used for various debugging aids
+const EnvDevelopment = "development"
+
+// EnvStaging is for the staging environment
+const EnvStaging = "test"
+
+// EnvTest is for automated tests, during which some things are disabled
+const EnvTest = "test"
+
 // Env Holds the values of environment variables
 var Env struct {
 	GoEnv                      string `ignored:"true"`
@@ -236,7 +245,7 @@ func readEnv() {
 	}
 
 	// Doing this separately to avoid needing two environment variables for the same thing
-	Env.GoEnv = envy.Get("GO_ENV", "development")
+	Env.GoEnv = envy.Get("GO_ENV", EnvDevelopment)
 }
 
 // ErrLogProxy is a "tee" that sends to Rollbar and to the local logger,

--- a/application/domain/warnerror.go
+++ b/application/domain/warnerror.go
@@ -38,7 +38,7 @@ func jsonIndented(i any) ([]byte, error) {
 // encodeLogMsg adds the message as an "extra" and returns a json-encoded copy of the resulting extras map
 func encodeLogMsg(msg string, extras map[string]any) string {
 	encoder := jsonMin
-	if Env.GoEnv == "development" {
+	if Env.GoEnv == EnvDevelopment {
 		encoder = jsonIndented
 	}
 

--- a/application/job/inactivate.go
+++ b/application/job/inactivate.go
@@ -1,0 +1,46 @@
+package job
+
+import (
+	"time"
+
+	"github.com/gobuffalo/buffalo/worker"
+	"github.com/gobuffalo/pop/v6"
+	"github.com/silinternational/cover-api/domain"
+	"github.com/silinternational/cover-api/models"
+)
+
+// inactivateItemsHandler is the Worker handler for inactivating items that
+// have a coverage end date in the past
+func inactivateItemsHandler(_ worker.Args) error {
+	defer resubmitInactivateJob()
+
+	ctx := createJobContext()
+
+	domain.Logger.Printf("starting inactivateItems job")
+	nw := time.Now().UTC()
+
+	err := models.DB.Transaction(func(tx *pop.Connection) error {
+		ctx.Set(domain.ContextKeyTx, tx)
+		var items models.Items
+		return items.InactivateApprovedButEnded(ctx)
+	})
+	if err != nil {
+		return err
+	}
+
+	domain.Logger.Printf("completed inactivateItems job in %v seconds", time.Since(nw).Seconds())
+	return nil
+}
+
+func resubmitInactivateJob() {
+	// Run twice a day, in case it errors out
+	delay := time.Hour * 12
+
+	// uncomment this in development, if you want it to run more often for debugging
+	// delay = time.Second * 10
+
+	if err := SubmitDelayed(InactivateItems, delay, map[string]any{}); err != nil {
+		domain.ErrLogger.Printf("error resubmitting inactivateItemsHandler: " + err.Error())
+	}
+	return
+}

--- a/application/job/job.go
+++ b/application/job/job.go
@@ -116,7 +116,6 @@ func Submit(jobType string, args map[string]any) error {
 	if domain.Env.GoEnv == domain.EnvTest {
 		return nil
 	}
-	time.Sleep(time.Second)
 	job := worker.Job{
 		Queue:   "default",
 		Args:    args,

--- a/application/job/job.go
+++ b/application/job/job.go
@@ -83,7 +83,7 @@ func Init(appWorker *worker.Worker) {
 	delay := time.Second * 10
 
 	// Kick off first run of inactivating items between 1h11 and 3h27 from now
-	if domain.Env.GoEnv != "development" {
+	if domain.Env.GoEnv != domain.EnvDevelopment {
 		randMins := time.Duration(domain.RandomInsecureIntInRange(71, 387))
 		delay = randMins * time.Minute
 	}

--- a/application/job/job.go
+++ b/application/job/job.go
@@ -110,44 +110,11 @@ func mainHandler(args worker.Args) error {
 	return nil
 }
 
-// inactivateItemsHandler is the Worker handler for inactivating items that
-// have a coverage end date in the past
-func inactivateItemsHandler(_ worker.Args) error {
-	defer resubmitInactivateJob()
-
-	ctx := createJobContext()
-
-	domain.Logger.Printf("starting inactivateItems job")
-	nw := time.Now().UTC()
-
-	err := models.DB.Transaction(func(tx *pop.Connection) error {
-		ctx.Set(domain.ContextKeyTx, tx)
-		var items models.Items
-		return items.InactivateApprovedButEnded(ctx)
-	})
-	if err != nil {
-		return err
-	}
-
-	domain.Logger.Printf("completed inactivateItems job in %v seconds", time.Since(nw).Seconds())
-	return nil
-}
-
-func resubmitInactivateJob() {
-	// Run twice a day, in case it errors out
-	delay := time.Hour * 12
-
-	// uncomment this in development, if you want it to run more often for debugging
-	// delay = time.Second * 10
-
-	if err := SubmitDelayed(InactivateItems, delay, map[string]any{}); err != nil {
-		domain.ErrLogger.Printf("error resubmitting inactivateItemsHandler: " + err.Error())
-	}
-	return
-}
-
-// SubmitDelayed enqueues a new Worker job for the given handler. Arguments can be provided in `args`.
+// SubmitDelayed enqueues a new Worker job for the given job type. Arguments can be provided in `args`.
 func SubmitDelayed(jobType string, delay time.Duration, args map[string]any) error {
+	if domain.Env.GoEnv == domain.EnvTest {
+		return nil
+	}
 	job := worker.Job{
 		Queue:   "default",
 		Args:    args,

--- a/application/job/renewal.go
+++ b/application/job/renewal.go
@@ -1,0 +1,32 @@
+package job
+
+import (
+	"time"
+
+	"github.com/gobuffalo/buffalo/worker"
+	"github.com/gobuffalo/pop/v6"
+	"github.com/silinternational/cover-api/domain"
+	"github.com/silinternational/cover-api/models"
+)
+
+// annualRenewalHandler is the Worker handler for processing annual policy renewal
+func annualRenewalHandler(_ worker.Args) error {
+	domain.Logger.Printf("starting annualRenewal job")
+	nw := time.Now().UTC()
+
+	err := models.DB.Transaction(func(tx *pop.Connection) error {
+		currentYear := time.Now().UTC().Year()
+
+		var policies models.Policies
+		if err := policies.AllActive(tx); err != nil {
+			return err
+		}
+		return policies.ProcessAnnualCoverage(tx, currentYear)
+	})
+	if err != nil {
+		return err
+	}
+
+	domain.Logger.Printf("completed annualRenewal job in %v seconds", time.Since(nw).Seconds())
+	return nil
+}

--- a/application/models/models.go
+++ b/application/models/models.go
@@ -169,7 +169,7 @@ func init() {
 		domain.ErrLogger.Printf("error connecting to database ... %v", err)
 		log.Fatal(err)
 	}
-	pop.Debug = env == "development"
+	pop.Debug = env == domain.EnvDevelopment
 
 	// Just make sure we can use the crypto/rand library on our system
 	if _, err = getRandomToken(); err != nil {

--- a/application/models/user.go
+++ b/application/models/user.go
@@ -143,7 +143,7 @@ func (u *User) FindOrCreateFromAuthUser(tx *pop.Connection, authUser *auth.User)
 	if u.AppRole == "" {
 		u.AppRole = AppRoleCustomer
 		id, _ := strconv.Atoi(authUser.StaffID)
-		if domain.Env.GoEnv == "development" || domain.Env.GoEnv == "staging" {
+		if domain.Env.GoEnv == domain.EnvDevelopment || domain.Env.GoEnv == domain.EnvStaging {
 			if id >= 1000000 {
 				u.AppRole = AppRoleSteward
 			}

--- a/application/models/useraccesstoken.go
+++ b/application/models/useraccesstoken.go
@@ -152,7 +152,7 @@ func (u *UserAccessToken) Update(tx *pop.Connection) error {
 func InitAccessToken(clientID string) UserAccessToken {
 	token, _ := getRandomToken() // The init() function would have made sure there was no error
 
-	if domain.Env.GoEnv == "development" {
+	if domain.Env.GoEnv == domain.EnvDevelopment {
 		fmt.Printf("\n\nClientID+token: %s%s\n", clientID, token)
 	}
 

--- a/application/storage/storage.go
+++ b/application/storage/storage.go
@@ -44,7 +44,7 @@ func getS3ConfigFromEnv() awsConfig {
 	a.awsS3Bucket = domain.Env.AwsS3Bucket
 	a.awsDisableSSL = domain.Env.AwsS3DisableSSL
 
-	if domain.Env.GoEnv == "development" || domain.Env.GoEnv == "test" {
+	if domain.Env.GoEnv == domain.EnvDevelopment || domain.Env.GoEnv == domain.EnvTest {
 		a.awsAccessKeyID = "abc123"
 		a.awsSecretAccessKey = "abcd1234"
 	}
@@ -187,7 +187,7 @@ func RemoveFile(key string) error {
 // exists, it will not return an error.
 func CreateS3Bucket() error {
 	env := domain.Env.GoEnv
-	if env != "test" && env != "development" {
+	if env != domain.EnvTest && env != domain.EnvDevelopment {
 		return errors.New("CreateS3Bucket should only be used in test and development")
 	}
 


### PR DESCRIPTION
### Changed
- Moved the annual policy renewal process into a background job
- Added const identifiers for "development", "test", and "staging"
### Fixed
- Moved the initialization of listeners and jobs inside the `if app == nil` statement so they don't run twice. That constructor is only called twice in the compiled binary, so we didn't see this in development.