### PR TITLE
move the item_categories.premium_factor patch out of init()

### DIFF
--- a/application/actions/app.go
+++ b/application/actions/app.go
@@ -93,6 +93,7 @@ func App() *buffalo.App {
 	if app == nil {
 		domain.Init()
 		auth.Init()
+		models.PatchItemCategories()
 
 		app = buffalo.New(buffalo.Options{
 			Env:    domain.Env.GoEnv,

--- a/application/models/models.go
+++ b/application/models/models.go
@@ -168,17 +168,6 @@ func init() {
 		panic(fmt.Errorf("error using crypto/rand ... %v", err))
 	}
 
-	//itemCategories := ItemCategories{}
-	//if err := DB.Where("premium_factor IS NULL").All(&itemCategories); domain.IsOtherThanNoRows(err) {
-	//	panic(fmt.Sprintf("failed to query item_categories: %s", err))
-	//}
-	//for i := range itemCategories {
-	//	itemCategories[i].PremiumFactor = nulls.NewFloat64(domain.Env.PremiumFactor)
-	//	if err := DB.UpdateColumns(&itemCategories[i], "premium_factor", "updated_at"); err != nil {
-	//		panic(fmt.Sprintf("failed to set item_categories.premium_factor: %s", err))
-	//	}
-	//}
-
 	// register custom validators for custom types
 	for tag, vFunc := range fieldValidators {
 		if err := mValidate.RegisterValidation(tag, vFunc, false); err != nil {
@@ -192,6 +181,19 @@ func init() {
 	mValidate.RegisterStructValidation(policyStructLevelValidation, Policy{})
 	mValidate.RegisterStructValidation(itemStructLevelValidation, Item{})
 	mValidate.RegisterStructValidation(notificationStructLevelValidation, Notification{})
+}
+
+func PatchItemCategories() {
+	itemCategories := ItemCategories{}
+	if err := DB.Where("premium_factor IS NULL").All(&itemCategories); domain.IsOtherThanNoRows(err) {
+		panic(fmt.Sprintf("failed to query item_categories: %s", err))
+	}
+	for i := range itemCategories {
+		itemCategories[i].PremiumFactor = nulls.NewFloat64(domain.Env.PremiumFactor)
+		if err := DB.UpdateColumns(&itemCategories[i], "premium_factor", "updated_at"); err != nil {
+			panic(fmt.Sprintf("failed to set item_categories.premium_factor: %s", err))
+		}
+	}
 }
 
 func getDB() *pop.Connection {


### PR DESCRIPTION
since init code runs before migrations, this method broke any time a migration changed the item_categories table