### PR TITLE
changed monthly premium calculation

### DIFF
--- a/application/api/items.go
+++ b/application/api/items.go
@@ -104,7 +104,7 @@ type Item struct {
 	ProratedAnnualPremium Currency `json:"prorated_annual_premium"`
 
 	// monthly premium (0.01 USD)
-	MonthlyPremium *Currency `json:"monthly_premium"`
+	MonthlyPremium Currency `json:"monthly_premium"`
 
 	// Accountable person assigned to the policy item
 	AccountablePerson AccountablePerson `json:"accountable_person"`

--- a/application/models/item.go
+++ b/application/models/item.go
@@ -704,7 +704,6 @@ func (i *Item) LoadPolicyMembers(tx *pop.Connection, reload bool) {
 	i.Policy.LoadMembers(tx, reload)
 }
 
-// TODO: split this into two functions (and add a `reload` parameter)
 // Load - a simple wrapper method for loading child objects
 func (i *Item) Load(tx *pop.Connection) {
 	if i.Category.ID == uuid.Nil {

--- a/application/models/item.go
+++ b/application/models/item.go
@@ -704,6 +704,7 @@ func (i *Item) LoadPolicyMembers(tx *pop.Connection, reload bool) {
 	i.Policy.LoadMembers(tx, reload)
 }
 
+// TODO: split this into two functions (and add a `reload` parameter)
 // Load - a simple wrapper method for loading child objects
 func (i *Item) Load(tx *pop.Connection) {
 	if i.Category.ID == uuid.Nil {
@@ -845,15 +846,15 @@ func (i *Item) CalculateProratedPremium(t time.Time) api.Currency {
 
 // CalculateMonthlyPremium returns the rounded product of the item's CoverageAmount and the category's
 // PremiumFactor divided by 12
-func (i *Item) CalculateMonthlyPremium(tx *pop.Connection) *api.Currency {
+func (i *Item) CalculateMonthlyPremium(tx *pop.Connection) api.Currency {
 	i.Load(tx)
-
 	if i.Category.PremiumFactor.Valid {
 		premium := api.Currency(math.Round(float64(i.CoverageAmount) * i.Category.PremiumFactor.Float64 / 12))
-		return &premium
+		return premium
+	} else {
+		premium := api.Currency(math.Round(float64(i.CoverageAmount) * domain.Env.PremiumFactor / 12))
+		return premium
 	}
-
-	return nil
 }
 
 // True if coverage on the item started in a previous year and the current

--- a/application/models/item.go
+++ b/application/models/item.go
@@ -843,12 +843,13 @@ func (i *Item) CalculateProratedPremium(t time.Time) api.Currency {
 	return api.Currency(p)
 }
 
-// CalculateMonthlyPremium returns the rounded product of the item's CoverageAmount and the PremiumFactor
+// CalculateMonthlyPremium returns the rounded product of the item's CoverageAmount and the category's
+// PremiumFactor divided by 12
 func (i *Item) CalculateMonthlyPremium(tx *pop.Connection) *api.Currency {
 	i.Load(tx)
 
 	if i.Category.PremiumFactor.Valid {
-		premium := api.Currency(math.Round(float64(i.CoverageAmount) * i.Category.PremiumFactor.Float64))
+		premium := api.Currency(math.Round(float64(i.CoverageAmount) * i.Category.PremiumFactor.Float64 / 12))
 		return &premium
 	}
 

--- a/application/models/item_test.go
+++ b/application/models/item_test.go
@@ -825,38 +825,35 @@ func (ms *ModelSuite) TestItem_CalculateMonthlyPremium() {
 	f := CreateItemFixtures(ms.DB, FixturesConfig{ItemsPerPolicy: 2})
 
 	defaultPremium := f.Items[0]
+	defaultPremium.CoverageAmount = 30000
+	Must(ms.DB.Update(&defaultPremium))
 
 	categoryPremium := f.Items[1]
-	categoryPremium.CoverageAmount = 10000
+	categoryPremium.CoverageAmount = 30000
 	Must(ms.DB.Update(&categoryPremium))
 	f.ItemCategories[1].PremiumFactor = nulls.NewFloat64(0.03)
 	Must(ms.DB.Update(&f.ItemCategories[1]))
 
 	tests := []struct {
-		name    string
-		item    Item
-		wantNil bool
-		want    api.Currency
+		name string
+		item Item
+		want api.Currency
 	}{
 		{
-			name:    "default premium",
-			item:    defaultPremium,
-			wantNil: true,
+			name: "default premium",
+			item: defaultPremium,
+			want: 50,
 		},
 		{
 			name: "category premium",
 			item: categoryPremium,
-			want: 25,
+			want: 75,
 		},
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
 			got := tt.item.CalculateMonthlyPremium(ms.DB)
-			if tt.wantNil {
-				ms.Nil(got)
-				return
-			}
-			ms.Equal(tt.want, *got)
+			ms.Equal(tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
### Changed
- Changed `CalculateMonthlyPremium` to assume `PremiumFactor` is an annual percentage.
- Return the premium amount from `CalculateMonthlyPremium` for any item, not just those with a category that has a `PremiumFactor` value.