### PR TITLE
fix swagger docs to play nicely with gofmt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ application/emailtester/*.go
 .vscode/
 application/grifts/private.go
 application/migrations/schema.sql
-application/swagger.json
 application/vendor/
 bin/
 coverage
@@ -46,3 +45,4 @@ go-build/
 # Data files
 *.csv
 *.json
+!swagger.json

--- a/application/actions/actions.go
+++ b/application/actions/actions.go
@@ -28,7 +28,7 @@ func init() {
 
 // StrictBind hydrates a struct with values from a POST
 // REMEMBER the request body must have *exported* fields.
-//  Otherwise, this will give an empty result without an error.
+// Otherwise, this will give an empty result without an error.
 func StrictBind(c buffalo.Context, dest any) error {
 	dec := json.NewDecoder(c.Request().Body)
 	dec.DisallowUnknownFields()

--- a/application/actions/app.go
+++ b/application/actions/app.go
@@ -1,8 +1,7 @@
 // Cover API
 //
 //	Terms Of Service:
-//
-// there are no TOS at this moment, use at your own risk we take no responsibility
+//	  there are no TOS at this moment, use at your own risk we take no responsibility
 //
 //	 Schemes: https
 //	 Host: localhost
@@ -11,22 +10,22 @@
 //	 License: MIT http://opensource.org/licenses/MIT
 //
 //	 Consumes:
-//  - application/json
+//	 - application/json
 //
 //	 Produces:
-//  - application/json
+//	 - application/json
 //
 //	 Security:
 //	 - oauth2:
 //
 //	 SecurityDefinitions:
 //	 oauth2:
-//	     type: oauth2
-//	     authorizationUrl: /auth/login
-//	     tokenUrl: /auth/token
-//	     scopes:
-//	       all: scopes are not used at this time
-//	     flow: implicit
+//	   type: oauth2
+//	   authorizationUrl: /auth/login
+//	   tokenUrl: /auth/token
+//	   flow: implicit
+//	   scopes:
+//	     all: scopes are not used at this time
 //
 // swagger:meta
 package actions

--- a/application/actions/app.go
+++ b/application/actions/app.go
@@ -1,32 +1,32 @@
 // Cover API
 //
-// Terms Of Service:
+//	Terms Of Service:
 //
 // there are no TOS at this moment, use at your own risk we take no responsibility
 //
-//  Schemes: https
-//  Host: localhost
-//  BasePath: /
-//  Version: 0.0.1
-//  License: MIT http://opensource.org/licenses/MIT
+//	 Schemes: https
+//	 Host: localhost
+//	 BasePath: /
+//	 Version: 0.0.1
+//	 License: MIT http://opensource.org/licenses/MIT
 //
-//  Consumes:
+//	 Consumes:
 //  - application/json
 //
-//  Produces:
+//	 Produces:
 //  - application/json
 //
-//  Security:
-//  - oauth2:
+//	 Security:
+//	 - oauth2:
 //
-//  SecurityDefinitions:
-//  oauth2:
-//      type: oauth2
-//      authorizationUrl: /auth/login
-//      tokenUrl: /auth/token
-//      scopes:
-//        all: scopes are not used at this time
-//      flow: implicit
+//	 SecurityDefinitions:
+//	 oauth2:
+//	     type: oauth2
+//	     authorizationUrl: /auth/login
+//	     tokenUrl: /auth/token
+//	     scopes:
+//	       all: scopes are not used at this time
+//	     flow: implicit
 //
 // swagger:meta
 package actions

--- a/application/actions/audits.go
+++ b/application/actions/audits.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/gobuffalo/buffalo"
+
 	"github.com/silinternational/cover-api/api"
 	"github.com/silinternational/cover-api/domain"
 	"github.com/silinternational/cover-api/models"
@@ -25,18 +26,18 @@ const MaxResultSize = 1000
 // + `renewal` - Return all items that were incorrectly renewed and billed for another year of coverage.
 //
 // ---
-// parameters:
-//   - name: input
-//     in: body
-//     description: parameters for the Audit Run
-//     required: true
-//     schema:
-//       "$ref": "#/definitions/AuditRunInput"
-// responses:
-//   '200':
-//     description: the audit result
-//     schema:
-//       "$ref": "#/definitions/AuditResult"
+//	parameters:
+//	  - name: input
+//	    in: body
+//	    description: parameters for the Audit Run
+//	    required: true
+//	    schema:
+//	      "$ref": "#/definitions/AuditRunInput"
+//	responses:
+//	  '200':
+//	    description: the audit result
+//	    schema:
+//	      "$ref": "#/definitions/AuditResult"
 func auditRun(c buffalo.Context) error {
 	actor := models.CurrentUser(c)
 	if !actor.IsAdmin() {

--- a/application/actions/audits.go
+++ b/application/actions/audits.go
@@ -17,14 +17,12 @@ import (
 const MaxResultSize = 1000
 
 // swagger:operation POST /audits Audits AuditRun
-//
 // AuditsRun
 //
 // Run an audit
 //
 // ### Audit types:
 // + `renewal` - Return all items that were incorrectly renewed and billed for another year of coverage.
-//
 // ---
 //	parameters:
 //	  - name: input

--- a/application/actions/audits.go
+++ b/application/actions/audits.go
@@ -17,13 +17,14 @@ import (
 const MaxResultSize = 1000
 
 // swagger:operation POST /audits Audits AuditRun
-// AuditsRun
-//
-// Run an audit
-//
-// ### Audit types:
-// + `renewal` - Return all items that were incorrectly renewed and billed for another year of coverage.
 // ---
+//
+//	summary: AuditsRun
+//	description: |-
+//	  Run an audit
+//
+//	  ### Audit types:
+//	  + `renewal` - Return all items that were incorrectly renewed and billed for another year of coverage.
 //	parameters:
 //	  - name: input
 //	    in: body

--- a/application/actions/auth.go
+++ b/application/actions/auth.go
@@ -65,14 +65,14 @@ var samlConfig = saml.Config{
 // Start the SAML login process
 //
 // ---
-// parameters:
-// - name: client-id
-//   in: query
-//   required: true
-//   description: the user's client id
-// responses:
-//   '200':
-//     description: returns a "RedirectURL" key with the saml idp url that has a saml request
+//	parameters:
+//	- name: client-id
+//	  in: query
+//	  required: true
+//	  description: the user's client id
+//	responses:
+//	  '200':
+//	    description: returns a "RedirectURL" key with the saml idp url that has a saml request
 func authRequest(c buffalo.Context) error {
 	// Push the Client ID into the Session
 	clientID := c.Param(ClientIDParam)
@@ -294,14 +294,14 @@ func getLoginSuccessRedirectURL(authUser auth.User, returnTo string) string {
 // Logout of application
 //
 // ---
-// parameters:
-// - name: token
-//   in: query
-//   required: true
-//   description: the user's bearer token
-// responses:
-//   '302':
-//     description: redirect to UI
+//	parameters:
+//	- name: token
+//	  in: query
+//	  required: true
+//	  description: the user's bearer token
+//	responses:
+//	  '302':
+//	    description: redirect to UI
 func authDestroy(c buffalo.Context) error {
 	tokenParam := c.Param(LogoutToken)
 	if tokenParam == "" {

--- a/application/actions/auth.go
+++ b/application/actions/auth.go
@@ -63,6 +63,7 @@ var samlConfig = saml.Config{
 //
 // Start the SAML login process
 // ---
+//
 //	parameters:
 //	- name: client-id
 //	  in: query
@@ -290,6 +291,7 @@ func getLoginSuccessRedirectURL(authUser auth.User, returnTo string) string {
 //
 // Logout of application
 // ---
+//
 //	parameters:
 //	- name: token
 //	  in: query

--- a/application/actions/auth.go
+++ b/application/actions/auth.go
@@ -59,11 +59,9 @@ var samlConfig = saml.Config{
 }
 
 // swagger:operation POST /auth/login Authentication AuthLogin
-//
 // AuthLogin
 //
 // Start the SAML login process
-//
 // ---
 //	parameters:
 //	- name: client-id
@@ -288,11 +286,9 @@ func getLoginSuccessRedirectURL(authUser auth.User, returnTo string) string {
 }
 
 // swagger:operation GET /auth/logout Authentication AuthLogout
-//
 // AuthLogout
 //
 // Logout of application
-//
 // ---
 //	parameters:
 //	- name: token

--- a/application/actions/claimfiles.go
+++ b/application/actions/claimfiles.go
@@ -15,6 +15,7 @@ import (
 //
 // attach a File to a Claim
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -53,6 +54,7 @@ func claimFilesAttach(c buffalo.Context) error {
 //
 // Delete a ClaimFile and its associated File in the db and on S3
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path

--- a/application/actions/claimfiles.go
+++ b/application/actions/claimfiles.go
@@ -11,11 +11,9 @@ import (
 )
 
 // swagger:operation POST /claims/{id}/files ClaimFiles ClaimFilesAttach
-//
 // ClaimFilesAttach
 //
 // attach a File to a Claim
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -51,11 +49,9 @@ func claimFilesAttach(c buffalo.Context) error {
 }
 
 // swagger:operation DELETE /claim-files/{id} ClaimFiles ClaimFilesDelete
-//
 // ClaimFilesDelete
 //
 // Delete a ClaimFile and its associated File in the db and on S3
-//
 // ---
 //	parameters:
 //	  - name: id

--- a/application/actions/claimfiles.go
+++ b/application/actions/claimfiles.go
@@ -17,22 +17,22 @@ import (
 // attach a File to a Claim
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: claim ID
-//   - name: claim file input
-//     in: body
-//     description: claim file attach input object
-//     required: true
-//     schema:
-//       "$ref": "#/definitions/ClaimFileAttachInput"
-// responses:
-//   '200':
-//     description: the new ClaimFile
-//     schema:
-//       "$ref": "#/definitions/ClaimFile"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: claim ID
+//	  - name: claim file input
+//	    in: body
+//	    description: claim file attach input object
+//	    required: true
+//	    schema:
+//	      "$ref": "#/definitions/ClaimFileAttachInput"
+//	responses:
+//	  '200':
+//	    description: the new ClaimFile
+//	    schema:
+//	      "$ref": "#/definitions/ClaimFile"
 func claimFilesAttach(c buffalo.Context) error {
 	var input api.ClaimFileAttachInput
 	if err := StrictBind(c, &input); err != nil {
@@ -57,14 +57,14 @@ func claimFilesAttach(c buffalo.Context) error {
 // Delete a ClaimFile and its associated File in the db and on S3
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: claim file ID
-// responses:
-//   '204':
-//     description: OK but no content in response
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: claim file ID
+//	responses:
+//	  '204':
+//	    description: OK but no content in response
 func claimFilesDelete(c buffalo.Context) error {
 	tx := models.Tx(c)
 	cFile := getReferencedClaimFileFromCtx(c)

--- a/application/actions/claimitems.go
+++ b/application/actions/claimitems.go
@@ -16,22 +16,22 @@ import (
 // update a claim item
 //
 // ---
-// parameters:
-// - name: id
-//   in: path
-//   required: true
-//   description: claim item ID
-// - name: claim item input
-//   in: body
-//   description: claim item update input object
-//   required: true
-//   schema:
-//     "$ref": "#/definitions/ClaimItemUpdateInput"
-// responses:
-//   '200':
-//     description: the updated ClaimItem
-//     schema:
-//       "$ref": "#/definitions/ClaimItem"
+//	parameters:
+//	- name: id
+//	  in: path
+//	  required: true
+//	  description: claim item ID
+//	- name: claim item input
+//	  in: body
+//	  description: claim item update input object
+//	  required: true
+//	  schema:
+//	    "$ref": "#/definitions/ClaimItemUpdateInput"
+//	responses:
+//	  '200':
+//	    description: the updated ClaimItem
+//	    schema:
+//	      "$ref": "#/definitions/ClaimItem"
 func claimItemsUpdate(c buffalo.Context) error {
 	tx := models.Tx(c)
 	claimItem := getReferencedClaimItemFromCtx(c)

--- a/application/actions/claimitems.go
+++ b/application/actions/claimitems.go
@@ -14,6 +14,7 @@ import (
 //
 // update a claim item
 // ---
+//
 //	parameters:
 //	- name: id
 //	  in: path

--- a/application/actions/claimitems.go
+++ b/application/actions/claimitems.go
@@ -10,11 +10,9 @@ import (
 )
 
 // swagger:operation PUT /claim-items/{id} ClaimItems ClaimItemsUpdate
-//
 // ClaimItemsUpdate
 //
 // update a claim item
-//
 // ---
 //	parameters:
 //	- name: id

--- a/application/actions/claims.go
+++ b/application/actions/claims.go
@@ -22,18 +22,18 @@ import (
 // Review3, Revision, Receipt, Approved, Paid, Denied
 //
 // ---
-// parameters:
-// - name: status
-//   in: query
-//   required: false
-//   description: comma-separated list of status values to include
-// responses:
-//   '200':
-//     description: a list of Claims
-//     schema:
-//       type: array
-//       items:
-//         "$ref": "#/definitions/Claim"
+//	parameters:
+//	- name: status
+//	  in: query
+//	  required: false
+//	  description: comma-separated list of status values to include
+//	responses:
+//	  '200':
+//	    description: a list of Claims
+//	    schema:
+//	      type: array
+//	      items:
+//	        "$ref": "#/definitions/Claim"
 func claimsList(c buffalo.Context) error {
 	user := models.CurrentUser(c)
 
@@ -78,13 +78,13 @@ func claimsListCustomer(c buffalo.Context) error {
 // List claims for a given policy
 //
 // ---
-// responses:
-//   '200':
-//     description: a list of Claims
-//     schema:
-//       type: array
-//       items:
-//         "$ref": "#/definitions/Claim"
+//	responses:
+//	  '200':
+//	    description: a list of Claims
+//	    schema:
+//	      type: array
+//	      items:
+//	        "$ref": "#/definitions/Claim"
 func policiesClaimsList(c buffalo.Context) error {
 	policy := getReferencedPolicyFromCtx(c)
 
@@ -102,16 +102,16 @@ func policiesClaimsList(c buffalo.Context) error {
 // view a specific claim
 //
 // ---
-// parameters:
-// - name: id
-//   in: path
-//   required: true
-//   description: claim ID
-// responses:
-//   '200':
-//     description: a Claim
-//     schema:
-//       "$ref": "#/definitions/Claim"
+//	parameters:
+//	- name: id
+//	  in: path
+//	  required: true
+//	  description: claim ID
+//	responses:
+//	  '200':
+//	    description: a Claim
+//	    schema:
+//	      "$ref": "#/definitions/Claim"
 func claimsView(c buffalo.Context) error {
 	tx := models.Tx(c)
 	claim := getReferencedClaimFromCtx(c)
@@ -125,22 +125,22 @@ func claimsView(c buffalo.Context) error {
 // update a claim
 //
 // ---
-// parameters:
-// - name: id
-//   in: path
-//   required: true
-//   description: claim ID
-// - name: claim input
-//   in: body
-//   description: claim create input object
-//   required: true
-//   schema:
-//     "$ref": "#/definitions/ClaimUpdateInput"
-// responses:
-//   '200':
-//     description: a Claim
-//     schema:
-//       "$ref": "#/definitions/Claim"
+//	parameters:
+//	- name: id
+//	  in: path
+//	  required: true
+//	  description: claim ID
+//	- name: claim input
+//	  in: body
+//	  description: claim create input object
+//	  required: true
+//	  schema:
+//	    "$ref": "#/definitions/ClaimUpdateInput"
+//	responses:
+//	  '200':
+//	    description: a Claim
+//	    schema:
+//	      "$ref": "#/definitions/Claim"
 func claimsUpdate(c buffalo.Context) error {
 	tx := models.Tx(c)
 	claim := getReferencedClaimFromCtx(c)
@@ -168,22 +168,22 @@ func claimsUpdate(c buffalo.Context) error {
 // create a new Claim on a policy
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: policy ID
-//   - name: claim input
-//     in: body
-//     description: claim create input object
-//     required: true
-//     schema:
-//       "$ref": "#/definitions/ClaimCreateInput"
-// responses:
-//   '200':
-//     description: the new Claim
-//     schema:
-//       "$ref": "#/definitions/Claim"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: policy ID
+//	  - name: claim input
+//	    in: body
+//	    description: claim create input object
+//	    required: true
+//	    schema:
+//	      "$ref": "#/definitions/ClaimCreateInput"
+//	responses:
+//	  '200':
+//	    description: the new Claim
+//	    schema:
+//	      "$ref": "#/definitions/Claim"
 func claimsCreate(c buffalo.Context) error {
 	policy := getReferencedPolicyFromCtx(c)
 
@@ -209,16 +209,16 @@ func claimsCreate(c buffalo.Context) error {
 //  "Receipt" to submit for payout approval.
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: claim ID
-// responses:
-//   '200':
-//     description: submitted Claim
-//     schema:
-//       "$ref": "#/definitions/Claim"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: claim ID
+//	responses:
+//	  '200':
+//	    description: submitted Claim
+//	    schema:
+//	      "$ref": "#/definitions/Claim"
 func claimsSubmit(c buffalo.Context) error {
 	tx := models.Tx(c)
 	claim := getReferencedClaimFromCtx(c)
@@ -239,14 +239,14 @@ func claimsSubmit(c buffalo.Context) error {
 //   approved, denied or paid.
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: claim ID
-// responses:
-//   '204':
-//     description: OK but no content in response
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: claim ID
+//	responses:
+//	  '204':
+//	    description: OK but no content in response
 func claimsRemove(c buffalo.Context) error {
 	claim := getReferencedClaimFromCtx(c)
 
@@ -264,22 +264,22 @@ func claimsRemove(c buffalo.Context) error {
 // Admin requests revisions on a claim.  Can be used at state "Review1", "Review2", or "Review3".
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: claim ID
-//   - name: claim revision input
-//     in: body
-//     description: claim request revision input object
-//     required: true
-//     schema:
-//       "$ref": "#/definitions/ClaimStatusInput"
-// responses:
-//   '200':
-//     description: Claim in focus
-//     schema:
-//       "$ref": "#/definitions/Claim"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: claim ID
+//	  - name: claim revision input
+//	    in: body
+//	    description: claim request revision input object
+//	    required: true
+//	    schema:
+//	      "$ref": "#/definitions/ClaimStatusInput"
+//	responses:
+//	  '200':
+//	    description: Claim in focus
+//	    schema:
+//	      "$ref": "#/definitions/Claim"
 func claimsRequestRevision(c buffalo.Context) error {
 	tx := models.Tx(c)
 	claim := getReferencedClaimFromCtx(c)
@@ -304,16 +304,16 @@ func claimsRequestRevision(c buffalo.Context) error {
 // Admin preapproves a claim and requests a receipt.  Can only be used at state "Review1".
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: claim ID
-// responses:
-//   '200':
-//     description: Claim in focus
-//     schema:
-//       "$ref": "#/definitions/Claim"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: claim ID
+//	responses:
+//	  '200':
+//	    description: Claim in focus
+//	    schema:
+//	      "$ref": "#/definitions/Claim"
 func claimsPreapprove(c buffalo.Context) error {
 	tx := models.Tx(c)
 	claim := getReferencedClaimFromCtx(c)
@@ -334,22 +334,22 @@ func claimsPreapprove(c buffalo.Context) error {
 // Can be used at state "Review2" or "Review3".
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: claim ID
-//   - name: claim receipt reason input
-//     in: body
-//     description: claim receipt reason input object
-//     required: true
-//     schema:
-//       "$ref": "#/definitions/ClaimStatusInput"
-// responses:
-//   '200':
-//     description: Claim in focus
-//     schema:
-//       "$ref": "#/definitions/Claim"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: claim ID
+//	  - name: claim receipt reason input
+//	    in: body
+//	    description: claim receipt reason input object
+//	    required: true
+//	    schema:
+//	      "$ref": "#/definitions/ClaimStatusInput"
+//	responses:
+//	  '200':
+//	    description: Claim in focus
+//	    schema:
+//	      "$ref": "#/definitions/Claim"
 func claimsRequestReceipt(c buffalo.Context) error {
 	tx := models.Tx(c)
 	claim := getReferencedClaimFromCtx(c)
@@ -374,16 +374,16 @@ func claimsRequestReceipt(c buffalo.Context) error {
 // Admin approves a claim.  Can be used at states "Review1","Review2","Review3".
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: claim ID
-// responses:
-//   '200':
-//     description: Claim in focus
-//     schema:
-//       "$ref": "#/definitions/Claim"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: claim ID
+//	responses:
+//	  '200':
+//	    description: Claim in focus
+//	    schema:
+//	      "$ref": "#/definitions/Claim"
 func claimsApprove(c buffalo.Context) error {
 	tx := models.Tx(c)
 
@@ -404,22 +404,22 @@ func claimsApprove(c buffalo.Context) error {
 // Admin denies a claim.  Can be used at states "Review1","Review2","Review3".
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: claim ID
-//   - name: claim deny input
-//     in: body
-//     description: claim deny input object
-//     required: true
-//     schema:
-//       "$ref": "#/definitions/ClaimStatusInput"
-// responses:
-//   '200':
-//     description: Claim in focus
-//     schema:
-//       "$ref": "#/definitions/Claim"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: claim ID
+//	  - name: claim deny input
+//	    in: body
+//	    description: claim deny input object
+//	    required: true
+//	    schema:
+//	      "$ref": "#/definitions/ClaimStatusInput"
+//	responses:
+//	  '200':
+//	    description: Claim in focus
+//	    schema:
+//	      "$ref": "#/definitions/Claim"
 func claimsDeny(c buffalo.Context) error {
 	tx := models.Tx(c)
 
@@ -445,22 +445,22 @@ func claimsDeny(c buffalo.Context) error {
 // create a new ClaimItem on a Claim
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: claim ID
-//   - name: claim item input
-//     in: body
-//     description: claim item create input object
-//     required: true
-//     schema:
-//       "$ref": "#/definitions/ClaimItemCreateInput"
-// responses:
-//   '200':
-//     description: the new ClaimItem
-//     schema:
-//       "$ref": "#/definitions/ClaimItem"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: claim ID
+//	  - name: claim item input
+//	    in: body
+//	    description: claim item create input object
+//	    required: true
+//	    schema:
+//	      "$ref": "#/definitions/ClaimItemCreateInput"
+//	responses:
+//	  '200':
+//	    description: the new ClaimItem
+//	    schema:
+//	      "$ref": "#/definitions/ClaimItem"
 func claimsItemsCreate(c buffalo.Context) error {
 	claim := getReferencedClaimFromCtx(c)
 

--- a/application/actions/claims.go
+++ b/application/actions/claims.go
@@ -20,6 +20,7 @@ import (
 // included by default. Accepted status values: Draft, Review1, Review2,
 // Review3, Revision, Receipt, Approved, Paid, Denied
 // ---
+//
 //	parameters:
 //	- name: status
 //	  in: query
@@ -74,6 +75,7 @@ func claimsListCustomer(c buffalo.Context) error {
 //
 // List claims for a given policy
 // ---
+//
 //	responses:
 //	  '200':
 //	    description: a list of Claims
@@ -96,6 +98,7 @@ func policiesClaimsList(c buffalo.Context) error {
 //
 // view a specific claim
 // ---
+//
 //	parameters:
 //	- name: id
 //	  in: path
@@ -117,6 +120,7 @@ func claimsView(c buffalo.Context) error {
 //
 // update a claim
 // ---
+//
 //	parameters:
 //	- name: id
 //	  in: path
@@ -158,6 +162,7 @@ func claimsUpdate(c buffalo.Context) error {
 //
 // create a new Claim on a policy
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -193,10 +198,12 @@ func claimsCreate(c buffalo.Context) error {
 
 // swagger:operation POST /claims/{id}/submit Claims ClaimsSubmit
 // ClaimsSubmit
-//
-// Submit a claim for review.  Can be used at state "Draft" to submit for pre-approval or
-//  "Receipt" to submit for payout approval.
 // ---
+//
+//	summary: ClaimsSubmit
+//	description: |-
+//	  Submit a claim for review.  Can be used at state "Draft" to submit for pre-approval or
+//	  "Receipt" to submit for payout approval.
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -222,9 +229,9 @@ func claimsSubmit(c buffalo.Context) error {
 // swagger:operation DELETE /claims/{id} Claims ClaimsRemove
 // ClaimsRemove
 //
-// Delete a claim and its claim items as long as it does not have a status of
-//   approved, denied or paid.
+// Delete a claim and its claim items as long as it does not have a status of approved, denied or paid.
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -248,6 +255,7 @@ func claimsRemove(c buffalo.Context) error {
 //
 // Admin requests revisions on a claim.  Can be used at state "Review1", "Review2", or "Review3".
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -286,6 +294,7 @@ func claimsRequestRevision(c buffalo.Context) error {
 //
 // Admin preapproves a claim and requests a receipt.  Can only be used at state "Review1".
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -314,6 +323,7 @@ func claimsPreapprove(c buffalo.Context) error {
 // Admin reverts a claim to request a new/better receipt.
 // Can be used at state "Review2" or "Review3".
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -352,6 +362,7 @@ func claimsRequestReceipt(c buffalo.Context) error {
 //
 // Admin approves a claim.  Can be used at states "Review1","Review2","Review3".
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -380,6 +391,7 @@ func claimsApprove(c buffalo.Context) error {
 //
 // Admin denies a claim.  Can be used at states "Review1","Review2","Review3".
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -419,6 +431,7 @@ func claimsDeny(c buffalo.Context) error {
 //
 // create a new ClaimItem on a Claim
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path

--- a/application/actions/claims.go
+++ b/application/actions/claims.go
@@ -12,7 +12,6 @@ import (
 )
 
 // swagger:operation GET /claims Claims ClaimsList
-//
 // ClaimsList
 //
 // List the claims visible to the authenticated user, filtered by the given
@@ -20,7 +19,6 @@ import (
 // For an admin (steward or signator) only the review status values are
 // included by default. Accepted status values: Draft, Review1, Review2,
 // Review3, Revision, Receipt, Approved, Paid, Denied
-//
 // ---
 //	parameters:
 //	- name: status
@@ -72,11 +70,9 @@ func claimsListCustomer(c buffalo.Context) error {
 }
 
 // swagger:operation GET /policies/{id}/claims Claims PolicyClaimsList
-//
 // PolicyClaimsList
 //
 // List claims for a given policy
-//
 // ---
 //	responses:
 //	  '200':
@@ -96,11 +92,9 @@ func policiesClaimsList(c buffalo.Context) error {
 }
 
 // swagger:operation GET /claims/{id} Claims ClaimsView
-//
 // ClaimsView
 //
 // view a specific claim
-//
 // ---
 //	parameters:
 //	- name: id
@@ -119,11 +113,9 @@ func claimsView(c buffalo.Context) error {
 }
 
 // swagger:operation PUT /claims/{id} Claims ClaimsUpdate
-//
 // ClaimsUpdate
 //
 // update a claim
-//
 // ---
 //	parameters:
 //	- name: id
@@ -162,11 +154,9 @@ func claimsUpdate(c buffalo.Context) error {
 }
 
 // swagger:operation POST /policies/{id}/claims Claims ClaimsCreate
-//
 // ClaimsCreate
 //
 // create a new Claim on a policy
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -202,12 +192,10 @@ func claimsCreate(c buffalo.Context) error {
 }
 
 // swagger:operation POST /claims/{id}/submit Claims ClaimsSubmit
-//
 // ClaimsSubmit
 //
 // Submit a claim for review.  Can be used at state "Draft" to submit for pre-approval or
 //  "Receipt" to submit for payout approval.
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -232,12 +220,10 @@ func claimsSubmit(c buffalo.Context) error {
 }
 
 // swagger:operation DELETE /claims/{id} Claims ClaimsRemove
-//
 // ClaimsRemove
 //
 // Delete a claim and its claim items as long as it does not have a status of
 //   approved, denied or paid.
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -258,11 +244,9 @@ func claimsRemove(c buffalo.Context) error {
 }
 
 // swagger:operation POST /claims/{id}/revision Claims ClaimsRequestRevision
-//
 // ClaimsRequestRevision
 //
 // Admin requests revisions on a claim.  Can be used at state "Review1", "Review2", or "Review3".
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -298,11 +282,9 @@ func claimsRequestRevision(c buffalo.Context) error {
 }
 
 // swagger:operation POST /claims/{id}/preapprove Claims ClaimsPreapprove
-//
 // ClaimsPreapprove
 //
 // Admin preapproves a claim and requests a receipt.  Can only be used at state "Review1".
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -327,12 +309,10 @@ func claimsPreapprove(c buffalo.Context) error {
 }
 
 // swagger:operation POST /claims/{id}/receipt Claims ClaimsFixReceipt
-//
 // ClaimsFixReceipt
 //
 // Admin reverts a claim to request a new/better receipt.
 // Can be used at state "Review2" or "Review3".
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -368,11 +348,9 @@ func claimsRequestReceipt(c buffalo.Context) error {
 }
 
 // swagger:operation POST /claims/{id}/approve Claims ClaimsApprove
-//
 // ClaimsApprove
 //
 // Admin approves a claim.  Can be used at states "Review1","Review2","Review3".
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -398,11 +376,9 @@ func claimsApprove(c buffalo.Context) error {
 }
 
 // swagger:operation POST /claims/{id}/deny Claims ClaimsDeny
-//
 // ClaimsDeny
 //
 // Admin denies a claim.  Can be used at states "Review1","Review2","Review3".
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -439,11 +415,9 @@ func claimsDeny(c buffalo.Context) error {
 }
 
 // swagger:operation POST /claims/{id}/items Claims ClaimsItemsCreate
-//
 // ClaimsItemsCreate
 //
 // create a new ClaimItem on a Claim
-//
 // ---
 //	parameters:
 //	  - name: id

--- a/application/actions/config.go
+++ b/application/actions/config.go
@@ -7,11 +7,9 @@ import (
 )
 
 // swagger:operation GET /config/claim-incident-types Config ClaimIncidentTypes
-//
 // ClaimIncidentTypes
 //
 // list all valid Claim Incident Types
-//
 // ---
 //	responses:
 //	  '200':
@@ -25,11 +23,9 @@ func claimIncidentTypes(c buffalo.Context) error {
 }
 
 // swagger:operation GET /config/countries Config Countries
-//
 // Countries
 //
 // list of countries
-//
 // ---
 //	responses:
 //	  '200':

--- a/application/actions/config.go
+++ b/application/actions/config.go
@@ -13,13 +13,13 @@ import (
 // list all valid Claim Incident Types
 //
 // ---
-// responses:
-//   '200':
-//     description: list of valid Claim Incident Types
-//     schema:
-//       type: array
-//       items:
-//         "$ref": "#/definitions/ClaimIncidentTypeStruct"
+//	responses:
+//	  '200':
+//	    description: list of valid Claim Incident Types
+//	    schema:
+//	      type: array
+//	      items:
+//	        "$ref": "#/definitions/ClaimIncidentTypeStruct"
 func claimIncidentTypes(c buffalo.Context) error {
 	return renderOk(c, api.AllClaimIncidentTypes)
 }
@@ -31,13 +31,13 @@ func claimIncidentTypes(c buffalo.Context) error {
 // list of countries
 //
 // ---
-// responses:
-//   '200':
-//     description: list of countries
-//     schema:
-//       type: array
-//       items:
-//         "$ref": "#/definitions/Country"
+//	responses:
+//	  '200':
+//	    description: list of countries
+//	    schema:
+//	      type: array
+//	      items:
+//	        "$ref": "#/definitions/Country"
 func countries(c buffalo.Context) error {
 	return renderOk(c, api.AllCountries)
 }

--- a/application/actions/config.go
+++ b/application/actions/config.go
@@ -11,6 +11,7 @@ import (
 //
 // list all valid Claim Incident Types
 // ---
+//
 //	responses:
 //	  '200':
 //	    description: list of valid Claim Incident Types
@@ -27,6 +28,7 @@ func claimIncidentTypes(c buffalo.Context) error {
 //
 // list of countries
 // ---
+//
 //	responses:
 //	  '200':
 //	    description: list of countries

--- a/application/actions/dependents.go
+++ b/application/actions/dependents.go
@@ -17,6 +17,7 @@ import (
 //
 // list policy dependents
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -43,6 +44,7 @@ func dependentsList(c buffalo.Context) error {
 //
 // create a new PolicyDependent on a policy
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -83,6 +85,7 @@ func dependentsCreate(c buffalo.Context) error {
 //
 // update a policy dependent
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -126,6 +129,7 @@ func dependentsUpdate(c buffalo.Context) error {
 //
 // Delete a policy dependent if it has no related policy items.
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path

--- a/application/actions/dependents.go
+++ b/application/actions/dependents.go
@@ -13,11 +13,9 @@ import (
 )
 
 // swagger:operation GET /policies/{id}/dependents PolicyDependents PolicyDependentsList
-//
 // PolicyDependentsList
 //
 // list policy dependents
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -41,11 +39,9 @@ func dependentsList(c buffalo.Context) error {
 }
 
 // swagger:operation POST /policies/{id}/dependents PolicyDependents PolicyDependentsCreate
-//
 // PolicyDependentsCreate
 //
 // create a new PolicyDependent on a policy
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -83,11 +79,9 @@ func dependentsCreate(c buffalo.Context) error {
 }
 
 // swagger:operation PUT /policy-dependents/{id} PolicyDependents PolicyDependentsUpdate
-//
 // PolicyDependentsUpdate
 //
 // update a policy dependent
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -128,11 +122,9 @@ func dependentsUpdate(c buffalo.Context) error {
 }
 
 // swagger:operation DELETE /policy-dependents/{id} PolicyDependents PolicyDependentsDelete
-//
 // PolicyDependentsDelete
 //
 // Delete a policy dependent if it has no related policy items.
-//
 // ---
 //	parameters:
 //	  - name: id

--- a/application/actions/dependents.go
+++ b/application/actions/dependents.go
@@ -19,18 +19,18 @@ import (
 // list policy dependents
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: policy ID
-// responses:
-//   '200':
-//     description: a list of PolicyDependents
-//     schema:
-//       type: array
-//       items:
-//         "$ref": "#/definitions/PolicyDependents"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: policy ID
+//	responses:
+//	  '200':
+//	    description: a list of PolicyDependents
+//	    schema:
+//	      type: array
+//	      items:
+//	        "$ref": "#/definitions/PolicyDependents"
 func dependentsList(c buffalo.Context) error {
 	policy := getReferencedPolicyFromCtx(c)
 
@@ -47,22 +47,22 @@ func dependentsList(c buffalo.Context) error {
 // create a new PolicyDependent on a policy
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: policy ID
-//   - name: policy dependent
-//     in: body
-//     description: policy dependent input object
-//     required: true
-//     schema:
-//       "$ref": "#/definitions/PolicyDependentInput"
-// responses:
-//   '200':
-//     description: the new PolicyDependent
-//     schema:
-//       "$ref": "#/definitions/PolicyDependent"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: policy ID
+//	  - name: policy dependent
+//	    in: body
+//	    description: policy dependent input object
+//	    required: true
+//	    schema:
+//	      "$ref": "#/definitions/PolicyDependentInput"
+//	responses:
+//	  '200':
+//	    description: the new PolicyDependent
+//	    schema:
+//	      "$ref": "#/definitions/PolicyDependent"
 func dependentsCreate(c buffalo.Context) error {
 	policy := getReferencedPolicyFromCtx(c)
 
@@ -89,22 +89,22 @@ func dependentsCreate(c buffalo.Context) error {
 // update a policy dependent
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: policy dependent ID
-//   - name: policy dependent update input
-//     in: body
-//     description: policy dependent input object
-//     required: true
-//     schema:
-//       "$ref": "#/definitions/PolicyDependentInput"
-// responses:
-//   '200':
-//     description: the updated PolicyDependent
-//     schema:
-//       "$ref": "#/definitions/PolicyDependent"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: policy dependent ID
+//	  - name: policy dependent update input
+//	    in: body
+//	    description: policy dependent input object
+//	    required: true
+//	    schema:
+//	      "$ref": "#/definitions/PolicyDependentInput"
+//	responses:
+//	  '200':
+//	    description: the updated PolicyDependent
+//	    schema:
+//	      "$ref": "#/definitions/PolicyDependent"
 func dependentsUpdate(c buffalo.Context) error {
 	tx := models.Tx(c)
 	dependent := getReferencedDependentFromCtx(c)
@@ -134,14 +134,14 @@ func dependentsUpdate(c buffalo.Context) error {
 // Delete a policy dependent if it has no related policy items.
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: policy dependent ID
-// responses:
-//   '204':
-//     description: OK but no content in response
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: policy dependent ID
+//	responses:
+//	  '204':
+//	    description: OK but no content in response
 func dependentsDelete(c buffalo.Context) error {
 	tx := models.Tx(c)
 	dependent := getReferencedDependentFromCtx(c)

--- a/application/actions/entitycodes.go
+++ b/application/actions/entitycodes.go
@@ -13,6 +13,7 @@ import (
 //
 // list Entity Codes
 // ---
+//
 //	responses:
 //	  '200':
 //	    description: list of Entity Codes
@@ -41,6 +42,7 @@ func entityCodesList(c buffalo.Context) error {
 //
 // get a single Entity Code
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -61,6 +63,7 @@ func entityCodesView(c buffalo.Context) error {
 //
 // update a Entity Code
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -94,6 +97,7 @@ func entityCodesUpdate(c buffalo.Context) error {
 //
 // create a new Entity Code
 // ---
+//
 //	parameters:
 //	  - name: entity code create input
 //	    in: body

--- a/application/actions/entitycodes.go
+++ b/application/actions/entitycodes.go
@@ -9,11 +9,9 @@ import (
 )
 
 // swagger:operation GET /entity-codes EntityCodes EntityCodesList
-//
 // EntityCodesList
 //
 // list Entity Codes
-//
 // ---
 //	responses:
 //	  '200':
@@ -39,11 +37,9 @@ func entityCodesList(c buffalo.Context) error {
 }
 
 // swagger:operation GET /entity-codes/{id} EntityCodes EntityCodesView
-//
 // EntityCodesView
 //
 // get a single Entity Code
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -61,11 +57,9 @@ func entityCodesView(c buffalo.Context) error {
 }
 
 // swagger:operation PUT /entity-codes/{id} EntityCodes EntityCodesUpdate
-//
 // EntityCodesUpdate
 //
 // update a Entity Code
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -96,11 +90,9 @@ func entityCodesUpdate(c buffalo.Context) error {
 }
 
 // swagger:operation POST /entity-codes EntityCodes EntityCodesCreate
-//
 // EntityCodesCreate
 //
 // create a new Entity Code
-//
 // ---
 //	parameters:
 //	  - name: entity code create input

--- a/application/actions/entitycodes.go
+++ b/application/actions/entitycodes.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"github.com/gobuffalo/buffalo"
+
 	"github.com/silinternational/cover-api/api"
 	"github.com/silinternational/cover-api/domain"
 	"github.com/silinternational/cover-api/models"
@@ -14,13 +15,13 @@ import (
 // list Entity Codes
 //
 // ---
-// responses:
-//   '200':
-//     description: list of Entity Codes
-//     schema:
-//       type: array
-//       items:
-//         "$ref": "#/definitions/EntityCode"
+//	responses:
+//	  '200':
+//	    description: list of Entity Codes
+//	    schema:
+//	      type: array
+//	      items:
+//	        "$ref": "#/definitions/EntityCode"
 func entityCodesList(c buffalo.Context) error {
 	tx := models.Tx(c)
 	actor := models.CurrentUser(c)
@@ -44,16 +45,16 @@ func entityCodesList(c buffalo.Context) error {
 // get a single Entity Code
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: entity code ID
-// responses:
-//  '200':
-//    description: an Entity Code record
-//    schema:
-//      "$ref": "#/definitions/EntityCode"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: entity code ID
+//	responses:
+//	 '200':
+//	   description: an Entity Code record
+//	   schema:
+//	     "$ref": "#/definitions/EntityCode"
 func entityCodesView(c buffalo.Context) error {
 	e := getReferencedEntityCodeFromCtx(c)
 	return renderEntityCode(c, *e)
@@ -66,22 +67,22 @@ func entityCodesView(c buffalo.Context) error {
 // update a Entity Code
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: entity code ID
-//   - name: entity code update input
-//     in: body
-//     description: entity code update input object
-//     required: true
-//     schema:
-//       "$ref": "#/definitions/EntityCodeInput"
-// responses:
-//  '200':
-//    description: an Entity Code record
-//    schema:
-//      "$ref": "#/definitions/EntityCode"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: entity code ID
+//	  - name: entity code update input
+//	    in: body
+//	    description: entity code update input object
+//	    required: true
+//	    schema:
+//	      "$ref": "#/definitions/EntityCodeInput"
+//	responses:
+//	 '200':
+//	   description: an Entity Code record
+//	   schema:
+//	     "$ref": "#/definitions/EntityCode"
 func entityCodesUpdate(c buffalo.Context) error {
 	e := getReferencedEntityCodeFromCtx(c)
 	var input api.EntityCodeInput
@@ -101,24 +102,24 @@ func entityCodesUpdate(c buffalo.Context) error {
 // create a new Entity Code
 //
 // ---
-// parameters:
-//   - name: entity code create input
-//     in: body
-//     description: entity code create input object
-//     required: true
-//     schema:
-//       "$ref": "#/definitions/EntityCodeCreateInput"
-// responses:
-//  '200':
-//    description: an Entity Code record
-//    schema:
-//      "$ref": "#/definitions/EntityCode"
+//	parameters:
+//	  - name: entity code create input
+//	    in: body
+//	    description: entity code create input object
+//	    required: true
+//	    schema:
+//	      "$ref": "#/definitions/EntityCodeCreateInput"
+//	responses:
+//	 '200':
+//	   description: an Entity Code record
+//	   schema:
+//	     "$ref": "#/definitions/EntityCode"
 func entityCodesCreate(c buffalo.Context) error {
 	var input api.EntityCodeCreateInput
 	if err := StrictBind(c, &input); err != nil {
 		return reportError(c, err)
 	}
-	
+
 	e := models.EntityCode{}
 	if err := e.CreateFromAPI(models.Tx(c), input); err != nil {
 		return err

--- a/application/actions/itemcategories.go
+++ b/application/actions/itemcategories.go
@@ -13,13 +13,13 @@ import (
 // list all the enabled item categories
 //
 // ---
-// responses:
-//   '200':
-//     description: a list of ItemCategories
-//     schema:
-//       type: array
-//       items:
-//         "$ref": "#/definitions/ItemCategory"
+//	responses:
+//	  '200':
+//	    description: a list of ItemCategories
+//	    schema:
+//	      type: array
+//	      items:
+//	        "$ref": "#/definitions/ItemCategory"
 func itemCategoriesList(c buffalo.Context) error {
 	tx := models.Tx(c)
 

--- a/application/actions/itemcategories.go
+++ b/application/actions/itemcategories.go
@@ -11,6 +11,7 @@ import (
 //
 // list all the enabled item categories
 // ---
+//
 //	responses:
 //	  '200':
 //	    description: a list of ItemCategories

--- a/application/actions/itemcategories.go
+++ b/application/actions/itemcategories.go
@@ -7,11 +7,9 @@ import (
 )
 
 // swagger:operation GET /config/item-categories Config ItemCategoriesList
-//
 // ItemCategoriesList
 //
 // list all the enabled item categories
-//
 // ---
 //	responses:
 //	  '200':

--- a/application/actions/items.go
+++ b/application/actions/items.go
@@ -15,6 +15,7 @@ import (
 //
 // gets the data for all the items on a Policy
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -42,6 +43,7 @@ func itemsList(c buffalo.Context) error {
 //
 // create a policy item
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -86,6 +88,7 @@ func itemsCreate(c buffalo.Context) error {
 //
 // update a policy item
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -149,6 +152,7 @@ func itemsUpdate(c buffalo.Context) error {
 //
 // submit a policy item for coverage
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -176,6 +180,7 @@ func itemsSubmit(c buffalo.Context) error {
 //
 // admin requires changes on a policy item
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -214,6 +219,7 @@ func itemsRevision(c buffalo.Context) error {
 //
 // approve coverage on a policy item
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -241,6 +247,7 @@ func itemsApprove(c buffalo.Context) error {
 //
 // deny coverage on a policy item
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -277,9 +284,9 @@ func itemsDeny(c buffalo.Context) error {
 // swagger:operation DELETE /items/{id} PolicyItems PolicyItemsRemove
 // PolicyItemsRemove
 //
-// Delete a policy item if it is less than 72 hours old and has no associations.
-//   Otherwise, inactivate coverage on it.
+// Delete a policy item if it is less than 72 hours old and has no associations. Otherwise, inactivate coverage on it.
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path

--- a/application/actions/items.go
+++ b/application/actions/items.go
@@ -17,18 +17,18 @@ import (
 // gets the data for all the items on a Policy
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: policy ID
-// responses:
-//   '200':
-//     description: all policy items
-//     schema:
-//       type: array
-//       items:
-//         "$ref": "#/definitions/Item"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: policy ID
+//	responses:
+//	  '200':
+//	    description: all policy items
+//	    schema:
+//	      type: array
+//	      items:
+//	        "$ref": "#/definitions/Item"
 func itemsList(c buffalo.Context) error {
 	tx := models.Tx(c)
 
@@ -46,22 +46,22 @@ func itemsList(c buffalo.Context) error {
 // create a policy item
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: policy ID
-//   - name: policy item create input
-//     in: body
-//     description: policy item create input object
-//     required: true
-//     schema:
-//       "$ref": "#/definitions/ItemCreate"
-// responses:
-//   '200':
-//     description: new Item
-//     schema:
-//       "$ref": "#/definitions/Item"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: policy ID
+//	  - name: policy item create input
+//	    in: body
+//	    description: policy item create input object
+//	    required: true
+//	    schema:
+//	      "$ref": "#/definitions/ItemCreate"
+//	responses:
+//	  '200':
+//	    description: new Item
+//	    schema:
+//	      "$ref": "#/definitions/Item"
 func itemsCreate(c buffalo.Context) error {
 	tx := models.Tx(c)
 	policy := getReferencedPolicyFromCtx(c)
@@ -92,22 +92,22 @@ func itemsCreate(c buffalo.Context) error {
 // update a policy item
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: item ID
-//   - name: policy item update input
-//     in: body
-//     description: policy item update object
-//     required: true
-//     schema:
-//       "$ref": "#/definitions/ItemUpdate"
-// responses:
-//   '200':
-//     description: updated Item
-//     schema:
-//       "$ref": "#/definitions/Item"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: item ID
+//	  - name: policy item update input
+//	    in: body
+//	    description: policy item update object
+//	    required: true
+//	    schema:
+//	      "$ref": "#/definitions/ItemUpdate"
+//	responses:
+//	  '200':
+//	    description: updated Item
+//	    schema:
+//	      "$ref": "#/definitions/Item"
 func itemsUpdate(c buffalo.Context) error {
 	tx := models.Tx(c)
 	item := getReferencedItemFromCtx(c)
@@ -157,16 +157,16 @@ func itemsUpdate(c buffalo.Context) error {
 // submit a policy item for coverage
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: item ID
-// responses:
-//   '200':
-//     description: submitted Item
-//     schema:
-//       "$ref": "#/definitions/Item"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: item ID
+//	responses:
+//	  '200':
+//	    description: submitted Item
+//	    schema:
+//	      "$ref": "#/definitions/Item"
 func itemsSubmit(c buffalo.Context) error {
 	tx := models.Tx(c)
 	item := getReferencedItemFromCtx(c)
@@ -186,22 +186,22 @@ func itemsSubmit(c buffalo.Context) error {
 // admin requires changes on a policy item
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: item ID
-//   - name: item revision input
-//     in: body
-//     description: item revision input object
-//     required: true
-//     schema:
-//       "$ref": "#/definitions/ItemStatusInput"
-// responses:
-//   '200':
-//     description: Policy Item
-//     schema:
-//       "$ref": "#/definitions/Item"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: item ID
+//	  - name: item revision input
+//	    in: body
+//	    description: item revision input object
+//	    required: true
+//	    schema:
+//	      "$ref": "#/definitions/ItemStatusInput"
+//	responses:
+//	  '200':
+//	    description: Policy Item
+//	    schema:
+//	      "$ref": "#/definitions/Item"
 func itemsRevision(c buffalo.Context) error {
 	tx := models.Tx(c)
 	item := getReferencedItemFromCtx(c)
@@ -226,16 +226,16 @@ func itemsRevision(c buffalo.Context) error {
 // approve coverage on a policy item
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: item ID
-// responses:
-//   '200':
-//     description: approved Item
-//     schema:
-//       "$ref": "#/definitions/Item"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: item ID
+//	responses:
+//	  '200':
+//	    description: approved Item
+//	    schema:
+//	      "$ref": "#/definitions/Item"
 func itemsApprove(c buffalo.Context) error {
 	tx := models.Tx(c)
 	item := getReferencedItemFromCtx(c)
@@ -255,22 +255,22 @@ func itemsApprove(c buffalo.Context) error {
 // deny coverage on a policy item
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: item ID
-//   - name: item denial input
-//     in: body
-//     description: item denial input object
-//     required: true
-//     schema:
-//       "$ref": "#/definitions/ItemStatusInput"
-// responses:
-//   '200':
-//     description: denied Item
-//     schema:
-//       "$ref": "#/definitions/Item"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: item ID
+//	  - name: item denial input
+//	    in: body
+//	    description: item denial input object
+//	    required: true
+//	    schema:
+//	      "$ref": "#/definitions/ItemStatusInput"
+//	responses:
+//	  '200':
+//	    description: denied Item
+//	    schema:
+//	      "$ref": "#/definitions/Item"
 func itemsDeny(c buffalo.Context) error {
 	tx := models.Tx(c)
 	item := getReferencedItemFromCtx(c)
@@ -296,14 +296,14 @@ func itemsDeny(c buffalo.Context) error {
 //   Otherwise, inactivate coverage on it.
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: item ID
-// responses:
-//   '204':
-//     description: OK but no content in response
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: item ID
+//	responses:
+//	  '204':
+//	    description: OK but no content in response
 func itemsRemove(c buffalo.Context) error {
 	item := getReferencedItemFromCtx(c)
 

--- a/application/actions/items.go
+++ b/application/actions/items.go
@@ -11,11 +11,9 @@ import (
 )
 
 // swagger:operation GET /policies/{id}/items PolicyItems PolicyItemsList
-//
 // PolicyItemsList
 //
 // gets the data for all the items on a Policy
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -40,11 +38,9 @@ func itemsList(c buffalo.Context) error {
 }
 
 // swagger:operation POST /policies/{id}/items PolicyItems PolicyItemsCreate
-//
 // PolicyItemsCreate
 //
 // create a policy item
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -86,11 +82,9 @@ func itemsCreate(c buffalo.Context) error {
 }
 
 // swagger:operation PUT /items/{id} PolicyItems PolicyItemsUpdate
-//
 // PolicyItemsUpdate
 //
 // update a policy item
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -151,11 +145,9 @@ func itemsUpdate(c buffalo.Context) error {
 }
 
 // swagger:operation POST /items/{id}/submit PolicyItems PolicyItemsSubmit
-//
 // PolicyItemsSubmit
 //
 // submit a policy item for coverage
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -180,11 +172,9 @@ func itemsSubmit(c buffalo.Context) error {
 }
 
 // swagger:operation POST /items/{id}/revision PolicyItems PolicyItemsRevision
-//
 // PolicyItemsRevision
 //
 // admin requires changes on a policy item
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -220,11 +210,9 @@ func itemsRevision(c buffalo.Context) error {
 }
 
 // swagger:operation POST /items/{id}/approve PolicyItems PolicyItemsApprove
-//
 // PolicyItemsApprove
 //
 // approve coverage on a policy item
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -249,11 +237,9 @@ func itemsApprove(c buffalo.Context) error {
 }
 
 // swagger:operation POST /items/{id}/deny PolicyItems PolicyItemsDeny
-//
 // PolicyItemsDeny
 //
 // deny coverage on a policy item
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -289,12 +275,10 @@ func itemsDeny(c buffalo.Context) error {
 }
 
 // swagger:operation DELETE /items/{id} PolicyItems PolicyItemsRemove
-//
 // PolicyItemsRemove
 //
 // Delete a policy item if it is less than 72 hours old and has no associations.
 //   Otherwise, inactivate coverage on it.
-//
 // ---
 //	parameters:
 //	  - name: id

--- a/application/actions/ledger.go
+++ b/application/actions/ledger.go
@@ -16,11 +16,9 @@ import (
 )
 
 // swagger:operation GET /ledger-reports LedgerReport LedgerReportList
-//
 // LedgerReportList
 //
 // Return a list of ledger reports that are not associated with a policy
-//
 // ---
 //	responses:
 //	  '200':
@@ -41,12 +39,10 @@ func ledgerReportList(c buffalo.Context) error {
 }
 
 // swagger:operation GET /ledger-reports/{id} LedgerReport LedgerReportView
-//
 // LedgerReportView
 //
 // Return the ledger report specified by `id`. The returned object contains metadata and a File object pointing to
 // a CSV file suitable for use with Sage Accounting.
-//
 // ---
 //	parameters:
 //	- name: id
@@ -66,7 +62,6 @@ func ledgerReportView(c buffalo.Context) error {
 }
 
 // swagger:operation POST /ledger-reports LedgerReport LedgerReportCreate
-//
 // LedgerReportCreate
 //
 // Create and return a report on the ledger entries as specified by the input object. The returned object
@@ -75,7 +70,6 @@ func ledgerReportView(c buffalo.Context) error {
 // ### Report types:
 // + `monthly` - Return all ledger entries not yet reconciled, up to the beginning of the given day (0:00 UTC).
 // + `annual` - Return the billing detail for given year's policy renewals.
-//
 // ---
 //	parameters:
 //	  - name: input
@@ -122,12 +116,10 @@ func ledgerReportCreate(c buffalo.Context) error {
 }
 
 // swagger:operation PUT /ledger-reports/{id} LedgerReport LedgerReportReconcile
-//
 // LedgerReportReconcile
 //
 // Mark ledger entries in the report reconciled as of today. Call this only after all transactions in the report
 // have been fully loaded into the accounting record.
-//
 // ---
 //	parameters:
 //	- name: id
@@ -151,11 +143,9 @@ func ledgerReportReconcile(c buffalo.Context) error {
 }
 
 // swagger:operation POST /ledger-reports/annual Ledger LedgerAnnualProcess
-//
 // LedgerAnnualProcess
 //
 // Process billing for current year's policy renewals.
-//
 // ---
 //	responses:
 //	  '204':
@@ -175,11 +165,9 @@ func ledgerAnnualRenewalProcess(c buffalo.Context) error {
 }
 
 // swagger:operation GET /ledger-reports/annual Ledger LedgerAnnualRenewalStatus
-//
 // LedgerAnnualRenewalStatus
 //
 // Get the status of the annual billing process.
-//
 // ---
 //	responses:
 //	  '200':

--- a/application/actions/ledger.go
+++ b/application/actions/ledger.go
@@ -20,6 +20,7 @@ import (
 //
 // Return a list of ledger reports that are not associated with a policy
 // ---
+//
 //	responses:
 //	  '200':
 //	    description: LedgerReport list
@@ -44,6 +45,7 @@ func ledgerReportList(c buffalo.Context) error {
 // Return the ledger report specified by `id`. The returned object contains metadata and a File object pointing to
 // a CSV file suitable for use with Sage Accounting.
 // ---
+//
 //	parameters:
 //	- name: id
 //	  in: path
@@ -71,6 +73,7 @@ func ledgerReportView(c buffalo.Context) error {
 // + `monthly` - Return all ledger entries not yet reconciled, up to the beginning of the given day (0:00 UTC).
 // + `annual` - Return the billing detail for given year's policy renewals.
 // ---
+//
 //	parameters:
 //	  - name: input
 //	    in: body
@@ -121,6 +124,7 @@ func ledgerReportCreate(c buffalo.Context) error {
 // Mark ledger entries in the report reconciled as of today. Call this only after all transactions in the report
 // have been fully loaded into the accounting record.
 // ---
+//
 //	parameters:
 //	- name: id
 //	  in: path
@@ -147,6 +151,7 @@ func ledgerReportReconcile(c buffalo.Context) error {
 //
 // Process billing for current year's policy renewals.
 // ---
+//
 //	responses:
 //	  '204':
 //	    description: OK but no content in response
@@ -169,6 +174,7 @@ func ledgerAnnualRenewalProcess(c buffalo.Context) error {
 //
 // Get the status of the annual billing process.
 // ---
+//
 //	responses:
 //	  '200':
 //	    description: the status of the annual billing process

--- a/application/actions/ledger.go
+++ b/application/actions/ledger.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/gobuffalo/buffalo"
+
 	"github.com/silinternational/cover-api/fin"
 	"github.com/silinternational/cover-api/job"
 
@@ -21,13 +22,13 @@ import (
 // Return a list of ledger reports that are not associated with a policy
 //
 // ---
-// responses:
-//   '200':
-//     description: LedgerReport list
-//     schema:
-//       type: array
-//       items:
-//         "$ref": "#/definitions/LedgerReport"
+//	responses:
+//	  '200':
+//	    description: LedgerReport list
+//	    schema:
+//	      type: array
+//	      items:
+//	        "$ref": "#/definitions/LedgerReport"
 func ledgerReportList(c buffalo.Context) error {
 	var list models.LedgerReports
 
@@ -47,16 +48,16 @@ func ledgerReportList(c buffalo.Context) error {
 // a CSV file suitable for use with Sage Accounting.
 //
 // ---
-// parameters:
-// - name: id
-//   in: path
-//   required: true
-//   description: specifies the ID of the report to view
-// responses:
-//   '200':
-//     description: the requested LedgerReport
-//     schema:
-//       "$ref": "#/definitions/LedgerReport"
+//	parameters:
+//	- name: id
+//	  in: path
+//	  required: true
+//	  description: specifies the ID of the report to view
+//	responses:
+//	  '200':
+//	    description: the requested LedgerReport
+//	    schema:
+//	      "$ref": "#/definitions/LedgerReport"
 func ledgerReportView(c buffalo.Context) error {
 	tx := models.Tx(c)
 
@@ -76,18 +77,18 @@ func ledgerReportView(c buffalo.Context) error {
 // + `annual` - Return the billing detail for given year's policy renewals.
 //
 // ---
-// parameters:
-//   - name: input
-//     in: body
-//     description: LedgerReportCreateInput object
-//     required: true
-//     schema:
-//       "$ref": "#/definitions/LedgerReportCreateInput"
-// responses:
-//   '200':
-//     description: the requested LedgerReport
-//     schema:
-//       "$ref": "#/definitions/LedgerReport"
+//	parameters:
+//	  - name: input
+//	    in: body
+//	    description: LedgerReportCreateInput object
+//	    required: true
+//	    schema:
+//	      "$ref": "#/definitions/LedgerReportCreateInput"
+//	responses:
+//	  '200':
+//	    description: the requested LedgerReport
+//	    schema:
+//	      "$ref": "#/definitions/LedgerReport"
 func ledgerReportCreate(c buffalo.Context) error {
 	var input api.LedgerReportCreateInput
 	if err := StrictBind(c, &input); err != nil {
@@ -128,16 +129,16 @@ func ledgerReportCreate(c buffalo.Context) error {
 // have been fully loaded into the accounting record.
 //
 // ---
-// parameters:
-// - name: id
-//   in: path
-//   required: true
-//   description: specifies the ID of the report to reconcile
-// responses:
-//   '200':
-//     description: the requested LedgerReport
-//     schema:
-//       "$ref": "#/definitions/LedgerReport"
+//	parameters:
+//	- name: id
+//	  in: path
+//	  required: true
+//	  description: specifies the ID of the report to reconcile
+//	responses:
+//	  '200':
+//	    description: the requested LedgerReport
+//	    schema:
+//	      "$ref": "#/definitions/LedgerReport"
 func ledgerReportReconcile(c buffalo.Context) error {
 	tx := models.Tx(c)
 
@@ -156,9 +157,9 @@ func ledgerReportReconcile(c buffalo.Context) error {
 // Process billing for current year's policy renewals.
 //
 // ---
-// responses:
-//   '204':
-//     description: OK but no content in response
+//	responses:
+//	  '204':
+//	    description: OK but no content in response
 func ledgerAnnualRenewalProcess(c buffalo.Context) error {
 	actor := models.CurrentUser(c)
 	if !actor.IsAdmin() {
@@ -180,11 +181,11 @@ func ledgerAnnualRenewalProcess(c buffalo.Context) error {
 // Get the status of the annual billing process.
 //
 // ---
-// responses:
-//   '200':
-//     description: the status of the annual billing process
-//     schema:
-//       "$ref": "#/definitions/AnnualRenewalStatus"
+//	responses:
+//	  '200':
+//	    description: the status of the annual billing process
+//	    schema:
+//	      "$ref": "#/definitions/AnnualRenewalStatus"
 func ledgerAnnualRenewalStatus(c buffalo.Context) error {
 	actor := models.CurrentUser(c)
 	if !actor.IsAdmin() {

--- a/application/actions/policies.go
+++ b/application/actions/policies.go
@@ -30,29 +30,29 @@ const (
 // in the system, limited by query parameters.
 //
 // ---
-// parameters:
-// - name: limit
-//   in: query
-//   required: false
-//   description: number of records to return, minimum 1, maximum 50, default 10
-// - name: search
-//   in: query
-//   required: false
-//   description: search text to find across fields (name, household_id, cost_center, and all members' first and last names)
-// - name: filter
-//   in: query
-//   required: false
-//   description: comma-separated list of search pairs like "field:text". Presently, only meta-field 'active' is supported
-// responses:
-//   '200':
-//     description: all policies
-//     schema:
-//       type: object
-//       properties:
-//         meta:
-//           "$ref": "#/definitions/Meta"
-//         data:
-//           "$ref": "#/definitions/Policies"
+//	parameters:
+//	- name: limit
+//	  in: query
+//	  required: false
+//	  description: number of records to return, minimum 1, maximum 50, default 10
+//	- name: search
+//	  in: query
+//	  required: false
+//	  description: search text to find across fields (name, household_id, cost_center, and all members' first and last names)
+//	- name: filter
+//	  in: query
+//	  required: false
+//	  description: comma-separated list of search pairs like "field:text". Presently, only meta-field 'active' is supported
+//	responses:
+//	  '200':
+//	    description: all policies
+//	    schema:
+//	      type: object
+//	      properties:
+//	        meta:
+//	          "$ref": "#/definitions/Meta"
+//	        data:
+//	          "$ref": "#/definitions/Policies"
 func policiesList(c buffalo.Context) error {
 	user := models.CurrentUser(c)
 
@@ -101,11 +101,11 @@ func policiesListCustomer(c buffalo.Context) error {
 // gets the data for a specific policy
 //
 // ---
-// responses:
-//   '200':
-//     description: a policy
-//     schema:
-//       "$ref": "#/definitions/Policy"
+//	responses:
+//	  '200':
+//	    description: a policy
+//	    schema:
+//	      "$ref": "#/definitions/Policy"
 func policiesView(c buffalo.Context) error {
 	policy := getReferencedPolicyFromCtx(c)
 
@@ -119,18 +119,18 @@ func policiesView(c buffalo.Context) error {
 // create a new Policy with type Team
 //
 // ---
-// parameters:
-//   - name: policy input
-//     in: body
-//     description: policy create input object
-//     required: true
-//     schema:
-//       "$ref": "#/definitions/PolicyCreate"
-// responses:
-//   '200':
-//     description: the new Policy
-//     schema:
-//       "$ref": "#/definitions/Policy"
+//	parameters:
+//	  - name: policy input
+//	    in: body
+//	    description: policy create input object
+//	    required: true
+//	    schema:
+//	      "$ref": "#/definitions/PolicyCreate"
+//	responses:
+//	  '200':
+//	    description: the new Policy
+//	    schema:
+//	      "$ref": "#/definitions/Policy"
 func policiesCreateTeam(c buffalo.Context) error {
 	var input api.PolicyCreate
 	if err := StrictBind(c, &input); err != nil {
@@ -161,22 +161,22 @@ func policiesCreateTeam(c buffalo.Context) error {
 // update a policy
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: policy ID
-//   - name: policy update input
-//     in: body
-//     description: policy update input object
-//     required: true
-//     schema:
-//       "$ref": "#/definitions/PolicyUpdate"
-// responses:
-//   '200':
-//     description: updated Policy
-//     schema:
-//       "$ref": "#/definitions/Policy"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: policy ID
+//	  - name: policy update input
+//	    in: body
+//	    description: policy update input object
+//	    required: true
+//	    schema:
+//	      "$ref": "#/definitions/PolicyUpdate"
+//	responses:
+//	  '200':
+//	    description: updated Policy
+//	    schema:
+//	      "$ref": "#/definitions/Policy"
 func policiesUpdate(c buffalo.Context) error {
 	tx := models.Tx(c)
 	policy := getReferencedPolicyFromCtx(c)
@@ -222,24 +222,24 @@ func policiesUpdate(c buffalo.Context) error {
 //  Type, Year and (if applicable) Month, then a 204 is returned.
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: policy ID
-//   - name: input
-//     in: body
-//     description: PolicyLedgerReportCreateInput object
-//     required: true
-//     schema:
-//       "$ref": "#/definitions/PolicyLedgerReportCreateInput"
-// responses:
-//   '200':
-//     description: the requested LedgerReport for the Policy
-//     schema:
-//       type: array
-//       items:
-//         "$ref": "#/definitions/LedgerReport"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: policy ID
+//	  - name: input
+//	    in: body
+//	    description: PolicyLedgerReportCreateInput object
+//	    required: true
+//	    schema:
+//	      "$ref": "#/definitions/PolicyLedgerReportCreateInput"
+//	responses:
+//	  '200':
+//	    description: the requested LedgerReport for the Policy
+//	    schema:
+//	      type: array
+//	      items:
+//	        "$ref": "#/definitions/LedgerReport"
 func policiesLedgerReportCreate(c buffalo.Context) error {
 	tx := models.Tx(c)
 	policy := getReferencedPolicyFromCtx(c)
@@ -274,24 +274,24 @@ func policiesLedgerReportCreate(c buffalo.Context) error {
 //  Year and Month, then a 204 is returned.
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: policy ID
-//   - name: month
-//     in: query
-//     required: true
-//     description: the month (number) within which the ledger entries were entered into the accounting system
-//   - name: year
-//     in: query
-//     required: true
-//     description: the year within which the ledger entries were entered into the accounting system
-// responses:
-//   '200':
-//     description: the requested LedgerTable for the Policy
-//     schema:
-//       "$ref": "#/definitions/LedgerTable"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: policy ID
+//	  - name: month
+//	    in: query
+//	    required: true
+//	    description: the month (number) within which the ledger entries were entered into the accounting system
+//	  - name: year
+//	    in: query
+//	    required: true
+//	    description: the year within which the ledger entries were entered into the accounting system
+//	responses:
+//	  '200':
+//	    description: the requested LedgerTable for the Policy
+//	    schema:
+//	      "$ref": "#/definitions/LedgerTable"
 func policiesLedgerTableView(c buffalo.Context) error {
 	policy := getReferencedPolicyFromCtx(c)
 
@@ -332,24 +332,24 @@ func policiesLedgerTableView(c buffalo.Context) error {
 // Create a strike on the policy and return its recent strikes
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: policy ID
-//   - name: input
-//     in: body
-//     description: StrikeInput object
-//     required: true
-//     schema:
-//       "$ref": "#/definitions/StrikeInput"
-// responses:
-//   '200':
-//     description: the Strikes for the Policy that are still in force
-//     schema:
-//       type: array
-//       items:
-//         "$ref": "#/definitions/Strike"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: policy ID
+//	  - name: input
+//	    in: body
+//	    description: StrikeInput object
+//	    required: true
+//	    schema:
+//	      "$ref": "#/definitions/StrikeInput"
+//	responses:
+//	  '200':
+//	    description: the Strikes for the Policy that are still in force
+//	    schema:
+//	      type: array
+//	      items:
+//	        "$ref": "#/definitions/Strike"
 func policiesStrikeCreate(c buffalo.Context) error {
 	tx := models.Tx(c)
 	policy := getReferencedPolicyFromCtx(c)

--- a/application/actions/policies.go
+++ b/application/actions/policies.go
@@ -23,12 +23,10 @@ const (
 )
 
 // swagger:operation GET /policies Policies PoliciesList
-//
 // PoliciesList
 //
 // Get the data for all the user's Policies if the user is not an admin. If called by an admin, returns all Policies
 // in the system, limited by query parameters.
-//
 // ---
 //	parameters:
 //	- name: limit
@@ -95,11 +93,9 @@ func policiesListCustomer(c buffalo.Context) error {
 }
 
 // swagger:operation GET /policies/{id} Policies PoliciesView
-//
 // PoliciesView
 //
 // gets the data for a specific policy
-//
 // ---
 //	responses:
 //	  '200':
@@ -113,11 +109,9 @@ func policiesView(c buffalo.Context) error {
 }
 
 // swagger:operation POST /policies Policies PoliciesCreateTeam
-//
 // PoliciesCreateTeam
 //
 // create a new Policy with type Team
-//
 // ---
 //	parameters:
 //	  - name: policy input
@@ -155,11 +149,9 @@ func policiesCreateTeam(c buffalo.Context) error {
 }
 
 // swagger:operation PUT /policies/{id} Policies PoliciesUpdate
-//
 // PoliciesUpdate
 //
 // update a policy
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -213,14 +205,12 @@ func policiesUpdate(c buffalo.Context) error {
 }
 
 // swagger:operation POST /policies/{id}/ledger-reports PolicyLedgerReport PolicyLedgerReportCreate
-//
 // PolicyLedgerReportCreate
 //
 // Create and return a report on the ledger entries of a policy as specified by the input object.
 // The returned object contains metadata and a File object pointing to a CSV file.
 // If no ledger entries are found with a `date_entered` value that matches the requested
 //  Type, Year and (if applicable) Month, then a 204 is returned.
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -266,13 +256,11 @@ func policiesLedgerReportCreate(c buffalo.Context) error {
 }
 
 // swagger:operation GET /policies/{id}/ledger-reports PolicyLedgerReport PolicyLedgerTableView
-//
 // PolicyLedgerTableView
 //
 // Return data regarding the ledger entries of a policy for a particular month.
 // If no ledger entries are found with a `date_entered` value that matches the requested
 //  Year and Month, then a 204 is returned.
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -326,11 +314,9 @@ func policiesLedgerTableView(c buffalo.Context) error {
 }
 
 // swagger:operation POST /policies/{id}/strikes PolicyStrike PolicyStrikeCreate
-//
 // PolicyStrikeCreate
 //
 // Create a strike on the policy and return its recent strikes
-//
 // ---
 //	parameters:
 //	  - name: id

--- a/application/actions/policies.go
+++ b/application/actions/policies.go
@@ -28,6 +28,7 @@ const (
 // Get the data for all the user's Policies if the user is not an admin. If called by an admin, returns all Policies
 // in the system, limited by query parameters.
 // ---
+//
 //	parameters:
 //	- name: limit
 //	  in: query
@@ -97,6 +98,7 @@ func policiesListCustomer(c buffalo.Context) error {
 //
 // gets the data for a specific policy
 // ---
+//
 //	responses:
 //	  '200':
 //	    description: a policy
@@ -113,6 +115,7 @@ func policiesView(c buffalo.Context) error {
 //
 // create a new Policy with type Team
 // ---
+//
 //	parameters:
 //	  - name: policy input
 //	    in: body
@@ -153,6 +156,7 @@ func policiesCreateTeam(c buffalo.Context) error {
 //
 // update a policy
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -210,8 +214,9 @@ func policiesUpdate(c buffalo.Context) error {
 // Create and return a report on the ledger entries of a policy as specified by the input object.
 // The returned object contains metadata and a File object pointing to a CSV file.
 // If no ledger entries are found with a `date_entered` value that matches the requested
-//  Type, Year and (if applicable) Month, then a 204 is returned.
+// Type, Year and (if applicable) Month, then a 204 is returned.
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -260,8 +265,9 @@ func policiesLedgerReportCreate(c buffalo.Context) error {
 //
 // Return data regarding the ledger entries of a policy for a particular month.
 // If no ledger entries are found with a `date_entered` value that matches the requested
-//  Year and Month, then a 204 is returned.
+// Year and Month, then a 204 is returned.
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -318,6 +324,7 @@ func policiesLedgerTableView(c buffalo.Context) error {
 //
 // Create a strike on the policy and return its recent strikes
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path

--- a/application/actions/policymembers.go
+++ b/application/actions/policymembers.go
@@ -17,18 +17,18 @@ import (
 // gets the data for all the members of a Policy
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: policy ID
-// responses:
-//   '200':
-//     description: all policy members
-//     schema:
-//       type: array
-//       items:
-//         "$ref": "#/definitions/PolicyMember"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: policy ID
+//	responses:
+//	  '200':
+//	    description: all policy members
+//	    schema:
+//	      type: array
+//	      items:
+//	        "$ref": "#/definitions/PolicyMember"
 func policiesListMembers(c buffalo.Context) error {
 	tx := models.Tx(c)
 	policy := getReferencedPolicyFromCtx(c)
@@ -45,21 +45,21 @@ func policiesListMembers(c buffalo.Context) error {
 // invite new user to co-manage policy
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: policy ID
-//   - name: policy member invite input
-//     in: body
-//     description: policy user invite input object
-//     required: true
-//     schema:
-//       "$ref": "#/definitions/PolicyUserInviteCreate"
-// responses:
-//   '204':
-//     description: success, no content
-//   '400':
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: policy ID
+//	  - name: policy member invite input
+//	    in: body
+//	    description: policy user invite input object
+//	    required: true
+//	    schema:
+//	      "$ref": "#/definitions/PolicyUserInviteCreate"
+//	responses:
+//	  '204':
+//	    description: success, no content
+//	  '400':
 //	   description: bad request, check the error and fix your code
 func policiesInviteMember(c buffalo.Context) error {
 	tx := models.Tx(c)
@@ -102,14 +102,14 @@ func policiesInviteMember(c buffalo.Context) error {
 //   null out the PolicyUserID on related items
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: policy-member ID
-// responses:
-//   '204':
-//     description: OK but no content in response
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: policy-member ID
+//	responses:
+//	  '204':
+//	    description: OK but no content in response
 func policiesMembersDelete(c buffalo.Context) error {
 	policyUser := getReferencedPolicyMemberFromCtx(c)
 

--- a/application/actions/policymembers.go
+++ b/application/actions/policymembers.go
@@ -15,6 +15,7 @@ import (
 //
 // gets the data for all the members of a Policy
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -41,6 +42,7 @@ func policiesListMembers(c buffalo.Context) error {
 //
 // invite new user to co-manage policy
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -94,8 +96,9 @@ func policiesInviteMember(c buffalo.Context) error {
 // PolicyMembersDelete
 //
 // Delete a policy user as long as the related policy has another user. Also,
-//   null out the PolicyUserID on related items
+// null out the PolicyUserID on related items
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path

--- a/application/actions/policymembers.go
+++ b/application/actions/policymembers.go
@@ -11,11 +11,9 @@ import (
 )
 
 // swagger:operation GET /policies/{id}/members PolicyMembers PolicyMembersList
-//
 // PolicyMembersList
 //
 // gets the data for all the members of a Policy
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -39,11 +37,9 @@ func policiesListMembers(c buffalo.Context) error {
 }
 
 // swagger:operation POST /policies/{id}/members PolicyMembers PolicyMembersInvite
-//
 // PolicyMembersInvite
 //
 // invite new user to co-manage policy
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -95,12 +91,10 @@ func policiesInviteMember(c buffalo.Context) error {
 }
 
 // swagger:operation DELETE /policy-members/{id} PolicyMembers PolicyMembersDelete
-//
 // PolicyMembersDelete
 //
 // Delete a policy user as long as the related policy has another user. Also,
 //   null out the PolicyUserID on related items
-//
 // ---
 //	parameters:
 //	  - name: id

--- a/application/actions/repairs.go
+++ b/application/actions/repairs.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/gobuffalo/buffalo"
+
 	"github.com/silinternational/cover-api/api"
 	"github.com/silinternational/cover-api/domain"
 	"github.com/silinternational/cover-api/models"
@@ -21,18 +22,18 @@ import (
 // + `renewal` - Repair all items that were incorrectly renewed and billed for another year of coverage. Also issues premium refunds for the incorrect renewal charges.
 //
 // ---
-// parameters:
-//   - name: input
-//     in: body
-//     description: parameters for the Repair Run
-//     required: true
-//     schema:
-//       "$ref": "#/definitions/RepairRunInput"
-// responses:
-//   '200':
-//     description: the repair result
-//     schema:
-//       "$ref": "#/definitions/RepairResult"
+//	parameters:
+//	  - name: input
+//	    in: body
+//	    description: parameters for the Repair Run
+//	    required: true
+//	    schema:
+//	      "$ref": "#/definitions/RepairRunInput"
+//	responses:
+//	  '200':
+//	    description: the repair result
+//	    schema:
+//	      "$ref": "#/definitions/RepairResult"
 func repairsRun(c buffalo.Context) error {
 	actor := models.CurrentUser(c)
 	if !actor.IsAdmin() {

--- a/application/actions/repairs.go
+++ b/application/actions/repairs.go
@@ -13,14 +13,12 @@ import (
 )
 
 // swagger:operation POST /repairs Repairs RepairsRun
-//
 // RepairsRun
 //
 // Run a repair
 //
 // ### Repair types:
 // + `renewal` - Repair all items that were incorrectly renewed and billed for another year of coverage. Also issues premium refunds for the incorrect renewal charges.
-//
 // ---
 //	parameters:
 //	  - name: input

--- a/application/actions/repairs.go
+++ b/application/actions/repairs.go
@@ -13,13 +13,14 @@ import (
 )
 
 // swagger:operation POST /repairs Repairs RepairsRun
-// RepairsRun
-//
-// Run a repair
-//
-// ### Repair types:
-// + `renewal` - Repair all items that were incorrectly renewed and billed for another year of coverage. Also issues premium refunds for the incorrect renewal charges.
 // ---
+//
+//	summary: RepairsRun
+//	description: |-
+//	  Run a repair
+//
+//	  ### Repair types:
+//	  + `renewal` - Repair all items that were incorrectly renewed and billed for another year of coverage. Also issues premium refunds for the incorrect renewal charges.
 //	parameters:
 //	  - name: input
 //	    in: body

--- a/application/actions/status.go
+++ b/application/actions/status.go
@@ -7,11 +7,9 @@ import (
 )
 
 // swagger:operation GET /status Status Status
-//
 // Status
 //
 // checks the app status
-//
 // ---
 //	responses:
 //	  '204':

--- a/application/actions/status.go
+++ b/application/actions/status.go
@@ -13,9 +13,9 @@ import (
 // checks the app status
 //
 // ---
-// responses:
-//   '204':
-//     description: app status is good
+//	responses:
+//	  '204':
+//	    description: app status is good
 func statusHandler(c buffalo.Context) error {
 	return c.Render(http.StatusNoContent, nil)
 }

--- a/application/actions/status.go
+++ b/application/actions/status.go
@@ -11,6 +11,7 @@ import (
 //
 // checks the app status
 // ---
+//
 //	responses:
 //	  '204':
 //	    description: app status is good

--- a/application/actions/steward.go
+++ b/application/actions/steward.go
@@ -14,6 +14,7 @@ import (
 //
 // gets Items and Claims that have recently had their coverage_status/status changed
 // ---
+//
 //	responses:
 //	  '200':
 //	    description: a list of Items and a list of Claims which each have the time when their status was last changed.

--- a/application/actions/steward.go
+++ b/application/actions/steward.go
@@ -16,11 +16,11 @@ import (
 // gets Items and Claims that have recently had their coverage_status/status changed
 //
 // ---
-// responses:
-//   '200':
-//     description: a list of Items and a list of Claims which each have the time when their status was last changed.
-//     schema:
-//       "$ref": "#/definitions/RecentObjects"
+//	responses:
+//	  '200':
+//	    description: a list of Items and a list of Claims which each have the time when their status was last changed.
+//	    schema:
+//	      "$ref": "#/definitions/RecentObjects"
 func stewardListRecentObjects(c buffalo.Context) error {
 	actor := models.CurrentUser(c)
 	if !actor.IsAdmin() {

--- a/application/actions/steward.go
+++ b/application/actions/steward.go
@@ -10,11 +10,9 @@ import (
 )
 
 // swagger:operation GET /steward/recent Steward ListRecentObjects
-//
 // ListRecentObjects
 //
 // gets Items and Claims that have recently had their coverage_status/status changed
-//
 // ---
 //	responses:
 //	  '200':

--- a/application/actions/strikes.go
+++ b/application/actions/strikes.go
@@ -11,11 +11,9 @@ import (
 )
 
 // swagger:operation PUT /strikes/{id} Strikes StrikesUpdate
-//
 // StrikesUpdate
 //
 // update a strike
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -52,11 +50,9 @@ func strikesUpdate(c buffalo.Context) error {
 }
 
 // swagger:operation DELETE /strikes/{id} Strikes StrikesDelete
-//
 // StrikesDelete
 //
 // Delete a strike.
-//
 // ---
 //	parameters:
 //	  - name: id

--- a/application/actions/strikes.go
+++ b/application/actions/strikes.go
@@ -15,6 +15,7 @@ import (
 //
 // update a strike
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -54,6 +55,7 @@ func strikesUpdate(c buffalo.Context) error {
 //
 // Delete a strike.
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path

--- a/application/actions/strikes.go
+++ b/application/actions/strikes.go
@@ -17,22 +17,22 @@ import (
 // update a strike
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: strike ID
-//   - name: strike input
-//     in: body
-//     description: policy item update object
-//     required: true
-//     schema:
-//       "$ref": "#/definitions/StrikeInput"
-// responses:
-//   '200':
-//     description: updated Strike
-//     schema:
-//       "$ref": "#/definitions/Strike"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: strike ID
+//	  - name: strike input
+//	    in: body
+//	    description: policy item update object
+//	    required: true
+//	    schema:
+//	      "$ref": "#/definitions/StrikeInput"
+//	responses:
+//	  '200':
+//	    description: updated Strike
+//	    schema:
+//	      "$ref": "#/definitions/Strike"
 func strikesUpdate(c buffalo.Context) error {
 	strike := getReferencedStrikeFromCtx(c)
 
@@ -58,14 +58,14 @@ func strikesUpdate(c buffalo.Context) error {
 // Delete a strike.
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: item ID
-// responses:
-//   '204':
-//     description: OK but no content in response
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: item ID
+//	responses:
+//	  '204':
+//	    description: OK but no content in response
 func strikesDelete(c buffalo.Context) error {
 	strike := getReferencedStrikeFromCtx(c)
 

--- a/application/actions/upload.go
+++ b/application/actions/upload.go
@@ -30,6 +30,7 @@ type UploadResponse struct {
 //
 // Upload a new File object
 // ---
+//
 //	consumes:
 //	  - multipart/form-data
 //	parameters:

--- a/application/actions/upload.go
+++ b/application/actions/upload.go
@@ -26,6 +26,7 @@ type UploadResponse struct {
 }
 
 // swagger:operation POST /upload Files UploadFile
+// UploadFile
 //
 // Upload a new File object
 // ---

--- a/application/actions/upload.go
+++ b/application/actions/upload.go
@@ -28,7 +28,6 @@ type UploadResponse struct {
 // swagger:operation POST /upload Files UploadFile
 //
 // Upload a new File object
-//
 // ---
 //	consumes:
 //	  - multipart/form-data

--- a/application/actions/upload.go
+++ b/application/actions/upload.go
@@ -30,18 +30,18 @@ type UploadResponse struct {
 // Upload a new File object
 //
 // ---
-// consumes:
-//   - multipart/form-data
-// parameters:
-//   - name: file
-//     in: formData
-//     type: file
-//     description: file object
-// responses:
-//   '200':
-//     description: uploaded File data
-//     schema:
-//       "$ref": "#/definitions/UploadResponse"
+//	consumes:
+//	  - multipart/form-data
+//	parameters:
+//	  - name: file
+//	    in: formData
+//	    type: file
+//	    description: file object
+//	responses:
+//	  '200':
+//	    description: uploaded File data
+//	    schema:
+//	      "$ref": "#/definitions/UploadResponse"
 func uploadHandler(c buffalo.Context) error {
 	f, err := c.File(fileFieldName)
 	if err != nil {

--- a/application/actions/users.go
+++ b/application/actions/users.go
@@ -18,13 +18,13 @@ import (
 // gets the data for all Users.
 //
 // ---
-// responses:
-//   '200':
-//     description: all users
-//     schema:
-//       type: array
-//       items:
-//         "$ref": "#/definitions/User"
+//	responses:
+//	  '200':
+//	    description: all users
+//	    schema:
+//	      type: array
+//	      items:
+//	        "$ref": "#/definitions/User"
 func usersList(c buffalo.Context) error {
 	var users models.Users
 	tx := models.Tx(c)
@@ -44,16 +44,16 @@ func usersList(c buffalo.Context) error {
 // gets the data for a specific User.
 //
 // ---
-// parameters:
-//   - name: id
-//     in: path
-//     required: true
-//     description: user ID
-// responses:
-//   '200':
-//     description: a user
-//     schema:
-//       "$ref": "#/definitions/User"
+//	parameters:
+//	  - name: id
+//	    in: path
+//	    required: true
+//	    description: user ID
+//	responses:
+//	  '200':
+//	    description: a user
+//	    schema:
+//	      "$ref": "#/definitions/User"
 func usersView(c buffalo.Context) error {
 	user := getReferencedUserFromCtx(c)
 	return renderUser(c, *user)
@@ -66,11 +66,11 @@ func usersView(c buffalo.Context) error {
 // gets the data for authenticated User.
 //
 // ---
-// responses:
-//   '200':
-//     description: authenticated user
-//     schema:
-//       "$ref": "#/definitions/User"
+//	responses:
+//	  '200':
+//	    description: authenticated user
+//	    schema:
+//	      "$ref": "#/definitions/User"
 func usersMe(c buffalo.Context) error {
 	return renderUser(c, models.CurrentUser(c))
 }
@@ -82,18 +82,18 @@ func usersMe(c buffalo.Context) error {
 // update the current user's personal settings
 //
 // ---
-// parameters:
-//   - name: user's settings input
-//     in: body
-//     description: the editable settings for a user
-//     required: true
-//     schema:
-//       "$ref": "#/definitions/UserInput"
-// responses:
-//   '200':
-//     description: updated User
-//     schema:
-//       "$ref": "#/definitions/User"
+//	parameters:
+//	  - name: user's settings input
+//	    in: body
+//	    description: the editable settings for a user
+//	    required: true
+//	    schema:
+//	      "$ref": "#/definitions/UserInput"
+//	responses:
+//	  '200':
+//	    description: updated User
+//	    schema:
+//	      "$ref": "#/definitions/User"
 func usersMeUpdate(c buffalo.Context) error {
 	tx := models.Tx(c)
 	user := models.CurrentUser(c)
@@ -123,18 +123,18 @@ func usersMeUpdate(c buffalo.Context) error {
 // attach a File to the current user
 //
 // ---
-// parameters:
-//   - name: user file input
-//     in: body
-//     description: photo/avatar to attach to the current user
-//     required: true
-//     schema:
-//       "$ref": "#/definitions/UserFileAttachInput"
-// responses:
-//   '200':
-//     description: the User
-//     schema:
-//       "$ref": "#/definitions/User"
+//	parameters:
+//	  - name: user file input
+//	    in: body
+//	    description: photo/avatar to attach to the current user
+//	    required: true
+//	    schema:
+//	      "$ref": "#/definitions/UserFileAttachInput"
+//	responses:
+//	  '200':
+//	    description: the User
+//	    schema:
+//	      "$ref": "#/definitions/User"
 func usersMeFilesAttach(c buffalo.Context) error {
 	var input api.UserFileAttachInput
 	if err := StrictBind(c, &input); err != nil {
@@ -158,10 +158,10 @@ func usersMeFilesAttach(c buffalo.Context) error {
 // detach the Photo File from the current user and remove it from S3
 //
 // ---
-// parameters:
-// responses:
-//   '204':
-//     description: OK but no content in response
+//	parameters:
+//	responses:
+//	  '204':
+//	    description: OK but no content in response
 func usersMeFilesDelete(c buffalo.Context) error {
 	tx := models.Tx(c)
 

--- a/application/actions/users.go
+++ b/application/actions/users.go
@@ -12,11 +12,9 @@ import (
 )
 
 // swagger:operation GET /users Users UsersList
-//
 // UsersList
 //
 // gets the data for all Users.
-//
 // ---
 //	responses:
 //	  '200':
@@ -38,11 +36,9 @@ func usersList(c buffalo.Context) error {
 }
 
 // swagger:operation GET /users/{id} Users UsersView
-//
 // UsersView
 //
 // gets the data for a specific User.
-//
 // ---
 //	parameters:
 //	  - name: id
@@ -60,11 +56,9 @@ func usersView(c buffalo.Context) error {
 }
 
 // swagger:operation GET /users/me Users UsersMe
-//
 // UsersMe
 //
 // gets the data for authenticated User.
-//
 // ---
 //	responses:
 //	  '200':
@@ -76,11 +70,9 @@ func usersMe(c buffalo.Context) error {
 }
 
 // swagger:operation PUT /users/me Users UserMeUpdate
-//
 // UserMeUpdate
 //
 // update the current user's personal settings
-//
 // ---
 //	parameters:
 //	  - name: user's settings input
@@ -117,11 +109,9 @@ func usersMeUpdate(c buffalo.Context) error {
 }
 
 // swagger:operation POST /users/me/files Users UsersMeFileAttach
-//
 // UsersMeFileAttach
 //
 // attach a File to the current user
-//
 // ---
 //	parameters:
 //	  - name: user file input
@@ -152,11 +142,9 @@ func usersMeFilesAttach(c buffalo.Context) error {
 }
 
 // swagger:operation DELETE /users/me/files Users UsersMeFileDelete
-//
 // UsersMeFileDelete
 //
 // detach the Photo File from the current user and remove it from S3
-//
 // ---
 //	parameters:
 //	responses:

--- a/application/actions/users.go
+++ b/application/actions/users.go
@@ -16,6 +16,7 @@ import (
 //
 // gets the data for all Users.
 // ---
+//
 //	responses:
 //	  '200':
 //	    description: all users
@@ -40,6 +41,7 @@ func usersList(c buffalo.Context) error {
 //
 // gets the data for a specific User.
 // ---
+//
 //	parameters:
 //	  - name: id
 //	    in: path
@@ -60,6 +62,7 @@ func usersView(c buffalo.Context) error {
 //
 // gets the data for authenticated User.
 // ---
+//
 //	responses:
 //	  '200':
 //	    description: authenticated user
@@ -74,6 +77,7 @@ func usersMe(c buffalo.Context) error {
 //
 // update the current user's personal settings
 // ---
+//
 //	parameters:
 //	  - name: user's settings input
 //	    in: body
@@ -113,6 +117,7 @@ func usersMeUpdate(c buffalo.Context) error {
 //
 // attach a File to the current user
 // ---
+//
 //	parameters:
 //	  - name: user file input
 //	    in: body
@@ -146,6 +151,7 @@ func usersMeFilesAttach(c buffalo.Context) error {
 //
 // detach the Photo File from the current user and remove it from S3
 // ---
+//
 //	parameters:
 //	responses:
 //	  '204':

--- a/application/swagger.json
+++ b/application/swagger.json
@@ -1,0 +1,3893 @@
+{
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "schemes": [
+    "https"
+  ],
+  "swagger": "2.0",
+  "info": {
+    "description": "Cover API",
+    "termsOfService": "there are no TOS at this moment, use at your own risk we take no responsibility",
+    "license": {
+      "name": "MIT",
+      "url": "http://opensource.org/licenses/MIT"
+    },
+    "version": "0.0.1"
+  },
+  "host": "localhost",
+  "basePath": "/",
+  "paths": {
+    "/audits": {
+      "post": {
+        "description": "Run an audit\n\n### Audit types:\n+ `renewal` - Return all items that were incorrectly renewed and billed for another year of coverage.",
+        "tags": [
+          "Audits"
+        ],
+        "summary": "AuditsRun",
+        "operationId": "AuditRun",
+        "parameters": [
+          {
+            "description": "parameters for the Audit Run",
+            "name": "input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AuditRunInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the audit result",
+            "schema": {
+              "$ref": "#/definitions/AuditResult"
+            }
+          }
+        }
+      }
+    },
+    "/auth/login": {
+      "post": {
+        "description": "Start the SAML login process",
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "AuthLogin",
+        "operationId": "AuthLogin",
+        "parameters": [
+          {
+            "description": "the user's client id",
+            "name": "client-id",
+            "in": "query",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "returns a \"RedirectURL\" key with the saml idp url that has a saml request"
+          }
+        }
+      }
+    },
+    "/auth/logout": {
+      "get": {
+        "description": "Logout of application",
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "AuthLogout",
+        "operationId": "AuthLogout",
+        "parameters": [
+          {
+            "description": "the user's bearer token",
+            "name": "token",
+            "in": "query",
+            "required": true
+          }
+        ],
+        "responses": {
+          "302": {
+            "description": "redirect to UI"
+          }
+        }
+      }
+    },
+    "/claim-files/{id}": {
+      "delete": {
+        "description": "Delete a ClaimFile and its associated File in the db and on S3",
+        "tags": [
+          "ClaimFiles"
+        ],
+        "summary": "ClaimFilesDelete",
+        "operationId": "ClaimFilesDelete",
+        "parameters": [
+          {
+            "description": "claim file ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "OK but no content in response"
+          }
+        }
+      }
+    },
+    "/claim-items/{id}": {
+      "put": {
+        "description": "update a claim item",
+        "tags": [
+          "ClaimItems"
+        ],
+        "summary": "ClaimItemsUpdate",
+        "operationId": "ClaimItemsUpdate",
+        "parameters": [
+          {
+            "description": "claim item ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "claim item update input object",
+            "name": "claim item input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ClaimItemUpdateInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the updated ClaimItem",
+            "schema": {
+              "$ref": "#/definitions/ClaimItem"
+            }
+          }
+        }
+      }
+    },
+    "/claims": {
+      "get": {
+        "description": "List the claims visible to the authenticated user, filtered by the given\nstatus values. For a user, all status values are included by default.\nFor an admin (steward or signator) only the review status values are\nincluded by default. Accepted status values: Draft, Review1, Review2,\nReview3, Revision, Receipt, Approved, Paid, Denied",
+        "tags": [
+          "Claims"
+        ],
+        "summary": "ClaimsList",
+        "operationId": "ClaimsList",
+        "parameters": [
+          {
+            "description": "comma-separated list of status values to include",
+            "name": "status",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "a list of Claims",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Claim"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/claims/{id}": {
+      "get": {
+        "description": "view a specific claim",
+        "tags": [
+          "Claims"
+        ],
+        "summary": "ClaimsView",
+        "operationId": "ClaimsView",
+        "parameters": [
+          {
+            "description": "claim ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "a Claim",
+            "schema": {
+              "$ref": "#/definitions/Claim"
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "update a claim",
+        "tags": [
+          "Claims"
+        ],
+        "summary": "ClaimsUpdate",
+        "operationId": "ClaimsUpdate",
+        "parameters": [
+          {
+            "description": "claim ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "claim create input object",
+            "name": "claim input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ClaimUpdateInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "a Claim",
+            "schema": {
+              "$ref": "#/definitions/Claim"
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete a claim and its claim items as long as it does not have a status of\napproved, denied or paid.",
+        "tags": [
+          "Claims"
+        ],
+        "summary": "ClaimsRemove",
+        "operationId": "ClaimsRemove",
+        "parameters": [
+          {
+            "description": "claim ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "OK but no content in response"
+          }
+        }
+      }
+    },
+    "/claims/{id}/approve": {
+      "post": {
+        "description": "Admin approves a claim.  Can be used at states \"Review1\",\"Review2\",\"Review3\".",
+        "tags": [
+          "Claims"
+        ],
+        "summary": "ClaimsApprove",
+        "operationId": "ClaimsApprove",
+        "parameters": [
+          {
+            "description": "claim ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Claim in focus",
+            "schema": {
+              "$ref": "#/definitions/Claim"
+            }
+          }
+        }
+      }
+    },
+    "/claims/{id}/deny": {
+      "post": {
+        "description": "Admin denies a claim.  Can be used at states \"Review1\",\"Review2\",\"Review3\".",
+        "tags": [
+          "Claims"
+        ],
+        "summary": "ClaimsDeny",
+        "operationId": "ClaimsDeny",
+        "parameters": [
+          {
+            "description": "claim ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "claim deny input object",
+            "name": "claim deny input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ClaimStatusInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Claim in focus",
+            "schema": {
+              "$ref": "#/definitions/Claim"
+            }
+          }
+        }
+      }
+    },
+    "/claims/{id}/files": {
+      "post": {
+        "description": "attach a File to a Claim",
+        "tags": [
+          "ClaimFiles"
+        ],
+        "summary": "ClaimFilesAttach",
+        "operationId": "ClaimFilesAttach",
+        "parameters": [
+          {
+            "description": "claim ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "claim file attach input object",
+            "name": "claim file input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ClaimFileAttachInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the new ClaimFile",
+            "schema": {
+              "$ref": "#/definitions/ClaimFile"
+            }
+          }
+        }
+      }
+    },
+    "/claims/{id}/items": {
+      "post": {
+        "description": "create a new ClaimItem on a Claim",
+        "tags": [
+          "Claims"
+        ],
+        "summary": "ClaimsItemsCreate",
+        "operationId": "ClaimsItemsCreate",
+        "parameters": [
+          {
+            "description": "claim ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "claim item create input object",
+            "name": "claim item input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ClaimItemCreateInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the new ClaimItem",
+            "schema": {
+              "$ref": "#/definitions/ClaimItem"
+            }
+          }
+        }
+      }
+    },
+    "/claims/{id}/preapprove": {
+      "post": {
+        "description": "Admin preapproves a claim and requests a receipt.  Can only be used at state \"Review1\".",
+        "tags": [
+          "Claims"
+        ],
+        "summary": "ClaimsPreapprove",
+        "operationId": "ClaimsPreapprove",
+        "parameters": [
+          {
+            "description": "claim ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Claim in focus",
+            "schema": {
+              "$ref": "#/definitions/Claim"
+            }
+          }
+        }
+      }
+    },
+    "/claims/{id}/receipt": {
+      "post": {
+        "description": "Admin reverts a claim to request a new/better receipt.\nCan be used at state \"Review2\" or \"Review3\".",
+        "tags": [
+          "Claims"
+        ],
+        "summary": "ClaimsFixReceipt",
+        "operationId": "ClaimsFixReceipt",
+        "parameters": [
+          {
+            "description": "claim ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "claim receipt reason input object",
+            "name": "claim receipt reason input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ClaimStatusInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Claim in focus",
+            "schema": {
+              "$ref": "#/definitions/Claim"
+            }
+          }
+        }
+      }
+    },
+    "/claims/{id}/revision": {
+      "post": {
+        "description": "Admin requests revisions on a claim.  Can be used at state \"Review1\", \"Review2\", or \"Review3\".",
+        "tags": [
+          "Claims"
+        ],
+        "summary": "ClaimsRequestRevision",
+        "operationId": "ClaimsRequestRevision",
+        "parameters": [
+          {
+            "description": "claim ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "claim request revision input object",
+            "name": "claim revision input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ClaimStatusInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Claim in focus",
+            "schema": {
+              "$ref": "#/definitions/Claim"
+            }
+          }
+        }
+      }
+    },
+    "/claims/{id}/submit": {
+      "post": {
+        "description": "Submit a claim for review.  Can be used at state \"Draft\" to submit for pre-approval or\n\"Receipt\" to submit for payout approval.",
+        "tags": [
+          "Claims"
+        ],
+        "summary": "ClaimsSubmit",
+        "operationId": "ClaimsSubmit",
+        "parameters": [
+          {
+            "description": "claim ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "submitted Claim",
+            "schema": {
+              "$ref": "#/definitions/Claim"
+            }
+          }
+        }
+      }
+    },
+    "/config/claim-incident-types": {
+      "get": {
+        "description": "list all valid Claim Incident Types",
+        "tags": [
+          "Config"
+        ],
+        "summary": "ClaimIncidentTypes",
+        "operationId": "ClaimIncidentTypes",
+        "responses": {
+          "200": {
+            "description": "list of valid Claim Incident Types",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ClaimIncidentTypeStruct"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/config/countries": {
+      "get": {
+        "description": "list of countries",
+        "tags": [
+          "Config"
+        ],
+        "summary": "Countries",
+        "operationId": "Countries",
+        "responses": {
+          "200": {
+            "description": "list of countries",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Country"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/config/item-categories": {
+      "get": {
+        "description": "list all the enabled item categories",
+        "tags": [
+          "Config"
+        ],
+        "summary": "ItemCategoriesList",
+        "operationId": "ItemCategoriesList",
+        "responses": {
+          "200": {
+            "description": "a list of ItemCategories",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ItemCategory"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/entity-codes": {
+      "get": {
+        "description": "list Entity Codes",
+        "tags": [
+          "EntityCodes"
+        ],
+        "summary": "EntityCodesList",
+        "operationId": "EntityCodesList",
+        "responses": {
+          "200": {
+            "description": "list of Entity Codes",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/EntityCode"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "create a new Entity Code",
+        "tags": [
+          "EntityCodes"
+        ],
+        "summary": "EntityCodesCreate",
+        "operationId": "EntityCodesCreate",
+        "parameters": [
+          {
+            "description": "entity code create input object",
+            "name": "entity code create input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EntityCodeCreateInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "an Entity Code record",
+            "schema": {
+              "$ref": "#/definitions/EntityCode"
+            }
+          }
+        }
+      }
+    },
+    "/entity-codes/{id}": {
+      "get": {
+        "description": "get a single Entity Code",
+        "tags": [
+          "EntityCodes"
+        ],
+        "summary": "EntityCodesView",
+        "operationId": "EntityCodesView",
+        "parameters": [
+          {
+            "description": "entity code ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "an Entity Code record",
+            "schema": {
+              "$ref": "#/definitions/EntityCode"
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "update a Entity Code",
+        "tags": [
+          "EntityCodes"
+        ],
+        "summary": "EntityCodesUpdate",
+        "operationId": "EntityCodesUpdate",
+        "parameters": [
+          {
+            "description": "entity code ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "entity code update input object",
+            "name": "entity code update input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EntityCodeInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "an Entity Code record",
+            "schema": {
+              "$ref": "#/definitions/EntityCode"
+            }
+          }
+        }
+      }
+    },
+    "/items/{id}": {
+      "put": {
+        "description": "update a policy item",
+        "tags": [
+          "PolicyItems"
+        ],
+        "summary": "PolicyItemsUpdate",
+        "operationId": "PolicyItemsUpdate",
+        "parameters": [
+          {
+            "description": "item ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "policy item update object",
+            "name": "policy item update input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ItemUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "updated Item",
+            "schema": {
+              "$ref": "#/definitions/Item"
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete a policy item if it is less than 72 hours old and has no associations.\nOtherwise, inactivate coverage on it.",
+        "tags": [
+          "PolicyItems"
+        ],
+        "summary": "PolicyItemsRemove",
+        "operationId": "PolicyItemsRemove",
+        "parameters": [
+          {
+            "description": "item ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "OK but no content in response"
+          }
+        }
+      }
+    },
+    "/items/{id}/approve": {
+      "post": {
+        "description": "approve coverage on a policy item",
+        "tags": [
+          "PolicyItems"
+        ],
+        "summary": "PolicyItemsApprove",
+        "operationId": "PolicyItemsApprove",
+        "parameters": [
+          {
+            "description": "item ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "approved Item",
+            "schema": {
+              "$ref": "#/definitions/Item"
+            }
+          }
+        }
+      }
+    },
+    "/items/{id}/deny": {
+      "post": {
+        "description": "deny coverage on a policy item",
+        "tags": [
+          "PolicyItems"
+        ],
+        "summary": "PolicyItemsDeny",
+        "operationId": "PolicyItemsDeny",
+        "parameters": [
+          {
+            "description": "item ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "item denial input object",
+            "name": "item denial input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ItemStatusInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "denied Item",
+            "schema": {
+              "$ref": "#/definitions/Item"
+            }
+          }
+        }
+      }
+    },
+    "/items/{id}/revision": {
+      "post": {
+        "description": "admin requires changes on a policy item",
+        "tags": [
+          "PolicyItems"
+        ],
+        "summary": "PolicyItemsRevision",
+        "operationId": "PolicyItemsRevision",
+        "parameters": [
+          {
+            "description": "item ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "item revision input object",
+            "name": "item revision input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ItemStatusInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Policy Item",
+            "schema": {
+              "$ref": "#/definitions/Item"
+            }
+          }
+        }
+      }
+    },
+    "/items/{id}/submit": {
+      "post": {
+        "description": "submit a policy item for coverage",
+        "tags": [
+          "PolicyItems"
+        ],
+        "summary": "PolicyItemsSubmit",
+        "operationId": "PolicyItemsSubmit",
+        "parameters": [
+          {
+            "description": "item ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "submitted Item",
+            "schema": {
+              "$ref": "#/definitions/Item"
+            }
+          }
+        }
+      }
+    },
+    "/ledger-reports": {
+      "get": {
+        "description": "Return a list of ledger reports that are not associated with a policy",
+        "tags": [
+          "LedgerReport"
+        ],
+        "summary": "LedgerReportList",
+        "operationId": "LedgerReportList",
+        "responses": {
+          "200": {
+            "description": "LedgerReport list",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/LedgerReport"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create and return a report on the ledger entries as specified by the input object. The returned object\ncontains metadata and a File object pointing to a CSV file suitable for use with Sage Accounting.\n\n### Report types:\n+ `monthly` - Return all ledger entries not yet reconciled, up to the beginning of the given day (0:00 UTC).\n+ `annual` - Return the billing detail for given year's policy renewals.",
+        "tags": [
+          "LedgerReport"
+        ],
+        "summary": "LedgerReportCreate",
+        "operationId": "LedgerReportCreate",
+        "parameters": [
+          {
+            "description": "LedgerReportCreateInput object",
+            "name": "input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/LedgerReportCreateInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the requested LedgerReport",
+            "schema": {
+              "$ref": "#/definitions/LedgerReport"
+            }
+          }
+        }
+      }
+    },
+    "/ledger-reports/annual": {
+      "get": {
+        "description": "Get the status of the annual billing process.",
+        "tags": [
+          "Ledger"
+        ],
+        "summary": "LedgerAnnualRenewalStatus",
+        "operationId": "LedgerAnnualRenewalStatus",
+        "responses": {
+          "200": {
+            "description": "the status of the annual billing process",
+            "schema": {
+              "$ref": "#/definitions/AnnualRenewalStatus"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Process billing for current year's policy renewals.",
+        "tags": [
+          "Ledger"
+        ],
+        "summary": "LedgerAnnualProcess",
+        "operationId": "LedgerAnnualProcess",
+        "responses": {
+          "204": {
+            "description": "OK but no content in response"
+          }
+        }
+      }
+    },
+    "/ledger-reports/{id}": {
+      "get": {
+        "description": "Return the ledger report specified by `id`. The returned object contains metadata and a File object pointing to\na CSV file suitable for use with Sage Accounting.",
+        "tags": [
+          "LedgerReport"
+        ],
+        "summary": "LedgerReportView",
+        "operationId": "LedgerReportView",
+        "parameters": [
+          {
+            "description": "specifies the ID of the report to view",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the requested LedgerReport",
+            "schema": {
+              "$ref": "#/definitions/LedgerReport"
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Mark ledger entries in the report reconciled as of today. Call this only after all transactions in the report\nhave been fully loaded into the accounting record.",
+        "tags": [
+          "LedgerReport"
+        ],
+        "summary": "LedgerReportReconcile",
+        "operationId": "LedgerReportReconcile",
+        "parameters": [
+          {
+            "description": "specifies the ID of the report to reconcile",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the requested LedgerReport",
+            "schema": {
+              "$ref": "#/definitions/LedgerReport"
+            }
+          }
+        }
+      }
+    },
+    "/policies": {
+      "get": {
+        "description": "Get the data for all the user's Policies if the user is not an admin. If called by an admin, returns all Policies\nin the system, limited by query parameters.",
+        "tags": [
+          "Policies"
+        ],
+        "summary": "PoliciesList",
+        "operationId": "PoliciesList",
+        "parameters": [
+          {
+            "description": "number of records to return, minimum 1, maximum 50, default 10",
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "description": "search text to find across fields (name, household_id, cost_center, and all members' first and last names)",
+            "name": "search",
+            "in": "query"
+          },
+          {
+            "description": "comma-separated list of search pairs like \"field:text\". Presently, only meta-field 'active' is supported",
+            "name": "filter",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "all policies",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "$ref": "#/definitions/Policies"
+                },
+                "meta": {
+                  "$ref": "#/definitions/Meta"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "create a new Policy with type Team",
+        "tags": [
+          "Policies"
+        ],
+        "summary": "PoliciesCreateTeam",
+        "operationId": "PoliciesCreateTeam",
+        "parameters": [
+          {
+            "description": "policy create input object",
+            "name": "policy input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PolicyCreate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the new Policy",
+            "schema": {
+              "$ref": "#/definitions/Policy"
+            }
+          }
+        }
+      }
+    },
+    "/policies/{id}": {
+      "get": {
+        "description": "gets the data for a specific policy",
+        "tags": [
+          "Policies"
+        ],
+        "summary": "PoliciesView",
+        "operationId": "PoliciesView",
+        "responses": {
+          "200": {
+            "description": "a policy",
+            "schema": {
+              "$ref": "#/definitions/Policy"
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "update a policy",
+        "tags": [
+          "Policies"
+        ],
+        "summary": "PoliciesUpdate",
+        "operationId": "PoliciesUpdate",
+        "parameters": [
+          {
+            "description": "policy ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "policy update input object",
+            "name": "policy update input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PolicyUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "updated Policy",
+            "schema": {
+              "$ref": "#/definitions/Policy"
+            }
+          }
+        }
+      }
+    },
+    "/policies/{id}/claims": {
+      "get": {
+        "description": "List claims for a given policy",
+        "tags": [
+          "Claims"
+        ],
+        "summary": "PolicyClaimsList",
+        "operationId": "PolicyClaimsList",
+        "responses": {
+          "200": {
+            "description": "a list of Claims",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Claim"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "create a new Claim on a policy",
+        "tags": [
+          "Claims"
+        ],
+        "summary": "ClaimsCreate",
+        "operationId": "ClaimsCreate",
+        "parameters": [
+          {
+            "description": "policy ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "claim create input object",
+            "name": "claim input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ClaimCreateInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the new Claim",
+            "schema": {
+              "$ref": "#/definitions/Claim"
+            }
+          }
+        }
+      }
+    },
+    "/policies/{id}/dependents": {
+      "get": {
+        "description": "list policy dependents",
+        "tags": [
+          "PolicyDependents"
+        ],
+        "summary": "PolicyDependentsList",
+        "operationId": "PolicyDependentsList",
+        "parameters": [
+          {
+            "description": "policy ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "a list of PolicyDependents",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PolicyDependents"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "create a new PolicyDependent on a policy",
+        "tags": [
+          "PolicyDependents"
+        ],
+        "summary": "PolicyDependentsCreate",
+        "operationId": "PolicyDependentsCreate",
+        "parameters": [
+          {
+            "description": "policy ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "policy dependent input object",
+            "name": "policy dependent",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PolicyDependentInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the new PolicyDependent",
+            "schema": {
+              "$ref": "#/definitions/PolicyDependent"
+            }
+          }
+        }
+      }
+    },
+    "/policies/{id}/items": {
+      "get": {
+        "description": "gets the data for all the items on a Policy",
+        "tags": [
+          "PolicyItems"
+        ],
+        "summary": "PolicyItemsList",
+        "operationId": "PolicyItemsList",
+        "parameters": [
+          {
+            "description": "policy ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "all policy items",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Item"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "create a policy item",
+        "tags": [
+          "PolicyItems"
+        ],
+        "summary": "PolicyItemsCreate",
+        "operationId": "PolicyItemsCreate",
+        "parameters": [
+          {
+            "description": "policy ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "policy item create input object",
+            "name": "policy item create input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ItemCreate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "new Item",
+            "schema": {
+              "$ref": "#/definitions/Item"
+            }
+          }
+        }
+      }
+    },
+    "/policies/{id}/ledger-reports": {
+      "get": {
+        "description": "Return data regarding the ledger entries of a policy for a particular month.\nIf no ledger entries are found with a `date_entered` value that matches the requested\nYear and Month, then a 204 is returned.",
+        "tags": [
+          "PolicyLedgerReport"
+        ],
+        "summary": "PolicyLedgerTableView",
+        "operationId": "PolicyLedgerTableView",
+        "parameters": [
+          {
+            "description": "policy ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "the month (number) within which the ledger entries were entered into the accounting system",
+            "name": "month",
+            "in": "query",
+            "required": true
+          },
+          {
+            "description": "the year within which the ledger entries were entered into the accounting system",
+            "name": "year",
+            "in": "query",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the requested LedgerTable for the Policy",
+            "schema": {
+              "$ref": "#/definitions/LedgerTable"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create and return a report on the ledger entries of a policy as specified by the input object.\nThe returned object contains metadata and a File object pointing to a CSV file.\nIf no ledger entries are found with a `date_entered` value that matches the requested\nType, Year and (if applicable) Month, then a 204 is returned.",
+        "tags": [
+          "PolicyLedgerReport"
+        ],
+        "summary": "PolicyLedgerReportCreate",
+        "operationId": "PolicyLedgerReportCreate",
+        "parameters": [
+          {
+            "description": "policy ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "PolicyLedgerReportCreateInput object",
+            "name": "input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PolicyLedgerReportCreateInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the requested LedgerReport for the Policy",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/LedgerReport"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/policies/{id}/members": {
+      "get": {
+        "description": "gets the data for all the members of a Policy",
+        "tags": [
+          "PolicyMembers"
+        ],
+        "summary": "PolicyMembersList",
+        "operationId": "PolicyMembersList",
+        "parameters": [
+          {
+            "description": "policy ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "all policy members",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PolicyMember"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "invite new user to co-manage policy",
+        "tags": [
+          "PolicyMembers"
+        ],
+        "summary": "PolicyMembersInvite",
+        "operationId": "PolicyMembersInvite",
+        "parameters": [
+          {
+            "description": "policy ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "policy user invite input object",
+            "name": "policy member invite input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PolicyUserInviteCreate"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "success, no content"
+          },
+          "400": {
+            "description": "bad request, check the error and fix your code"
+          }
+        }
+      }
+    },
+    "/policies/{id}/strikes": {
+      "post": {
+        "description": "Create a strike on the policy and return its recent strikes",
+        "tags": [
+          "PolicyStrike"
+        ],
+        "summary": "PolicyStrikeCreate",
+        "operationId": "PolicyStrikeCreate",
+        "parameters": [
+          {
+            "description": "policy ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "StrikeInput object",
+            "name": "input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/StrikeInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the Strikes for the Policy that are still in force",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Strike"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/policy-dependents/{id}": {
+      "put": {
+        "description": "update a policy dependent",
+        "tags": [
+          "PolicyDependents"
+        ],
+        "summary": "PolicyDependentsUpdate",
+        "operationId": "PolicyDependentsUpdate",
+        "parameters": [
+          {
+            "description": "policy dependent ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "policy dependent input object",
+            "name": "policy dependent update input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PolicyDependentInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the updated PolicyDependent",
+            "schema": {
+              "$ref": "#/definitions/PolicyDependent"
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete a policy dependent if it has no related policy items.",
+        "tags": [
+          "PolicyDependents"
+        ],
+        "summary": "PolicyDependentsDelete",
+        "operationId": "PolicyDependentsDelete",
+        "parameters": [
+          {
+            "description": "policy dependent ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "OK but no content in response"
+          }
+        }
+      }
+    },
+    "/policy-members/{id}": {
+      "delete": {
+        "description": "Delete a policy user as long as the related policy has another user. Also,\nnull out the PolicyUserID on related items",
+        "tags": [
+          "PolicyMembers"
+        ],
+        "summary": "PolicyMembersDelete",
+        "operationId": "PolicyMembersDelete",
+        "parameters": [
+          {
+            "description": "policy-member ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "OK but no content in response"
+          }
+        }
+      }
+    },
+    "/repairs": {
+      "post": {
+        "description": "Run a repair\n\n### Repair types:\n+ `renewal` - Repair all items that were incorrectly renewed and billed for another year of coverage. Also issues premium refunds for the incorrect renewal charges.",
+        "tags": [
+          "Repairs"
+        ],
+        "summary": "RepairsRun",
+        "operationId": "RepairsRun",
+        "parameters": [
+          {
+            "description": "parameters for the Repair Run",
+            "name": "input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RepairRunInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the repair result",
+            "schema": {
+              "$ref": "#/definitions/RepairResult"
+            }
+          }
+        }
+      }
+    },
+    "/status": {
+      "get": {
+        "description": "checks the app status",
+        "tags": [
+          "Status"
+        ],
+        "summary": "Status",
+        "operationId": "Status",
+        "responses": {
+          "204": {
+            "description": "app status is good"
+          }
+        }
+      }
+    },
+    "/steward/recent": {
+      "get": {
+        "description": "gets Items and Claims that have recently had their coverage_status/status changed",
+        "tags": [
+          "Steward"
+        ],
+        "summary": "ListRecentObjects",
+        "operationId": "ListRecentObjects",
+        "responses": {
+          "200": {
+            "description": "a list of Items and a list of Claims which each have the time when their status was last changed.",
+            "schema": {
+              "$ref": "#/definitions/RecentObjects"
+            }
+          }
+        }
+      }
+    },
+    "/strikes/{id}": {
+      "put": {
+        "description": "update a strike",
+        "tags": [
+          "Strikes"
+        ],
+        "summary": "StrikesUpdate",
+        "operationId": "StrikesUpdate",
+        "parameters": [
+          {
+            "description": "strike ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "policy item update object",
+            "name": "strike input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/StrikeInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "updated Strike",
+            "schema": {
+              "$ref": "#/definitions/Strike"
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete a strike.",
+        "tags": [
+          "Strikes"
+        ],
+        "summary": "StrikesDelete",
+        "operationId": "StrikesDelete",
+        "parameters": [
+          {
+            "description": "item ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "OK but no content in response"
+          }
+        }
+      }
+    },
+    "/upload": {
+      "post": {
+        "description": "Upload a new File object",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "tags": [
+          "Files"
+        ],
+        "operationId": "UploadFile",
+        "parameters": [
+          {
+            "type": "file",
+            "description": "file object",
+            "name": "file",
+            "in": "formData"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "uploaded File data",
+            "schema": {
+              "$ref": "#/definitions/UploadResponse"
+            }
+          }
+        }
+      }
+    },
+    "/users": {
+      "get": {
+        "description": "gets the data for all Users.",
+        "tags": [
+          "Users"
+        ],
+        "summary": "UsersList",
+        "operationId": "UsersList",
+        "responses": {
+          "200": {
+            "description": "all users",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/User"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/me": {
+      "get": {
+        "description": "gets the data for authenticated User.",
+        "tags": [
+          "Users"
+        ],
+        "summary": "UsersMe",
+        "operationId": "UsersMe",
+        "responses": {
+          "200": {
+            "description": "authenticated user",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "update the current user's personal settings",
+        "tags": [
+          "Users"
+        ],
+        "summary": "UserMeUpdate",
+        "operationId": "UserMeUpdate",
+        "parameters": [
+          {
+            "description": "the editable settings for a user",
+            "name": "user's settings input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UserInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "updated User",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          }
+        }
+      }
+    },
+    "/users/me/files": {
+      "post": {
+        "description": "attach a File to the current user",
+        "tags": [
+          "Users"
+        ],
+        "summary": "UsersMeFileAttach",
+        "operationId": "UsersMeFileAttach",
+        "parameters": [
+          {
+            "description": "photo/avatar to attach to the current user",
+            "name": "user file input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UserFileAttachInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the User",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "detach the Photo File from the current user and remove it from S3",
+        "tags": [
+          "Users"
+        ],
+        "summary": "UsersMeFileDelete",
+        "operationId": "UsersMeFileDelete",
+        "responses": {
+          "204": {
+            "description": "OK but no content in response"
+          }
+        }
+      }
+    },
+    "/users/{id}": {
+      "get": {
+        "description": "gets the data for a specific User.",
+        "tags": [
+          "Users"
+        ],
+        "summary": "UsersView",
+        "operationId": "UsersView",
+        "parameters": [
+          {
+            "description": "user ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "a user",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "AccountablePerson": {
+      "type": "object",
+      "properties": {
+        "country": {
+          "description": "country where person is located",
+          "type": "string",
+          "x-go-name": "Country"
+        },
+        "id": {
+          "description": "ID that can reference either a User or a PolicyDependent",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "ID"
+        },
+        "name": {
+          "description": "full name",
+          "type": "string",
+          "x-go-name": "Name"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "AnnualRenewalStatus": {
+      "type": "object",
+      "properties": {
+        "is_complete": {
+          "type": "boolean",
+          "x-go-name": "IsComplete"
+        },
+        "items_to_process": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "ItemsToProcess"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "AppError": {
+      "description": "AppError holds information that is helpful in logging and reporting api errors",
+      "type": "object",
+      "properties": {
+        "debug_msg": {
+          "description": "detailed error message for debugging, only provided in development environment",
+          "type": "string",
+          "x-go-name": "DebugMsg"
+        },
+        "extras": {
+          "description": "Extra data providing detail about the error condition, only provided in development environment",
+          "type": "object",
+          "additionalProperties": {},
+          "x-go-name": "Extras"
+        },
+        "key": {
+          "$ref": "#/definitions/ErrorKey"
+        },
+        "message": {
+          "description": "user-facing error message",
+          "type": "string",
+          "x-go-name": "Message"
+        },
+        "status": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "HttpStatus"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "AuditResult": {
+      "type": "object",
+      "properties": {
+        "audit_type": {
+          "type": "string",
+          "x-go-name": "AuditType"
+        },
+        "items": {
+          "$ref": "#/definitions/Items"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "AuditRunInput": {
+      "type": "object",
+      "properties": {
+        "audit_type": {
+          "type": "string",
+          "x-go-name": "AuditType"
+        },
+        "date": {
+          "type": "string",
+          "x-go-name": "Date"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "Claim": {
+      "type": "object",
+      "properties": {
+        "claim_files": {
+          "description": "list of files attached to the claim",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ClaimFile"
+          },
+          "x-go-name": "Files"
+        },
+        "claim_items": {
+          "$ref": "#/definitions/ClaimItems"
+        },
+        "id": {
+          "description": "unique ID",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "ID"
+        },
+        "incident_date": {
+          "description": "incident date",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "IncidentDate"
+        },
+        "incident_description": {
+          "description": "incident description .",
+          "type": "string",
+          "x-go-name": "IncidentDescription"
+        },
+        "incident_type": {
+          "$ref": "#/definitions/ClaimIncidentType"
+        },
+        "is_removable": {
+          "description": "whether the claim can be removed/deleted",
+          "type": "boolean",
+          "x-go-name": "IsRemovable"
+        },
+        "payment_date": {
+          "description": "payment date",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "PaymentDate"
+        },
+        "policy_id": {
+          "description": "policy ID",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "PolicyID"
+        },
+        "reference_number": {
+          "description": "reference number\n\nhuman friendly seven character string, e.g.: AB43312",
+          "type": "string",
+          "x-go-name": "ReferenceNumber"
+        },
+        "review_date": {
+          "description": "review date",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "ReviewDate"
+        },
+        "reviewer_id": {
+          "description": "reviewer ID",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "ReviewerID"
+        },
+        "status": {
+          "$ref": "#/definitions/ClaimStatus"
+        },
+        "status_change": {
+          "description": "how the status changed most recently (for the stewards dashboard)",
+          "type": "string",
+          "x-go-name": "StatusChange"
+        },
+        "status_reason": {
+          "description": "message from a reviewer detailing the revisions needed",
+          "type": "string",
+          "x-go-name": "StatusReason"
+        },
+        "total_payout": {
+          "$ref": "#/definitions/Currency"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "ClaimCreateInput": {
+      "type": "object",
+      "properties": {
+        "incident_date": {
+          "description": "incident date",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "IncidentDate"
+        },
+        "incident_description": {
+          "description": "incident description",
+          "type": "string",
+          "x-go-name": "IncidentDescription"
+        },
+        "incident_type": {
+          "$ref": "#/definitions/ClaimIncidentType"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "ClaimFile": {
+      "type": "object",
+      "properties": {
+        "claim_id": {
+          "description": "ID of the Claim",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "ClaimID"
+        },
+        "created_at": {
+          "description": "created time",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "CreatedAt"
+        },
+        "file": {
+          "$ref": "#/definitions/File"
+        },
+        "file_id": {
+          "description": "ID of the File",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "FileID"
+        },
+        "id": {
+          "description": "ID of the ClaimFile",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "ID"
+        },
+        "purpose": {
+          "$ref": "#/definitions/ClaimFilePurpose"
+        },
+        "updated_at": {
+          "description": "last updated time",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "UpdatedAt"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "ClaimFileAttachInput": {
+      "type": "object",
+      "properties": {
+        "file_id": {
+          "description": "File ID to attach to the claim",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "FileID"
+        },
+        "purpose": {
+          "$ref": "#/definitions/ClaimFilePurpose"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "ClaimFilePurpose": {
+      "description": "may be one of: \"Receipt\", \"Evidence of FMV\", \"Repair Estimate\"",
+      "type": "string",
+      "title": "ClaimFilePurpose",
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "ClaimIncidentType": {
+      "description": "must be one of the values returned by /config/claim-incident-types",
+      "type": "string",
+      "title": "ClaimIncidentType",
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "ClaimIncidentTypeStruct": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "x-go-name": "Description"
+        },
+        "is_repairable": {
+          "type": "boolean",
+          "x-go-name": "IsRepairable"
+        },
+        "name": {
+          "$ref": "#/definitions/ClaimIncidentType"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "ClaimItem": {
+      "type": "object",
+      "properties": {
+        "claim_id": {
+          "description": "claim ID",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "ClaimID"
+        },
+        "coverage_amount": {
+          "$ref": "#/definitions/Currency"
+        },
+        "created_at": {
+          "description": "date-time created",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "CreatedAt"
+        },
+        "fmv": {
+          "$ref": "#/definitions/Currency"
+        },
+        "id": {
+          "description": "claim item ID",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "ID"
+        },
+        "is_repairable": {
+          "description": "is item repairable?",
+          "type": "boolean",
+          "x-go-name": "IsRepairable"
+        },
+        "item": {
+          "$ref": "#/definitions/Item"
+        },
+        "item_id": {
+          "description": "item ID",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "ItemID"
+        },
+        "payout_amount": {
+          "$ref": "#/definitions/Currency"
+        },
+        "payout_option": {
+          "$ref": "#/definitions/PayoutOption"
+        },
+        "repair_actual": {
+          "$ref": "#/definitions/Currency"
+        },
+        "repair_estimate": {
+          "$ref": "#/definitions/Currency"
+        },
+        "replace_actual": {
+          "$ref": "#/definitions/Currency"
+        },
+        "replace_estimate": {
+          "$ref": "#/definitions/Currency"
+        },
+        "review_date": {
+          "description": "review date",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "ReviewDate"
+        },
+        "reviewer_id": {
+          "description": "reviewer User ID",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "ReviewerID"
+        },
+        "status": {
+          "$ref": "#/definitions/ClaimStatus"
+        },
+        "updated_at": {
+          "description": "date-time last updated",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "UpdatedAt"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "ClaimItemCreateInput": {
+      "type": "object",
+      "properties": {
+        "fmv": {
+          "$ref": "#/definitions/Currency"
+        },
+        "is_repairable": {
+          "description": "is item repairable?",
+          "type": "boolean",
+          "x-go-name": "IsRepairable"
+        },
+        "item_id": {
+          "description": "item ID",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "ItemID"
+        },
+        "payout_option": {
+          "$ref": "#/definitions/PayoutOption"
+        },
+        "repair_actual": {
+          "$ref": "#/definitions/Currency"
+        },
+        "repair_estimate": {
+          "$ref": "#/definitions/Currency"
+        },
+        "replace_actual": {
+          "$ref": "#/definitions/Currency"
+        },
+        "replace_estimate": {
+          "$ref": "#/definitions/Currency"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "ClaimItemUpdateInput": {
+      "type": "object",
+      "properties": {
+        "fmv": {
+          "$ref": "#/definitions/Currency"
+        },
+        "is_repairable": {
+          "description": "is item repairable?",
+          "type": "boolean",
+          "x-go-name": "IsRepairable"
+        },
+        "payout_option": {
+          "$ref": "#/definitions/PayoutOption"
+        },
+        "repair_actual": {
+          "$ref": "#/definitions/Currency"
+        },
+        "repair_estimate": {
+          "$ref": "#/definitions/Currency"
+        },
+        "replace_actual": {
+          "$ref": "#/definitions/Currency"
+        },
+        "replace_estimate": {
+          "$ref": "#/definitions/Currency"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "ClaimItems": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ClaimItem"
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "ClaimStatus": {
+      "description": "may be one of: Draft, Review1, Review2, Review3, Revision, Receipt, Approved, Paid, Denied",
+      "type": "string",
+      "title": "ClaimStatus",
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "ClaimStatusInput": {
+      "type": "object",
+      "properties": {
+        "status_reason": {
+          "description": "message from a reviewer noting the reason for the new status, e.g. detailing the revisions needed",
+          "type": "string",
+          "x-go-name": "StatusReason"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "ClaimUpdateInput": {
+      "type": "object",
+      "properties": {
+        "incident_date": {
+          "description": "incident date",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "IncidentDate"
+        },
+        "incident_description": {
+          "description": "incident description",
+          "type": "string",
+          "x-go-name": "IncidentDescription"
+        },
+        "incident_type": {
+          "$ref": "#/definitions/ClaimIncidentType"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "Claims": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Claim"
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "Country": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "Currency": {
+      "description": "Currency is in US Dollars, specified as an integer representing cents ($0.01 USD is represented as 1 and $105.36 as 10536)",
+      "type": "integer",
+      "format": "int64",
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "EntityCode": {
+      "type": "object",
+      "properties": {
+        "active": {
+          "description": "Active set to true allows it to be displayed in the selection list for policies. Only visible to admins.",
+          "type": "boolean",
+          "x-go-name": "Active"
+        },
+        "code": {
+          "description": "Code is a unique three-letter identifier for an accounting entity",
+          "type": "string",
+          "x-go-name": "Code"
+        },
+        "id": {
+          "description": "unique ID",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "ID"
+        },
+        "income_account": {
+          "description": "IncomeAccount is the account use for income transactions. Only visible to admins.",
+          "type": "string",
+          "x-go-name": "IncomeAccount"
+        },
+        "name": {
+          "description": "Name is a succinct description of the entity code.",
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "parent_entity": {
+          "description": "ParentEntity is the parent entity code for grouping in reports. Only visible to admins.",
+          "type": "string",
+          "x-go-name": "ParentEntity"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "EntityCodeCreateInput": {
+      "type": "object",
+      "properties": {
+        "active": {
+          "description": "Active set to true allows it to be displayed in the selection list for policies. Only visible to admins.",
+          "type": "boolean",
+          "x-go-name": "Active"
+        },
+        "code": {
+          "description": "Code is a unique three-letter identifier for an accounting entity",
+          "type": "string",
+          "x-go-name": "Code"
+        },
+        "income_account": {
+          "description": "IncomeAccount is the account use for income transactions. Only visible to admins.",
+          "type": "string",
+          "x-go-name": "IncomeAccount"
+        },
+        "name": {
+          "description": "Name is a succinct description of the entity code.",
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "parent_entity": {
+          "description": "ParentEntity is the parent entity code for grouping in reports. Only visible to admins.",
+          "type": "string",
+          "x-go-name": "ParentEntity"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "EntityCodeInput": {
+      "type": "object",
+      "properties": {
+        "active": {
+          "description": "Active set to true allows it to be displayed in the selection list for policies. Only visible to admins.",
+          "type": "boolean",
+          "x-go-name": "Active"
+        },
+        "income_account": {
+          "description": "IncomeAccount is the account use for income transactions. Only visible to admins.",
+          "type": "string",
+          "x-go-name": "IncomeAccount"
+        },
+        "name": {
+          "description": "Name is a succinct description of the entity code.",
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "parent_entity": {
+          "description": "ParentEntity is the parent entity code for grouping in reports. Only visible to admins.",
+          "type": "string",
+          "x-go-name": "ParentEntity"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "EntityCodes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/EntityCode"
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "ErrorKey": {
+      "type": "string",
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "File": {
+      "description": "If the URL expiration time passes, a new query will refresh\nthe URL and the URL expiration time.",
+      "type": "object",
+      "title": "File metadata for images and other supported file types.",
+      "properties": {
+        "content_type": {
+          "description": "MIME content type, limited to 255 characters, e.g. 'image/jpeg'",
+          "type": "string",
+          "x-go-name": "ContentType"
+        },
+        "created_by_id": {
+          "description": "ID of file creator / owner",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "CreatedByID"
+        },
+        "id": {
+          "description": "unique identifier for the File object",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "ID"
+        },
+        "name": {
+          "description": "filename with extension, limited to 255 characters, e.g. `image.jpg`",
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "size": {
+          "description": "file size in bytes",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Size"
+        },
+        "url": {
+          "description": "file content can be loaded from the given URL if the expiration time has not passed, limited to 1,024 characters",
+          "type": "string",
+          "x-go-name": "URL"
+        },
+        "url_expiration": {
+          "description": "expiration time of the URL, re-issue the API request to get a new URL and expiration time",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "URLExpiration"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "Item": {
+      "description": "Item represents a single item on a policy",
+      "type": "object",
+      "properties": {
+        "accountable_person": {
+          "$ref": "#/definitions/AccountablePerson"
+        },
+        "annual_premium": {
+          "$ref": "#/definitions/Currency"
+        },
+        "can_be_deleted": {
+          "description": "Can the item be deleted? Set to false if the item is in a state that prevents it from being deleted.",
+          "type": "boolean",
+          "x-go-name": "CanBeDeleted"
+        },
+        "can_be_updated": {
+          "description": "Can the item be updated? Set to false if there is an active claim for the item.",
+          "type": "boolean",
+          "x-go-name": "CanBeUpdated"
+        },
+        "category": {
+          "$ref": "#/definitions/ItemCategory"
+        },
+        "country": {
+          "description": "country where item is located",
+          "type": "string",
+          "x-go-name": "Country"
+        },
+        "coverage_amount": {
+          "description": "coverage amount (0.01 USD)",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "CoverageAmount"
+        },
+        "coverage_end_date": {
+          "description": "date (yyyy-mm-dd) of item's coverage end date",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "CoverageEndDate"
+        },
+        "coverage_start_date": {
+          "description": "date (yyyy-mm-dd) of item's coverage start date",
+          "type": "string",
+          "x-go-name": "CoverageStartDate"
+        },
+        "coverage_status": {
+          "$ref": "#/definitions/ItemCoverageStatus"
+        },
+        "created_at": {
+          "description": "The time the item was created",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "CreatedAt"
+        },
+        "description": {
+          "description": "item description",
+          "type": "string",
+          "x-go-name": "Description"
+        },
+        "id": {
+          "description": "unique ID",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "ID"
+        },
+        "in_storage": {
+          "description": "is item in storage?",
+          "type": "boolean",
+          "x-go-name": "InStorage"
+        },
+        "make": {
+          "description": "make (manufacturer)",
+          "type": "string",
+          "x-go-name": "Make"
+        },
+        "model": {
+          "description": "model",
+          "type": "string",
+          "x-go-name": "Model"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "policy_id": {
+          "description": "policy ID",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "PolicyID"
+        },
+        "prorated_annual_premium": {
+          "$ref": "#/definitions/Currency"
+        },
+        "risk_category": {
+          "$ref": "#/definitions/RiskCategory"
+        },
+        "serial_number": {
+          "description": "serial number",
+          "type": "string",
+          "x-go-name": "SerialNumber"
+        },
+        "status_change": {
+          "description": "how the status changed most recently (for the stewards dashboard)",
+          "type": "string",
+          "x-go-name": "StatusChange"
+        },
+        "status_reason": {
+          "description": "message from a reviewer detailing the revisions needed",
+          "type": "string",
+          "x-go-name": "StatusReason"
+        },
+        "updated_at": {
+          "description": "The time the item was last updated",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "UpdatedAt"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "ItemCategories": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ItemCategory"
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "ItemCategory": {
+      "type": "object",
+      "properties": {
+        "created_at": {
+          "description": "date-time created",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "CreatedAt"
+        },
+        "help_text": {
+          "description": "help text",
+          "type": "string",
+          "x-go-name": "HelpText"
+        },
+        "id": {
+          "description": "unique ID",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "ID"
+        },
+        "name": {
+          "description": "name",
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "require_make_model": {
+          "description": "whether make and model are required in order for item coverage to be auto approved",
+          "type": "boolean",
+          "x-go-name": "RequireMakeModel"
+        },
+        "risk_category": {
+          "$ref": "#/definitions/RiskCategory"
+        },
+        "updated_at": {
+          "description": "date-time last updated",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "UpdatedAt"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "ItemCategoryStatus": {
+      "description": "may be one of: Draft, Enabled, Deprecated, Disabled",
+      "type": "string",
+      "title": "ItemCategoryStatus",
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "ItemCoverageStatus": {
+      "description": "may be one of: Draft, Pending, Revision, Approved, Denied, Inactive",
+      "type": "string",
+      "title": "ItemCoverageStatus",
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "ItemCreate": {
+      "description": "ItemCreate represents payload for adding an item",
+      "type": "object",
+      "properties": {
+        "accountable_person_id": {
+          "description": "Accountable person ID. Can be either a policy dependent ID or a user ID",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "AccountablePersonID"
+        },
+        "category_id": {
+          "description": "category ID",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "CategoryID"
+        },
+        "country": {
+          "description": "country where item is located",
+          "type": "string",
+          "x-go-name": "Country"
+        },
+        "coverage_amount": {
+          "description": "coverage amount (0.01 USD)",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "CoverageAmount"
+        },
+        "coverage_end_date": {
+          "description": "date (yyyy-mm-dd) of item's coverage end date, optional",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "CoverageEndDate"
+        },
+        "coverage_start_date": {
+          "description": "date (yyyy-mm-dd) of item's coverage start date",
+          "type": "string",
+          "x-go-name": "CoverageStartDate"
+        },
+        "coverage_status": {
+          "$ref": "#/definitions/ItemCoverageStatus"
+        },
+        "description": {
+          "description": "item description",
+          "type": "string",
+          "x-go-name": "Description"
+        },
+        "in_storage": {
+          "description": "is item in storage?",
+          "type": "boolean",
+          "x-go-name": "InStorage"
+        },
+        "make": {
+          "description": "make (manufacturer)",
+          "type": "string",
+          "x-go-name": "Make"
+        },
+        "model": {
+          "description": "model",
+          "type": "string",
+          "x-go-name": "Model"
+        },
+        "name": {
+          "description": "name",
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "risk_category_id": {
+          "description": "risk category ID, should only be set if the user has adequate permissions to override the risk category\nassigned to the item's category",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "RiskCategoryID"
+        },
+        "serial_number": {
+          "description": "serial number",
+          "type": "string",
+          "x-go-name": "SerialNumber"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "ItemStatusInput": {
+      "type": "object",
+      "properties": {
+        "status_reason": {
+          "description": "message from a reviewer detailing the revisions needed or the reason for denial",
+          "type": "string",
+          "x-go-name": "StatusReason"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "ItemUpdate": {
+      "description": "ItemUpdate represents payload for updating an item",
+      "type": "object",
+      "properties": {
+        "accountable_person_id": {
+          "description": "Accountable person ID. Can be either a policy dependent ID or a user ID",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "AccountablePersonID"
+        },
+        "category_id": {
+          "description": "category ID",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "CategoryID"
+        },
+        "country": {
+          "description": "country where item is located",
+          "type": "string",
+          "x-go-name": "Country"
+        },
+        "coverage_amount": {
+          "description": "coverage amount (0.01 USD)",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "CoverageAmount"
+        },
+        "description": {
+          "description": "item description",
+          "type": "string",
+          "x-go-name": "Description"
+        },
+        "in_storage": {
+          "description": "is item in storage?",
+          "type": "boolean",
+          "x-go-name": "InStorage"
+        },
+        "make": {
+          "description": "make (manufacturer)",
+          "type": "string",
+          "x-go-name": "Make"
+        },
+        "model": {
+          "description": "model",
+          "type": "string",
+          "x-go-name": "Model"
+        },
+        "name": {
+          "description": "name",
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "risk_category_id": {
+          "description": "risk category ID, should only be set if the user has adequate permissions to override the risk category\nassigned to the item's category",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "RiskCategoryID"
+        },
+        "serial_number": {
+          "description": "serial number",
+          "type": "string",
+          "x-go-name": "SerialNumber"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "Items": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Item"
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "LedgerEntries": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/LedgerEntry"
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "LedgerEntry": {
+      "type": "object",
+      "properties": {
+        "account_number": {
+          "type": "string",
+          "x-go-name": "AccountNumber"
+        },
+        "amount": {
+          "$ref": "#/definitions/Currency"
+        },
+        "claim_id": {
+          "description": "claim ID",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "ClaimID"
+        },
+        "cost_center": {
+          "type": "string",
+          "x-go-name": "CostCenter"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "CreatedAt"
+        },
+        "date_entered": {
+          "description": "date entered into accounting system",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "DateEntered"
+        },
+        "date_submitted": {
+          "description": "date added to ledger",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "DateSubmitted"
+        },
+        "entity_code": {
+          "type": "string",
+          "x-go-name": "EntityCode"
+        },
+        "household_id": {
+          "type": "string",
+          "x-go-name": "HouseholdID"
+        },
+        "id": {
+          "description": "unique ID",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "ID"
+        },
+        "income_account": {
+          "type": "string",
+          "x-go-name": "IncomeAccount"
+        },
+        "item_id": {
+          "description": "item ID",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "ItemID"
+        },
+        "name": {
+          "description": "name of accountable person if available",
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "policy_id": {
+          "description": "policy ID",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "PolicyID"
+        },
+        "policy_name": {
+          "type": "string",
+          "x-go-name": "PolicyName"
+        },
+        "policy_type": {
+          "$ref": "#/definitions/PolicyType"
+        },
+        "risk_category_cc": {
+          "type": "string",
+          "x-go-name": "RiskCategoryCC"
+        },
+        "risk_category_name": {
+          "type": "string",
+          "x-go-name": "RiskCategoryName"
+        },
+        "type": {
+          "$ref": "#/definitions/LedgerEntryType"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "UpdatedAt"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "LedgerEntryType": {
+      "type": "string",
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "LedgerReport": {
+      "type": "object",
+      "properties": {
+        "created_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "CreatedAt"
+        },
+        "date": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "Date"
+        },
+        "file": {
+          "$ref": "#/definitions/File"
+        },
+        "id": {
+          "type": "string",
+          "format": "uuid",
+          "x-go-name": "ID"
+        },
+        "is_cleared": {
+          "type": "boolean",
+          "x-go-name": "IsCleared"
+        },
+        "transaction_count": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "TransactionCount"
+        },
+        "type": {
+          "type": "string",
+          "x-go-name": "Type"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "UpdatedAt"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "LedgerReportCreateInput": {
+      "type": "object",
+      "properties": {
+        "date": {
+          "description": "Report date, e.g. return the ledger entries prior to the given date. Details vary by the report type.",
+          "type": "string",
+          "x-go-name": "Date"
+        },
+        "type": {
+          "description": "Report types:\n+ `monthly` - Return all ledger entries not yet reconciled, up to the beginning of the given date.\n+ `annual` - Return the policy renewal entries for the year of the given date.",
+          "type": "string",
+          "x-go-name": "Type"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "LedgerReports": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/LedgerReport"
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "LedgerTable": {
+      "type": "object",
+      "properties": {
+        "coverage_value": {
+          "$ref": "#/definitions/Currency"
+        },
+        "entries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LedgerTableEntry"
+          },
+          "x-go-name": "Entries"
+        },
+        "last_changed": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "LastChanged"
+        },
+        "net_transactions": {
+          "$ref": "#/definitions/Currency"
+        },
+        "payout_total": {
+          "$ref": "#/definitions/Currency"
+        },
+        "premium_rate": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "PremiumRate"
+        },
+        "premium_total": {
+          "$ref": "#/definitions/Currency"
+        },
+        "report_month": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "ReportMonth"
+        },
+        "report_year": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "ReportYear"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "LedgerTableEntry": {
+      "type": "object",
+      "properties": {
+        "assigned_to": {
+          "type": "string",
+          "x-go-name": "AssignedTo"
+        },
+        "date": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "Date"
+        },
+        "item_name": {
+          "type": "string",
+          "x-go-name": "ItemName"
+        },
+        "location": {
+          "type": "string",
+          "x-go-name": "Location"
+        },
+        "status_after": {
+          "type": "string",
+          "x-go-name": "StatusAfter"
+        },
+        "status_before": {
+          "type": "string",
+          "x-go-name": "StatusBefore"
+        },
+        "type": {
+          "type": "string",
+          "x-go-name": "Type"
+        },
+        "value": {
+          "$ref": "#/definitions/Currency"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "ListResponse": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "description": "Data containing the relevant list type",
+          "x-go-name": "Data"
+        },
+        "meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "Meta": {
+      "description": "TODO: implement Meta type to provide pagination properties",
+      "type": "object",
+      "properties": {
+        "current_entries_size": {
+          "description": "Total records returns, will be \u003c= PerPage",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "CurrentEntriesSize"
+        },
+        "offset": {
+          "description": "Page * PerPage (ex: 2 * 20, Offset == 40)",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Offset"
+        },
+        "page": {
+          "description": "Current page you're on",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Page"
+        },
+        "per_page": {
+          "description": "Number of results you want per page",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "PerPage"
+        },
+        "total_entries_size": {
+          "description": "Total potential records matching the query",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "TotalEntriesSize"
+        },
+        "total_pages": {
+          "description": "Total pages",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "TotalPages"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "Paginator": {
+      "description": "Paginator is a type used to represent the pagination of records\nfrom the database.",
+      "type": "object",
+      "properties": {
+        "current_entries_size": {
+          "description": "Total records returns, will be \u003c= PerPage",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "CurrentEntriesSize"
+        },
+        "offset": {
+          "description": "Page * PerPage (ex: 2 * 20, Offset == 40)",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Offset"
+        },
+        "page": {
+          "description": "Current page you're on",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Page"
+        },
+        "per_page": {
+          "description": "Number of results you want per page",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "PerPage"
+        },
+        "total_entries_size": {
+          "description": "Total potential records matching the query",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "TotalEntriesSize"
+        },
+        "total_pages": {
+          "description": "Total pages",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "TotalPages"
+        }
+      },
+      "x-go-package": "github.com/gobuffalo/pop/v6"
+    },
+    "PayoutOption": {
+      "description": "may be one of: Repair, Replacement, FMV, FixedFraction",
+      "type": "string",
+      "title": "PayoutOption",
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "Policies": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Policy"
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "Policy": {
+      "description": "Policy represents a single policy, either household or team",
+      "type": "object",
+      "properties": {
+        "account": {
+          "description": "Account code for billing",
+          "type": "string",
+          "x-go-name": "Account"
+        },
+        "account_detail": {
+          "description": "AccountDetail allows for optional detail to route transactions. e.g.: \"Nigeria Grp Off-Ins\"",
+          "type": "string",
+          "x-go-name": "AccountDetail"
+        },
+        "claims": {
+          "$ref": "#/definitions/Claims"
+        },
+        "cost_center": {
+          "description": "Cost center for billing",
+          "type": "string",
+          "x-go-name": "CostCenter"
+        },
+        "created_at": {
+          "description": "The time the policy was created",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "CreatedAt"
+        },
+        "dependents": {
+          "$ref": "#/definitions/PolicyDependents"
+        },
+        "entity_code": {
+          "$ref": "#/definitions/EntityCode"
+        },
+        "household_id": {
+          "description": "Household ID for billing",
+          "type": "string",
+          "x-go-name": "HouseholdID"
+        },
+        "id": {
+          "description": "unique ID",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "ID"
+        },
+        "invites": {
+          "$ref": "#/definitions/PolicyUserInvites"
+        },
+        "ledger_reports": {
+          "$ref": "#/definitions/LedgerReports"
+        },
+        "members": {
+          "$ref": "#/definitions/PolicyMembers"
+        },
+        "name": {
+          "description": "policy name",
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "strikes": {
+          "$ref": "#/definitions/Strikes"
+        },
+        "type": {
+          "$ref": "#/definitions/PolicyType"
+        },
+        "updated_at": {
+          "description": "The time the policy was last updated",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "UpdatedAt"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "PolicyCreate": {
+      "description": "PolicyCreate represents payload for creating a policy",
+      "type": "object",
+      "properties": {
+        "account": {
+          "description": "Account code for billing. Only required/allowed on Team type policies.",
+          "type": "string",
+          "x-go-name": "Account"
+        },
+        "account_detail": {
+          "description": "AccountDetail allows for optional detail to route transactions. e.g.: \"Nigeria Grp Off-Ins\"",
+          "type": "string",
+          "x-go-name": "AccountDetail"
+        },
+        "cost_center": {
+          "description": "Cost center for billing. Only required/allowed on Team type policies.",
+          "type": "string",
+          "x-go-name": "CostCenter"
+        },
+        "entity_code": {
+          "description": "Entity code for billing. Only required/allowed on Team type policies.",
+          "type": "string",
+          "x-go-name": "EntityCode"
+        },
+        "name": {
+          "description": "policy name",
+          "type": "string",
+          "x-go-name": "Name"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "PolicyDependent": {
+      "type": "object",
+      "properties": {
+        "child_birth_year": {
+          "description": "birth year of child",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "ChildBirthYear"
+        },
+        "country": {
+          "description": "dependent location",
+          "type": "string",
+          "x-go-name": "Country"
+        },
+        "id": {
+          "description": "unique ID",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "ID"
+        },
+        "name": {
+          "description": "dependent name",
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "relationship": {
+          "$ref": "#/definitions/PolicyDependentRelationship"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "PolicyDependentInput": {
+      "type": "object",
+      "properties": {
+        "child_birth_year": {
+          "description": "birth year of child",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "ChildBirthYear"
+        },
+        "country": {
+          "description": "dependent location",
+          "type": "string",
+          "x-go-name": "Country"
+        },
+        "name": {
+          "description": "dependent name",
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "relationship": {
+          "$ref": "#/definitions/PolicyDependentRelationship"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "PolicyDependentRelationship": {
+      "description": "may be one of: Spouse, Child",
+      "type": "string",
+      "title": "PolicyDependentRelationship",
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "PolicyDependents": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PolicyDependent"
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "PolicyLedgerReportCreateInput": {
+      "type": "object",
+      "properties": {
+        "month": {
+          "description": "Report month, e.g. return the policy's ledger entries entered in that month and year.\nThe month and year (together) must not be in the future.\nFor annual reports only, the month may be 0.",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Month"
+        },
+        "type": {
+          "description": "Report types:\n+ `Monthly` - Return all ledger entries not yet reconciled, up to the beginning of the given date.\n+ `Annual` - Return the policy renewal entries for the year of the given date.",
+          "type": "string",
+          "x-go-name": "Type"
+        },
+        "year": {
+          "description": "Report year, e.g. return the policy's ledger entries entered in that year.",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Year"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "PolicyMember": {
+      "type": "object",
+      "properties": {
+        "country": {
+          "description": "a country",
+          "type": "string",
+          "x-go-name": "Country"
+        },
+        "email": {
+          "description": "email address",
+          "type": "string",
+          "x-go-name": "Email"
+        },
+        "email_override": {
+          "description": "email address",
+          "type": "string",
+          "x-go-name": "EmailOverride"
+        },
+        "first_name": {
+          "description": "first name",
+          "type": "string",
+          "x-go-name": "FirstName"
+        },
+        "id": {
+          "description": "unique ID",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "ID"
+        },
+        "last_login_utc": {
+          "description": "last login time (UTC)",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "LastLoginUTC"
+        },
+        "last_name": {
+          "description": "last name",
+          "type": "string",
+          "x-go-name": "LastName"
+        },
+        "policy_user_id": {
+          "description": "ID of the PolicyUser object that is related to this policy and user",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "PolicyUserID"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "PolicyMembers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PolicyMember"
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "PolicyType": {
+      "description": "may be one of: Household, Team",
+      "type": "string",
+      "title": "PolicyType",
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "PolicyUpdate": {
+      "description": "PolicyUpdate represents payload for updating a policy",
+      "type": "object",
+      "properties": {
+        "account": {
+          "description": "Account code for billing. Only required/allowed on Team type policies.",
+          "type": "string",
+          "x-go-name": "Account"
+        },
+        "account_detail": {
+          "description": "AccountDetail allows for optional detail to route transactions. e.g.: \"Nigeria Grp Off-Ins\"",
+          "type": "string",
+          "x-go-name": "AccountDetail"
+        },
+        "cost_center": {
+          "description": "Cost center for billing. Only required/allowed on Team type policies.",
+          "type": "string",
+          "x-go-name": "CostCenter"
+        },
+        "entity_code": {
+          "description": "Entity code for billing. Only required/allowed on Team type policies.",
+          "type": "string",
+          "x-go-name": "EntityCode"
+        },
+        "household_id": {
+          "description": "Household ID for billing. Only required/allowed on Household type policies.",
+          "type": "string",
+          "x-go-name": "HouseholdID"
+        },
+        "name": {
+          "description": "policy name",
+          "type": "string",
+          "x-go-name": "Name"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "PolicyUserInvite": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "description": "invitee's email",
+          "type": "string",
+          "x-go-name": "Email"
+        },
+        "email_sent_at": {
+          "description": "date and time when invite email was sent (omitted if empty)",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "EmailSentAt"
+        },
+        "name": {
+          "description": "invitee's name",
+          "type": "string",
+          "x-go-name": "Name"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "PolicyUserInviteCreate": {
+      "description": "input model for creating policy user invites",
+      "type": "object",
+      "title": "PolicyUserInviteCreate",
+      "required": [
+        "email",
+        "name"
+      ],
+      "properties": {
+        "email": {
+          "description": "invitee's email address",
+          "type": "string",
+          "x-go-name": "Email"
+        },
+        "inviter_message": {
+          "description": "A personal message from inviter to include in invite email",
+          "type": "string",
+          "x-go-name": "InviterMessage"
+        },
+        "name": {
+          "description": "invitee's name",
+          "type": "string",
+          "x-go-name": "Name"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "PolicyUserInvites": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PolicyUserInvite"
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "RecentClaim": {
+      "type": "object",
+      "properties": {
+        "Claim": {
+          "$ref": "#/definitions/Claim"
+        },
+        "StatusUpdatedAt": {
+          "description": "The time the claim had its status changed",
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "RecentClaims": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/RecentClaim"
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "RecentItem": {
+      "type": "object",
+      "properties": {
+        "Item": {
+          "$ref": "#/definitions/Item"
+        },
+        "StatusUpdatedAt": {
+          "description": "The time the item had its coverage_status changed",
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "RecentItems": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/RecentItem"
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "RecentObjects": {
+      "type": "object",
+      "properties": {
+        "Claims": {
+          "$ref": "#/definitions/RecentClaims"
+        },
+        "Items": {
+          "$ref": "#/definitions/RecentItems"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "RepairResult": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "$ref": "#/definitions/Items"
+        },
+        "repair_type": {
+          "type": "string",
+          "x-go-name": "RepairType"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "RepairRunInput": {
+      "type": "object",
+      "properties": {
+        "date": {
+          "type": "string",
+          "x-go-name": "Date"
+        },
+        "repair_type": {
+          "type": "string",
+          "x-go-name": "RepairType"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "RiskCategories": {
+      "description": "RiskCategories is a slice of RiskCategory objects",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/RiskCategory"
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "RiskCategory": {
+      "description": "RiskCategory represents an item category's risk category",
+      "type": "object",
+      "properties": {
+        "cost_center": {
+          "description": "financial cost center code used for crediting the transactions that use this risk category",
+          "type": "string",
+          "x-go-name": "CostCenter"
+        },
+        "created_at": {
+          "description": "created date",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "CreatedAt"
+        },
+        "id": {
+          "description": "unique ID",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "ID"
+        },
+        "name": {
+          "description": "risk category name",
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "policy_max": {
+          "description": "maximum coverage per policy (0.01 USD)",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "PolicyMax"
+        },
+        "updated_at": {
+          "description": "updated date",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "UpdatedAt"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "Strike": {
+      "type": "object",
+      "properties": {
+        "created_at": {
+          "description": "The time the strike was created",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "CreatedAt"
+        },
+        "description": {
+          "description": "strike description",
+          "type": "string",
+          "x-go-name": "Description"
+        },
+        "id": {
+          "description": "unique ID",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "ID"
+        },
+        "policy_id": {
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "PolicyID"
+        },
+        "updated_at": {
+          "description": "The time the strike was updated",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "UpdatedAt"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "StrikeInput": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "strike description",
+          "type": "string",
+          "x-go-name": "Description"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "Strikes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Strike"
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "UUID": {
+      "description": "UUID can be used with the standard sql package to represent a\nUUID value that can be NULL in the database",
+      "type": "object",
+      "properties": {
+        "UUID": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "Valid": {
+          "type": "boolean"
+        }
+      },
+      "x-go-package": "github.com/gobuffalo/nulls"
+    },
+    "UploadResponse": {
+      "description": "UploadResponse is a JSON response for the /upload endpoint",
+      "type": "object",
+      "properties": {
+        "content_type": {
+          "type": "string",
+          "x-go-name": "ContentType"
+        },
+        "filename": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "id": {
+          "type": "string",
+          "x-go-name": "ID"
+        },
+        "size": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Size"
+        },
+        "url": {
+          "type": "string",
+          "x-go-name": "URL"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/actions"
+    },
+    "User": {
+      "description": "app user",
+      "type": "object",
+      "properties": {
+        "app_role": {
+          "description": "role in the application ('User', 'Steward', 'Signator', 'Admin')",
+          "type": "string",
+          "x-go-name": "AppRole"
+        },
+        "country": {
+          "description": "country",
+          "type": "string",
+          "x-go-name": "Country"
+        },
+        "email": {
+          "description": "email address",
+          "type": "string",
+          "x-go-name": "Email"
+        },
+        "email_override": {
+          "description": "email address",
+          "type": "string",
+          "x-go-name": "EmailOverride"
+        },
+        "first_name": {
+          "description": "first name",
+          "type": "string",
+          "x-go-name": "FirstName"
+        },
+        "id": {
+          "description": "unique ID",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "ID"
+        },
+        "last_login_utc": {
+          "description": "last login date and time (UTC)",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "LastLoginUTC"
+        },
+        "last_name": {
+          "description": "last name",
+          "type": "string",
+          "x-go-name": "LastName"
+        },
+        "name": {
+          "description": "full name",
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "photo_file": {
+          "$ref": "#/definitions/File"
+        },
+        "photo_file_id": {
+          "description": "unique id (uuid) for a avatar or photo file",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "PhotoFileID"
+        },
+        "policies": {
+          "$ref": "#/definitions/Policies"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "UserFileAttachInput": {
+      "type": "object",
+      "properties": {
+        "file_id": {
+          "description": "File ID to attach to the current user",
+          "type": "string",
+          "format": "uuid4",
+          "x-go-name": "FileID"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "UserInput": {
+      "description": "app user update input",
+      "type": "object",
+      "properties": {
+        "country": {
+          "description": "country",
+          "type": "string",
+          "x-go-name": "Country"
+        },
+        "email_override": {
+          "description": "email address",
+          "type": "string",
+          "x-go-name": "EmailOverride"
+        }
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "Users": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/User"
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    }
+  },
+  "securityDefinitions": {
+    "oauth2": {
+      "type": "oauth2",
+      "flow": "implicit",
+      "authorizationUrl": "/auth/login",
+      "tokenUrl": "/auth/token",
+      "scopes": {
+        "all": "scopes are not used at this time"
+      }
+    }
+  },
+  "security": [
+    {
+      "oauth2": []
+    }
+  ]
+}

--- a/application/swagger.json
+++ b/application/swagger.json
@@ -1671,6 +1671,7 @@
         "tags": [
           "Files"
         ],
+        "summary": "UploadFile",
         "operationId": "UploadFile",
         "parameters": [
           {


### PR DESCRIPTION
### Added
- Add swagger.json to version control to monitor for changes. (You can look at the commits after the first one (5aea97c) to identify swagger changes made in this PR.)

### Fixed
- Formatted swagger yaml specs as code blocks to prevent gofmt from changing them. (Start each line with `//` and a single tab character.)
- Removed empty lines that would trigger gofmt to add a header format character (`#`).