### PR TITLE
get "primary" steward, not "default" steward

### DIFF
--- a/application/messages/messages.go
+++ b/application/messages/messages.go
@@ -131,7 +131,7 @@ func (m MessageData) addStewardData(tx *pop.Connection) {
 		m = map[string]any{}
 	}
 
-	steward := models.GetDefaultSteward(tx)
+	steward := models.GetPrimarySteward(tx)
 	m["supportEmail"] = domain.Env.SupportEmail
 	m["supportName"] = steward.Name()
 	m["supportFirstName"] = steward.FirstName

--- a/application/messages/messages.go
+++ b/application/messages/messages.go
@@ -64,6 +64,7 @@ func newEmailMessageData() MessageData {
 	m["uiURL"] = domain.Env.UIURL
 	m["appName"] = domain.Env.AppName
 	m["premiumPercentage"] = fmt.Sprintf("%.2g%%", domain.Env.PremiumFactor*100)
+	m["supportEmail"] = domain.Env.SupportEmail
 	m["supportURL"] = domain.Env.SupportURL
 	m["faqURL"] = domain.Env.FaqURL
 
@@ -132,7 +133,6 @@ func (m MessageData) addStewardData(tx *pop.Connection) {
 	}
 
 	steward := models.GetPrimarySteward(tx)
-	m["supportEmail"] = domain.Env.SupportEmail
 	m["supportName"] = steward.Name()
 	m["supportFirstName"] = steward.FirstName
 }

--- a/application/models/user.go
+++ b/application/models/user.go
@@ -189,11 +189,11 @@ func (u *User) EmailOfChoice() string {
 	return u.Email
 }
 
-// GetDefaultSteward returns the User with AppRoleSteward who logged in most recently
-func GetDefaultSteward(tx *pop.Connection) User {
+// GetPrimarySteward returns the User with AppRoleSteward and the earliest created_at
+func GetPrimarySteward(tx *pop.Connection) User {
 	u := User{}
-	if err := tx.Where("app_role = ?", AppRoleSteward).Order("last_login_utc desc").First(&u); err != nil {
-		panic("error finding most recently logged in steward user " + err.Error())
+	if err := tx.Where("app_role = ? AND NOT is_blocked", AppRoleSteward).Order("created_at ASC").First(&u); err != nil {
+		log.Fatalf("error finding the primary steward user: %s", err)
 	}
 	return u
 }


### PR DESCRIPTION
### Changed
- For email template data, get the **primary** (most senior) steward, not the **default** (latest to login) steward. 