### PR TITLE
make ecsdeploy timeout shorter (10 min -> 5 min)

### DIFF
--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -49,9 +49,9 @@
 - name: deploy_staging_web
   service: ecsdeploy
   tag: develop
-  command: "-c appsdev-stg -n cover-api -i 369020531563.dkr.ecr.us-east-1.amazonaws.com/cover-stg -e CI_TIMESTAMP -t 600 --max-definitions 10"
+  command: "-c appsdev-stg -n cover-api -i 369020531563.dkr.ecr.us-east-1.amazonaws.com/cover-stg -e CI_TIMESTAMP -t 300 --max-definitions 10"
 
 - name: deploy_production_web
   service: ecsdeploy
   tag: main
-  command: "-c appsdev-prod -n cover-api -i 369020531563.dkr.ecr.us-east-1.amazonaws.com/cover-prod -e CI_TIMESTAMP -t 600 --max-definitions 10"
+  command: "-c appsdev-prod -n cover-api -i 369020531563.dkr.ecr.us-east-1.amazonaws.com/cover-prod -e CI_TIMESTAMP -t 300 --max-definitions 10"


### PR DESCRIPTION
Deployment typically completes in 2 to 2.5 minutes. This change will save time in a deploy failure situation that is not due to a reportable error. One such situation is a database migration error.