### PR TITLE
fix TestNetSuite_Export test by ignoring the line number

### DIFF
--- a/application/fin/netsuite_test.go
+++ b/application/fin/netsuite_test.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -83,9 +82,6 @@ func TestNetSuite_Export(t *testing.T) {
 	files := r.File
 	require.Equal(t, 2, len(files))
 
-	// Find first instance of "<number>,"
-	re := regexp.MustCompile(`^(.*?)\d,(.*)$`)
-
 	for _, f := range files {
 		date := n.date.Format(domain.DateFormat)
 		name := f.Name[:len(f.Name)-4]
@@ -100,16 +96,12 @@ func TestNetSuite_Export(t *testing.T) {
 		body, err := io.ReadAll(contents)
 		require.NoError(t, err)
 
-		want := transaction1Row
+		// don't try to compare the row number since we can't guarantee the transaction batch ordering
+		want := transaction1Row[12:]
 		if name == "bar" {
-			want = transaction2Row
+			want = transaction2Row[12:]
 		}
 
-		// Replace the first instance of "<number>," with "\d,"
-		// So that map order will not affect test
-		// For example, 2023080000001 becomes 202308000000\d
-		want = re.ReplaceAllString(want, `$1\d,$2`)
-
-		require.Regexp(t, netSuiteHeader+want, string(body))
+		require.Contains(t, string(body), want)
 	}
 }

--- a/application/fin/netsuite_test.go
+++ b/application/fin/netsuite_test.go
@@ -96,11 +96,13 @@ func TestNetSuite_Export(t *testing.T) {
 		body, err := io.ReadAll(contents)
 		require.NoError(t, err)
 
-		// don't try to compare the row number since we can't guarantee the transaction batch ordering
-		want := transaction1Row[12:]
+		row := transaction1Row
 		if name == "bar" {
-			want = transaction2Row[12:]
+			row = transaction2Row
 		}
+
+		// don't try to compare the row number since we can't guarantee the transaction batch ordering
+		_, want, _ := strings.Cut(row, ",")
 
 		require.Contains(t, string(body), want)
 	}


### PR DESCRIPTION
### Fixed
- Fix the TestNetSuite_Export test by ignoring the line number.

Issue: [CVR-671](https://itse.youtrack.cloud/issue/CVR-671)