### PR TITLE
Add missing `key` values for createCategories() grift

### DIFF
--- a/application/grifts/db.go
+++ b/application/grifts/db.go
@@ -306,7 +306,7 @@ VALUES
 	'Enabled',	300000, false, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	6, 'home'),
 ('722c03e5-7852-44b9-b86a-af5d63b39d0e',	'7bed3c00-23cf-4282-b2b8-da89426cef2f',
 	'Field site electronics',	'Solar panels, power systems, antennae, and more',
-	'Enabled',	300000, false, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	7, 'field'),
+	'Enabled',	300000, false, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	7, 'electronics'),
 ('0f7aa101-bfdb-4a19-a182-c5ff1d16f6b2',	'7bed3c00-23cf-4282-b2b8-da89426cef2f',
 	'Books and media',	'Books, CDs, DVDs, and more',
 	'Enabled',	300000, false, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	8, 'books'),

--- a/application/grifts/db.go
+++ b/application/grifts/db.go
@@ -282,7 +282,7 @@ INSERT INTO "item_categories" ("id", "risk_category_id", "name", "help_text",
 VALUES
 ('d4632d64-67b5-4795-a7de-66b95312fa7e',	'3be38915-7092-44f2-90ef-26f48214b34f',
 	'Computers, tablets, and phones',	'Includes printers, screens, peripherals, and extras',
-	'Enabled',	300000, true, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	1, 'computer'),
+	'Enabled',	300000, true, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	1, 'computers'),
 ('9c682e38-78fd-475b-9810-3a7f2e9f1fe4',	'7bed3c00-23cf-4282-b2b8-da89426cef2f',
 	'Clothing',	'-',
 	'Enabled',	300000, false, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	10, 'clothing'),

--- a/application/grifts/db.go
+++ b/application/grifts/db.go
@@ -278,44 +278,44 @@ func createPolicyFixtures(tx *pop.Connection, fixUsers []*models.User, entityCod
 func createCategories(tx *pop.Connection) ([]uuid.UUID, error) {
 	const itemCategoriesSql = `
 INSERT INTO "item_categories" ("id", "risk_category_id", "name", "help_text",
-	"status", "auto_approve_max", "require_make_model", "premium_factor", "billing_period", "created_at", "updated_at", "legacy_id")
+	"status", "auto_approve_max", "require_make_model", "premium_factor", "billing_period", "created_at", "updated_at", "legacy_id", "key")
 VALUES
 ('d4632d64-67b5-4795-a7de-66b95312fa7e',	'3be38915-7092-44f2-90ef-26f48214b34f',
 	'Computers, tablets, and phones',	'Includes printers, screens, peripherals, and extras',
-	'Enabled',	300000, true, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	1),
+	'Enabled',	300000, true, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	1, 'computer'),
 ('9c682e38-78fd-475b-9810-3a7f2e9f1fe4',	'7bed3c00-23cf-4282-b2b8-da89426cef2f',
 	'Clothing',	'-',
-	'Enabled',	300000, false, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	10),
+	'Enabled',	300000, false, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	10, 'clothing'),
 ('4b06f087-3fb0-4345-82e8-803645962db0',	'3be38915-7092-44f2-90ef-26f48214b34f',
 	'Medical',	'Eyewear, insulin pumps, CPAP, prosthetics, and more',
-	'Enabled',	300000, true, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	11),
+	'Enabled',	300000, true, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	11, 'medical'),
 ('61081c4d-b6e3-47c5-aca7-373fa7d30896',	'3be38915-7092-44f2-90ef-26f48214b34f',
 	'Photography and recording',	'Includes video, audio, peripherals, and extras',
-	'Enabled',	300000, true, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	2),
+	'Enabled',	300000, true, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	2, 'photography'),
 ('863a3306-78f9-4aca-add5-0abda3a1ef02',	'3be38915-7092-44f2-90ef-26f48214b34f',
 	'Other',	'-',
-	'Enabled',	300000, true, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	3),
+	'Enabled',	300000, true, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	3, 'other'),
 ('faa39da0-981e-4fcf-92fc-2c047fd21f15',	'3be38915-7092-44f2-90ef-26f48214b34f',
 	'Musical instruments',	'Includes peripherals and extras',
-	'Enabled',	300000, true, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	4),
+	'Enabled',	300000, true, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	4, 'musical'),
 ('660629ef-ff63-4ace-8263-993897de7d6b',	'7bed3c00-23cf-4282-b2b8-da89426cef2f',
 	'Appliances and home electronics',	'Washing machines, ovens, theater equipment, and more',
-	'Enabled',	300000, false, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	5),
+	'Enabled',	300000, false, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	5, 'appliances'),
 ('aa304ce5-be3d-45eb-929e-b4575973c0d3',	'7bed3c00-23cf-4282-b2b8-da89426cef2f',
 	'Home goods',	'Furniture, kitchenware, decorations, linens, and more',
-	'Enabled',	300000, false, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	6),
+	'Enabled',	300000, false, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	6, 'home'),
 ('722c03e5-7852-44b9-b86a-af5d63b39d0e',	'7bed3c00-23cf-4282-b2b8-da89426cef2f',
 	'Field site electronics',	'Solar panels, power systems, antennae, and more',
-	'Enabled',	300000, false, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	7),
+	'Enabled',	300000, false, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	7, 'field'),
 ('0f7aa101-bfdb-4a19-a182-c5ff1d16f6b2',	'7bed3c00-23cf-4282-b2b8-da89426cef2f',
 	'Books and media',	'Books, CDs, DVDs, and more',
-	'Enabled',	300000, false, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	8),
+	'Enabled',	300000, false, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	8, 'books'),
 ('036e5315-18ca-4404-8435-72a695f2c9a7',	'3be38915-7092-44f2-90ef-26f48214b34f',
 	'Travel and recreation',	'Includes suitcases, travel bags, cycling, skating, sports. No motorized vehicles.',
-	'Enabled',	300000, true, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	9),
+	'Enabled',	300000, true, 0.02, 12,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	9, 'travel'),
 ('0619a0ba-785e-428d-858c-96d3bd56929a',	'dce80e61-74f9-42f0-9cbd-d3eebe4a1ccc',
 	'Cars and heavy vehicles',	'Coverage for cars and heavy vehicles does not include liability and is not intended to fulfill local regulations or compete with local insurance offerings.',
-	'Enabled',	8000000, true, 0.025, 1,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	NULL);
+	'Enabled',	8000000, true, 0.025, 1,	'2021-08-27 19:46:28',	'2021-08-27 19:46:28',	NULL, 'cars');
 `
 	if err := tx.RawQuery(itemCategoriesSql).Exec(); err != nil {
 		panic("error loading item categories, " + err.Error())


### PR DESCRIPTION
### Fixed
- Add missing `key` values for createCategories() grift

---

Without this, doing a `make fresh` gave this error:
> panic: error loading item categories, ERROR: duplicate key value violates unique constraint "item_categories_key_idx" (SQLSTATE 23505)