### PR TITLE
define init sequence in preparation for Go 1.21

### DIFF
--- a/application/actions/actions.go
+++ b/application/actions/actions.go
@@ -16,15 +16,9 @@ import (
 	"github.com/silinternational/cover-api/log"
 )
 
-var r *render.Engine
-
-func Init() {
-	r = render.New(render.Options{
-		DefaultContentType: domain.ContentJson,
-	})
-
-	checkSamlConfig()
-}
+var r = render.New(render.Options{
+	DefaultContentType: domain.ContentJson,
+})
 
 // StrictBind hydrates a struct with values from a POST
 // REMEMBER the request body must have *exported* fields.

--- a/application/actions/actions.go
+++ b/application/actions/actions.go
@@ -18,7 +18,7 @@ import (
 
 var r *render.Engine
 
-func init() {
+func Init() {
 	r = render.New(render.Options{
 		DefaultContentType: domain.ContentJson,
 	})

--- a/application/actions/actions_test.go
+++ b/application/actions/actions_test.go
@@ -45,6 +45,7 @@ func Test_ActionSuite(t *testing.T) {
 	}
 	c, err := pop.Connect("test")
 	if err == nil {
+		models.DB = c
 		as.DB = c
 	}
 	suite.Run(t, as)

--- a/application/actions/app.go
+++ b/application/actions/app.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gorilla/sessions"
 	"github.com/rs/cors"
 
+	"github.com/silinternational/cover-api/auth"
 	"github.com/silinternational/cover-api/job"
 	"github.com/silinternational/cover-api/log"
 
@@ -90,6 +91,10 @@ var app *buffalo.App
 // declared after it to never be called.
 func App() *buffalo.App {
 	if app == nil {
+		domain.Init()
+		auth.Init()
+		models.Init()
+
 		app = buffalo.New(buffalo.Options{
 			Env:    domain.Env.GoEnv,
 			Logger: logger.Logrus{FieldLogger: log.ErrLogger.LocalLog},

--- a/application/actions/auth.go
+++ b/application/actions/auth.go
@@ -363,36 +363,3 @@ func authDestroy(c buffalo.Context) error {
 func replaceNewLines(input string) string {
 	return strings.Replace(input, `\n`, "\n", -1)
 }
-
-func checkSamlConfig() {
-	if domain.Env.GoEnv == domain.EnvDevelopment || domain.Env.GoEnv == domain.EnvTest {
-		return
-	}
-	if domain.Env.SamlIdpEntityId == "" {
-		panic("required SAML variable SamlIdpEntityId is undefined")
-	}
-	if domain.Env.SamlSpEntityId == "" {
-		panic("required SAML variable SamlSpEntityId is undefined")
-	}
-	if domain.Env.SamlSsoURL == "" {
-		panic("required SAML variable SamlSsoURL is undefined")
-	}
-	if domain.Env.SamlSloURL == "" {
-		panic("required SAML variable SamlSloURL is undefined")
-	}
-	if domain.Env.SamlAudienceUri == "" {
-		panic("required SAML variable SamlAudienceUri is undefined")
-	}
-	if domain.Env.SamlAssertionConsumerServiceUrl == "" {
-		panic("required SAML variable SamlAssertionConsumerServiceUrl is undefined")
-	}
-	if domain.Env.SamlIdpCert == "" {
-		panic("required SAML variable SamlIdpCert is undefined")
-	}
-	if domain.Env.SamlSpCert == "" {
-		panic("required SAML variable SamlSpCert is undefined")
-	}
-	if domain.Env.SamlSpPrivateKey == "" {
-		panic("required SAML variable SamlSpPrivateKey is undefined")
-	}
-}

--- a/application/auth/oauthstate.go
+++ b/application/auth/oauthstate.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gorilla/sessions"
 	"github.com/markbates/goth"
+
 	"github.com/silinternational/cover-api/domain"
 )
 
@@ -27,7 +28,7 @@ var (
 
 var keySet = false
 
-func init() {
+func Init() {
 	key := []byte(domain.Env.SessionSecret)
 	keySet = len(key) != 0
 

--- a/application/cmd/app/main.go
+++ b/application/cmd/app/main.go
@@ -13,10 +13,8 @@ import (
 	"github.com/gobuffalo/buffalo/servers"
 
 	"github.com/silinternational/cover-api/actions"
-	"github.com/silinternational/cover-api/auth"
 	"github.com/silinternational/cover-api/domain"
 	"github.com/silinternational/cover-api/log"
-	"github.com/silinternational/cover-api/models"
 )
 
 // main is the starting point for your Buffalo application.
@@ -26,11 +24,6 @@ import (
 // call `app.Serve()`, unless you don't want to start your
 // application that is. :)
 func main() {
-	domain.Init()
-	actions.Init()
-	auth.Init()
-	models.Init()
-
 	srv, err := getServer()
 	if err != nil {
 		log.Fatal(err)

--- a/application/cmd/app/main.go
+++ b/application/cmd/app/main.go
@@ -13,8 +13,10 @@ import (
 	"github.com/gobuffalo/buffalo/servers"
 
 	"github.com/silinternational/cover-api/actions"
+	"github.com/silinternational/cover-api/auth"
 	"github.com/silinternational/cover-api/domain"
 	"github.com/silinternational/cover-api/log"
+	"github.com/silinternational/cover-api/models"
 )
 
 // main is the starting point for your Buffalo application.
@@ -24,6 +26,11 @@ import (
 // call `app.Serve()`, unless you don't want to start your
 // application that is. :)
 func main() {
+	domain.Init()
+	actions.Init()
+	auth.Init()
+	models.Init()
+
 	srv, err := getServer()
 	if err != nil {
 		log.Fatal(err)

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -245,8 +245,8 @@ func readEnv() *EnvStruct {
 	env.PolicyMaxCoverage *= CurrencyFactor
 	env.DependentAutoApproveMax *= CurrencyFactor
 	env.PremiumMinimum *= CurrencyFactor
-	env.RepairThresholdString = fmt.Sprintf("%.2g%%", env.RepairThreshold*100)
-	env.DeductibleMinimumString = fmt.Sprintf("%.2g%%", env.Deductible*100)
+	env.RepairThresholdString = fmt.Sprintf("%.2g%%", env.RepairThreshold*CurrencyFactor)
+	env.DeductibleMinimumString = fmt.Sprintf("%.2g%%", env.Deductible*CurrencyFactor)
 
 	//  Set an arbitrary but reasonable minimum lifetime for policy strikes
 	if env.StrikeLifetimeMonths < 2 {

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -212,7 +212,7 @@ var Env struct {
 	SandboxEmailAddress string `default:"" split_words:"true"`
 }
 
-func init() {
+func Init() {
 	readEnv()
 
 	AuthCallbackURL = Env.ApiBaseURL + "/auth/callback"

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -25,7 +25,7 @@ import (
 //go:embed commit.txt
 var Commit string
 
-var AuthCallbackURL = Env.ApiBaseURL + "/auth/callback"
+var AuthCallbackURL string
 
 // T is the Buffalo i18n translator
 var T *mwi18n.Translator
@@ -118,7 +118,7 @@ const (
 )
 
 // redirect url for after logout
-var LogoutRedirectURL = Env.UIURL + "/logged-out"
+var LogoutRedirectURL = "missing.ui.url/logged-out"
 
 // EnvDevelopment is used for various debugging aids
 const EnvDevelopment = "development"
@@ -215,6 +215,10 @@ type EnvStruct struct {
 }
 
 func Init() {
+	AuthCallbackURL = Env.ApiBaseURL + "/auth/callback"
+
+	LogoutRedirectURL = Env.UIURL + "/logged-out"
+
 	log.ErrLogger.Init(
 		log.UseCommit(strings.TrimSpace(Commit)),
 		log.UseEnv(Env.GoEnv),

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/gobuffalo/buffalo"
-	"github.com/gobuffalo/envy"
 	mwi18n "github.com/gobuffalo/mw-i18n/v2"
 	"github.com/gofrs/uuid"
 	"github.com/kelseyhightower/envconfig"
@@ -133,7 +132,7 @@ const EnvTest = "test"
 var Env = readEnv()
 
 type EnvStruct struct {
-	GoEnv                      string `ignored:"true"`
+	GoEnv                      string `default:"development" split_words:"true"`
 	ApiBaseURL                 string `required:"true" split_words:"true"`
 	AccessTokenLifetimeSeconds int    `default:"1166400" split_words:"true"` // 13.5 days
 	AppName                    string `default:"Cover" split_words:"true"`
@@ -253,9 +252,6 @@ func readEnv() *EnvStruct {
 	if env.StrikeLifetimeMonths < 2 {
 		env.StrikeLifetimeMonths = 2
 	}
-
-	// Doing this separately to avoid needing two environment variables for the same thing
-	env.GoEnv = envy.Get("GO_ENV", EnvDevelopment)
 
 	return env
 }

--- a/application/grifts/db.go
+++ b/application/grifts/db.go
@@ -22,6 +22,8 @@ import (
 var _ = grift.Namespace("db", func() {
 	grift.Desc("seed", "Seeds a database")
 	_ = grift.Add("seed", func(c *grift.Context) error {
+		models.Init()
+
 		countUsers := models.Users{}
 		count, err := models.DB.Count(countUsers)
 		if err != nil {

--- a/application/listeners/listeners_test.go
+++ b/application/listeners/listeners_test.go
@@ -33,6 +33,7 @@ func Test_TestSuite(t *testing.T) {
 	ts := &TestSuite{}
 	c, err := pop.Connect(domain.Env.GoEnv)
 	if err == nil {
+		models.DB = c
 		ts.DB = c
 	}
 	suite.Run(t, ts)

--- a/application/log/log.go
+++ b/application/log/log.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ErrLogger is an instance of ErrLogProxy, which can be used without access to the Buffalo context.
-var ErrLogger ErrLogProxy
+var ErrLogger = ErrLogProxy{LocalLog: logrus.StandardLogger()}
 
 // ErrLogProxy wraps a logrus logger with optional hooks for sending to remote loggers like Sentry
 type ErrLogProxy struct {

--- a/application/messages/messages_test.go
+++ b/application/messages/messages_test.go
@@ -33,6 +33,7 @@ func Test_TestSuite(t *testing.T) {
 	ts := &TestSuite{}
 	c, err := pop.Connect(domain.Env.GoEnv)
 	if err == nil {
+		models.DB = c
 		ts.DB = c
 	}
 	suite.Run(t, ts)

--- a/application/models/entitycode.go
+++ b/application/models/entitycode.go
@@ -12,7 +12,7 @@ import (
 
 const HouseholdEntityIDString = "5f181e39-0a2a-49ac-8796-2f3a3de9fcbd"
 
-var householdEntityID uuid.UUID
+var householdEntityID = uuid.FromStringOrNil(HouseholdEntityIDString)
 
 type EntityCodes []EntityCode
 

--- a/application/models/models.go
+++ b/application/models/models.go
@@ -161,7 +161,7 @@ type FieldUpdate struct {
 	NewValue  string
 }
 
-func init() {
+func Init() {
 	var err error
 	env := domain.Env.GoEnv
 	DB, err = pop.Connect(env)

--- a/application/models/models_test.go
+++ b/application/models/models_test.go
@@ -35,6 +35,7 @@ func Test_ModelSuite(t *testing.T) {
 	ms := &ModelSuite{}
 	c, err := pop.Connect(domain.Env.GoEnv)
 	if err == nil {
+		DB = c
 		ms.DB = c
 	}
 	suite.Run(t, ms)

--- a/application/models/validation.go
+++ b/application/models/validation.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Model validation tool
-var mValidate *validator.Validate
+var mValidate = validator.New()
 
 var fieldValidators = map[string]func(validator.FieldLevel) bool{
 	"appRole":                       validateAppRole,


### PR DESCRIPTION
### Changed
- Perform all package initialization from `main`. This avoids any possible bugs introduced by the new initialization sequence in Go 1.21.