### PR TITLE
if country code is set, use the country name from the countries table

### DIFF
--- a/application/actions/dependents.go
+++ b/application/actions/dependents.go
@@ -36,7 +36,7 @@ func dependentsList(c buffalo.Context) error {
 	tx := models.Tx(c)
 	policy.LoadDependents(tx, false)
 
-	return renderOk(c, policy.Dependents.ConvertToAPI())
+	return renderOk(c, policy.Dependents.ConvertToAPI(tx))
 }
 
 // swagger:operation POST /policies/{id}/dependents PolicyDependents PolicyDependentsCreate
@@ -77,7 +77,7 @@ func dependentsCreate(c buffalo.Context) error {
 
 	policy.LoadDependents(tx, false)
 
-	return renderOk(c, dependent.ConvertToAPI())
+	return renderOk(c, dependent.ConvertToAPI(tx))
 }
 
 // swagger:operation PUT /policy-dependents/{id} PolicyDependents PolicyDependentsUpdate
@@ -120,7 +120,7 @@ func dependentsUpdate(c buffalo.Context) error {
 		return reportError(c, err)
 	}
 
-	output := dependent.ConvertToAPI()
+	output := dependent.ConvertToAPI(tx)
 	return c.Render(http.StatusOK, r.JSON(output))
 }
 

--- a/application/models/claim.go
+++ b/application/models/claim.go
@@ -416,8 +416,7 @@ func (c *Claim) AddItem(ctx context.Context, input api.ClaimItemCreateInput) (Cl
 }
 
 // SubmitForApproval changes the status of the claim to either Review1 or Review2
-//
-//	depending on its current status.
+// depending on its current status.
 func (c *Claim) SubmitForApproval(ctx context.Context) error {
 	tx := Tx(ctx)
 	user := CurrentUser(ctx)

--- a/application/models/item.go
+++ b/application/models/item.go
@@ -730,6 +730,7 @@ func (i *Item) Load(tx *pop.Connection) {
 
 func (i *Item) ConvertToAPI(tx *pop.Connection) api.Item {
 	i.Load(tx)
+	i.OverrideCountryName(tx)
 
 	var coverageEndDate *string
 	if i.CoverageEndDate.Valid {
@@ -1200,4 +1201,17 @@ func CountItemsToRenew(tx *pop.Connection, year int) (int, error) {
 		return 0, appErrorFromDB(err, api.ErrorQueryFailure)
 	}
 	return count, nil
+}
+
+func (i *Item) OverrideCountryName(tx *pop.Connection) {
+	if i.CountryCode == "" {
+		return
+	}
+
+	var country Country
+	if err := country.FindByCode(tx, i.CountryCode); err != nil {
+		log.Errorf("found invalid country code %q on item %s", i.CountryCode, i.ID)
+	} else {
+		i.Country = country.Name
+	}
 }

--- a/application/models/policy.go
+++ b/application/models/policy.go
@@ -304,7 +304,7 @@ func (p *Policy) hydrateApiPolicy(tx *pop.Connection, apiPolicy *api.Policy) {
 	p.LoadDependents(tx, true)
 	p.LoadInvites(tx, true)
 	apiPolicy.Claims = p.Claims.ConvertToAPI(tx)
-	apiPolicy.Dependents = p.Dependents.ConvertToAPI()
+	apiPolicy.Dependents = p.Dependents.ConvertToAPI(tx)
 	apiPolicy.Invites = p.Invites.ConvertToAPI()
 
 	var reports LedgerReports

--- a/application/models/policydependent_test.go
+++ b/application/models/policydependent_test.go
@@ -102,7 +102,7 @@ func (ms *ModelSuite) TestPolicyDependent_ConvertToAPI() {
 		ChildBirthYear: domain.RandomInsecureIntInRange(2000, 2020),
 	}
 
-	got := dependent.ConvertToAPI()
+	got := dependent.ConvertToAPI(ms.DB)
 
 	ms.Equal(dependent.ID, got.ID, "ID is not correct")
 	ms.Equal(dependent.Name, got.Name, "Name is not correct")

--- a/application/models/user.go
+++ b/application/models/user.go
@@ -490,6 +490,7 @@ func (u *Users) ConvertToAPI(tx *pop.Connection) api.Users {
 
 func (u *User) ConvertToAPI(tx *pop.Connection, hydrate bool) api.User {
 	u.LoadPhotoFile(tx)
+	u.OverrideCountryName(tx)
 
 	output := api.User{
 		ID:            u.ID,
@@ -522,5 +523,18 @@ func (u *User) GetLocation() Location {
 		City:    u.City,
 		State:   u.State,
 		Country: u.Country,
+	}
+}
+
+func (u *User) OverrideCountryName(tx *pop.Connection) {
+	if u.CountryCode == "" {
+		return
+	}
+
+	var country Country
+	if err := country.FindByCode(tx, u.CountryCode); err != nil {
+		log.Errorf("found invalid country code %q on user %s", u.CountryCode, u.ID)
+	} else {
+		u.Country = country.Name
 	}
 }


### PR DESCRIPTION
### Fixed
- Override the country name sent to the API with the name in the `countries` table.

YouTrack issue: [CVR-643](https://itse.youtrack.cloud/issue/CVR-643)