### PR TITLE
fix Sentry log weirdness

### DIFF
--- a/application/actions/auth.go
+++ b/application/actions/auth.go
@@ -258,7 +258,7 @@ func authCallback(c buffalo.Context) error {
 	authUser.AccessTokenExpiresAt = uat.ExpiresAt.UTC().Unix()
 
 	// set person on rollbar session
-	log.SetUser(user.StaffID.String, user.GetName().String(), user.Email)
+	log.SetUser(c, user.StaffID.String, user.GetName().String(), user.Email)
 
 	return c.Redirect(302, getLoginSuccessRedirectURL(*authUser, returnTo))
 }
@@ -328,7 +328,7 @@ func authDestroy(c buffalo.Context) error {
 	}
 
 	// set person on rollbar session
-	log.SetUser(authUser.ID.String(), authUser.GetName().String(), authUser.Email)
+	log.SetUser(c, authUser.ID.String(), authUser.GetName().String(), authUser.Email)
 
 	sp, err := saml.New(samlConfig)
 	if err != nil {

--- a/application/actions/authn.go
+++ b/application/actions/authn.go
@@ -44,7 +44,7 @@ func AuthN(next buffalo.Handler) buffalo.Handler {
 		c.Set(domain.ContextKeyCurrentUser, user)
 
 		// set user for remote logger (e.g. Rollbar, Sentry)
-		log.SetUser(user.ID.String(), user.GetName().String(), user.Email)
+		log.SetUser(c, user.ID.String(), user.GetName().String(), user.Email)
 
 		return next(c)
 	}

--- a/application/log/log.go
+++ b/application/log/log.go
@@ -175,10 +175,10 @@ func WithContext(ctx context.Context) *logrus.Entry {
 	return ErrLogger.LocalLog.WithContext(ctx)
 }
 
-func SetUser(id, username, email string) {
+func SetUser(ctx context.Context, id, username, email string) {
 	if !ErrLogger.config.remote {
 		return
 	}
-	ErrLogger.rollbar.SetUser(id, username, email)
-	ErrLogger.sentry.SetUser(id, username, email)
+	ErrLogger.rollbar.SetUser(ctx, id, username, email)
+	ErrLogger.sentry.SetUser(ctx, id, username, email)
 }

--- a/application/log/rollbar.go
+++ b/application/log/rollbar.go
@@ -68,7 +68,7 @@ func (r *RollbarHook) Levels() []logrus.Level {
 func (r *RollbarHook) Fire(entry *logrus.Entry) error {
 	extras := entry.Data
 
-	if extras["status"] == 401 || extras["status"] == 404 {
+	if extras["status"] == 401 {
 		return nil
 	}
 

--- a/application/log/rollbar.go
+++ b/application/log/rollbar.go
@@ -74,25 +74,28 @@ func (r *RollbarHook) Fire(entry *logrus.Entry) error {
 
 	if ctx, ok := entry.Context.(buffalo.Context); ok {
 		client := r.getClient(ctx)
-		client.RequestMessageWithExtras(mapRollbarToLogrusLevel[entry.Level], ctx.Request(), entry.Message, extras)
-	} else {
-		r.client.MessageWithExtras(mapRollbarToLogrusLevel[entry.Level], entry.Message, extras)
+		if client != nil {
+			client.RequestMessageWithExtras(mapRollbarToLogrusLevel[entry.Level], ctx.Request(), entry.Message, extras)
+			return nil
+		}
 	}
-
+	r.client.MessageWithExtras(mapRollbarToLogrusLevel[entry.Level], entry.Message, extras)
 	return nil
 }
 
-func (r *RollbarHook) SetUser(id, username, email string) {
+func (r *RollbarHook) SetUser(ctx context.Context, id, username, email string) {
 	if r == nil || r.client == nil {
 		return
 	}
-
-	r.client.SetPerson(id, username, email)
+	contextClient := r.getClient(ctx)
+	if contextClient != nil {
+		contextClient.SetPerson(id, username, email)
+	}
 }
 
 func (r *RollbarHook) getClient(ctx context.Context) *rollbar.Client {
 	if c, ok := ctx.Value(ContextKeyRollbar).(*rollbar.Client); ok {
 		return c
 	}
-	return r.client
+	return nil
 }

--- a/application/log/sentry.go
+++ b/application/log/sentry.go
@@ -48,7 +48,7 @@ func (s *SentryHook) Levels() []logrus.Level {
 func (s *SentryHook) Fire(entry *logrus.Entry) error {
 	extras := entry.Data
 
-	if extras["status"] == 401 || extras["status"] == 404 {
+	if extras["status"] == 401 {
 		return nil
 	}
 

--- a/application/log/sentry.go
+++ b/application/log/sentry.go
@@ -3,9 +3,7 @@ package log
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"os"
-	"time"
 
 	"github.com/getsentry/sentry-go"
 	_ "github.com/getsentry/sentry-go"
@@ -38,23 +36,8 @@ func SentryMiddleware(next buffalo.Handler) buffalo.Handler {
 			hub = sentry.CurrentHub().Clone()
 		}
 
-		hub.Scope().SetRequest(r)
-		defer recoverWithSentry(hub, r)
 		c.Set(ContextKeySentryHub, hub)
 		return next(c)
-	}
-}
-
-func recoverWithSentry(hub *sentry.Hub, r *http.Request) {
-	if err := recover(); err != nil {
-		eventID := hub.RecoverWithContext(
-			context.WithValue(r.Context(), sentry.RequestContextKey, r),
-			err,
-		)
-		if eventID != nil {
-			hub.Flush(time.Second * 2)
-		}
-		panic(err)
 	}
 }
 

--- a/local-example.env
+++ b/local-example.env
@@ -47,6 +47,8 @@ SAML_REQUIRE_ENCRYPTED_ASSERTION=true
 ROLLBAR_SERVER_ROOT=github.com/myorg/myapp
 ROLLBAR_TOKEN=
 
+SENTRY_DSN=
+
 SESSION_SECRET=abc123
 UIURL=
 USER_WELCOME_EMAIL_INTRO=Welcome to <a href="example.org">Our App</a>.


### PR DESCRIPTION
### Fixed
- Stop using Sentry's panic recover. It is redundant with Buffalo's panic recovery, and not as useful because it doesn't log the extra information we add in our custom error handler.
- Log the user info on the logger client stored in the context. This fixes a problem with attributing the wrong user information on subsequent error log events.
- Include `SENTRY_DSN` in the example env file.

### Change
- Go ahead and log 404 errors for now. May need to silence them if we get too many, but let's see what it looks like.

