### PR TITLE
set the item's coverage_start_date correctly

### DIFF
--- a/application/actions/items.go
+++ b/application/actions/items.go
@@ -236,7 +236,7 @@ func itemsApprove(c buffalo.Context) error {
 	tx := models.Tx(c)
 	item := getReferencedItemFromCtx(c)
 
-	if err := item.Approve(c, true); err != nil {
+	if err := item.Approve(c, time.Now().UTC()); err != nil {
 		return reportError(c, err)
 	}
 

--- a/application/actions/ledger_test.go
+++ b/application/actions/ledger_test.go
@@ -430,7 +430,7 @@ func (as *ActionSuite) createFixturesForLedger() models.Fixtures {
 		f.Items[i].Policy.LoadMembers(as.DB, false)
 		user := f.Items[i].Policy.Members[0]
 		ctx := models.CreateTestContext(user)
-		as.NoError(f.Items[i].Approve(ctx, false))
+		as.NoError(f.Items[i].Approve(ctx, now))
 
 		entry := models.LedgerEntry{}
 		as.NoError(as.DB.Where("item_id = ?", f.Items[i].ID).First(&entry))

--- a/application/api/errorcodes.go
+++ b/application/api/errorcodes.go
@@ -85,8 +85,6 @@ const (
 	ErrorItemNullAccountablePerson        = ErrorKey("ErrorItemNullAccountablePerson")
 	ErrorItemCoverageAmountCannotIncrease = ErrorKey("ErrorItemCoverageAmountCannotIncrease")
 	ErrorItemCoverageAmountTooLow         = ErrorKey("ErrorItemCoverageAmountTooLow")
-	ErrorItemInvalidCoverageStartDate     = ErrorKey("ErrorItemInvalidCoverageStartDate")
-	ErrorItemInvalidCoverageEndDate       = ErrorKey("ErrorItemInvalidCoverageEndDate")
 	ErrorInvalidCategory                  = ErrorKey("ErrorInvalidCategory")
 	ErrorItemHasActiveClaim               = ErrorKey("ErrorItemHasActiveClaim")
 

--- a/application/api/items.go
+++ b/application/api/items.go
@@ -176,14 +176,6 @@ type ItemCreate struct {
 	// coverage status
 	CoverageStatus ItemCoverageStatus `json:"coverage_status"`
 
-	// date (yyyy-mm-dd) of item's coverage start date
-	CoverageStartDate string `json:"coverage_start_date"`
-
-	// date (yyyy-mm-dd) of item's coverage end date, optional
-	//
-	// swagger:strfmt date-time
-	CoverageEndDate *string `json:"coverage_end_date"`
-
 	// Accountable person ID. Can be either a policy dependent ID or a user ID
 	//
 	// swagger:strfmt uuid4

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -416,6 +416,11 @@ func BeginningOfDay(date time.Time) time.Time {
 	return time.Date(date.Year(), date.Month(), date.Day(), 0, 0, 0, 0, time.UTC)
 }
 
+func StartOfMonth(date time.Time) time.Time {
+	d := date.AddDate(0, 0, -date.Day()+1)
+	return d.Truncate(time.Hour * 24)
+}
+
 func EndOfMonth(date time.Time) time.Time {
 	d := date.AddDate(0, 1, -date.Day())
 	return d.Truncate(time.Hour * 24)

--- a/application/domain/domain_test.go
+++ b/application/domain/domain_test.go
@@ -202,6 +202,45 @@ func (ts *TestSuite) Test_BeginningOfDay() {
 	}
 }
 
+func (ts *TestSuite) Test_StartOfMonth() {
+	tests := []struct {
+		name string
+		time time.Time
+		want time.Time
+	}{
+		{
+			name: "first of month",
+			time: time.Date(2020, 1, 1, 1, 1, 1, 1, time.UTC),
+			want: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "last of month",
+			time: time.Date(2020, 1, 31, 1, 1, 1, 1, time.UTC),
+			want: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "30-day month",
+			time: time.Date(2020, 4, 30, 1, 1, 1, 1, time.UTC),
+			want: time.Date(2020, 4, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "29-day month",
+			time: time.Date(2020, 2, 29, 1, 1, 1, 1, time.UTC),
+			want: time.Date(2020, 2, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "28-day month",
+			time: time.Date(2021, 2, 28, 1, 1, 1, 1, time.UTC),
+			want: time.Date(2021, 2, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+	for _, tt := range tests {
+		ts.T().Run(tt.name, func(t *testing.T) {
+			ts.Equal(tt.want, StartOfMonth(tt.time))
+		})
+	}
+}
+
 func (ts *TestSuite) Test_EndOfMonth() {
 	tests := []struct {
 		name string
@@ -210,27 +249,27 @@ func (ts *TestSuite) Test_EndOfMonth() {
 	}{
 		{
 			name: "first of month",
-			time: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+			time: time.Date(2020, 1, 1, 1, 1, 1, 1, time.UTC),
 			want: time.Date(2020, 1, 31, 0, 0, 0, 0, time.UTC),
 		},
 		{
 			name: "last of month",
-			time: time.Date(2020, 1, 31, 0, 0, 0, 0, time.UTC),
+			time: time.Date(2020, 1, 31, 1, 1, 1, 1, time.UTC),
 			want: time.Date(2020, 1, 31, 0, 0, 0, 0, time.UTC),
 		},
 		{
 			name: "30-day month",
-			time: time.Date(2020, 4, 1, 0, 0, 0, 0, time.UTC),
+			time: time.Date(2020, 4, 1, 1, 1, 1, 1, time.UTC),
 			want: time.Date(2020, 4, 30, 0, 0, 0, 0, time.UTC),
 		},
 		{
 			name: "29-day month",
-			time: time.Date(2020, 2, 1, 0, 0, 0, 0, time.UTC),
+			time: time.Date(2020, 2, 1, 1, 1, 1, 1, time.UTC),
 			want: time.Date(2020, 2, 29, 0, 0, 0, 0, time.UTC),
 		},
 		{
 			name: "28-day month",
-			time: time.Date(2021, 2, 1, 0, 0, 0, 0, time.UTC),
+			time: time.Date(2021, 2, 1, 1, 1, 1, 1, time.UTC),
 			want: time.Date(2021, 2, 28, 0, 0, 0, 0, time.UTC),
 		},
 	}

--- a/application/models/ledgerentry_test.go
+++ b/application/models/ledgerentry_test.go
@@ -26,7 +26,7 @@ func (ms *ModelSuite) TestLedgerEntries_AllForMonth() {
 	datesEntered := []nulls.Time{nulls.NewTime(april), {}}
 
 	for i := range f.Items {
-		ms.NoError(f.Items[i].Approve(ctx, false))
+		ms.NoError(f.Items[i].Approve(ctx, time.Now().UTC()))
 
 		entry := LedgerEntry{}
 		ms.NoError(ms.DB.Where("item_id = ?", f.Items[i].ID).First(&entry))
@@ -552,7 +552,7 @@ func (ms *ModelSuite) TestLedgerEntries_Reconcile() {
 
 	itemEntries := make(LedgerEntries, len(f.Items))
 	for i := range f.Items {
-		ms.NoError(f.Items[i].Approve(ctx, false))
+		ms.NoError(f.Items[i].Approve(ctx, time.Now().UTC()))
 
 		ms.NoError(ms.DB.Where("item_id = ?", f.Items[i].ID).First(&itemEntries[i]))
 		itemEntries[i].DateSubmitted = datesSubmitted[i]

--- a/application/models/models.go
+++ b/application/models/models.go
@@ -162,6 +162,12 @@ type FieldUpdate struct {
 	NewValue  string
 }
 
+type CoveragePeriod struct {
+	Premium   api.Currency
+	StartDate time.Time
+	EndDate   time.Time
+}
+
 func init() {
 	// Just make sure we can use the crypto/rand library on our system
 	if _, err := getRandomToken(); err != nil {

--- a/application/models/testutils.go
+++ b/application/models/testutils.go
@@ -593,7 +593,7 @@ func CreateLedgerFixtures(tx *pop.Connection, config FixturesConfig) Fixtures {
 	ctx := CreateTestContext(user)
 	f.LedgerEntries = make(LedgerEntries, len(f.Items))
 	for i := range f.Items {
-		Must(f.Items[i].Approve(ctx, false))
+		Must(f.Items[i].Approve(ctx, time.Now().UTC()))
 		Must(tx.Where("item_id = ?", f.Items[i].ID).First(&f.LedgerEntries[i]))
 	}
 	return f

--- a/application/swagger.json
+++ b/application/swagger.json
@@ -1260,6 +1260,35 @@
         }
       }
     },
+    "/policies/{id}/imports": {
+      "post": {
+        "description": "Import policies and items from a CSV file. This endpoint is initially for importing vehicle information\nfrom a legacy system. It may be removed at a later time, or it may be adapted for other types of data.",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "tags": [
+          "Policies"
+        ],
+        "summary": "PoliciesImport",
+        "operationId": "PoliciesImport",
+        "parameters": [
+          {
+            "type": "file",
+            "description": "file object",
+            "name": "file",
+            "in": "formData"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "uploaded File data",
+            "schema": {
+              "$ref": "#/definitions/PoliciesImportResponse"
+            }
+          }
+        }
+      }
+    },
     "/policies/{id}/items": {
       "get": {
         "description": "gets the data for all the items on a Policy",
@@ -2670,6 +2699,12 @@
           "type": "string",
           "x-go-name": "Key"
         },
+        "minimum_deductible": {
+          "description": "the minimum deductible amount (in units of 0.01 USD)",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "MinimumDeductible"
+        },
         "name": {
           "description": "name",
           "type": "string",
@@ -2735,17 +2770,6 @@
           "type": "integer",
           "format": "int64",
           "x-go-name": "CoverageAmount"
-        },
-        "coverage_end_date": {
-          "description": "date (yyyy-mm-dd) of item's coverage end date, optional",
-          "type": "string",
-          "format": "date-time",
-          "x-go-name": "CoverageEndDate"
-        },
-        "coverage_start_date": {
-          "description": "date (yyyy-mm-dd) of item's coverage start date",
-          "type": "string",
-          "x-go-name": "CoverageStartDate"
         },
         "coverage_status": {
           "$ref": "#/definitions/ItemCoverageStatus"
@@ -3251,6 +3275,27 @@
       "type": "array",
       "items": {
         "$ref": "#/definitions/Policy"
+      },
+      "x-go-package": "github.com/silinternational/cover-api/api"
+    },
+    "PoliciesImportResponse": {
+      "type": "object",
+      "properties": {
+        "items_created": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "ItemsCreated"
+        },
+        "lines_processed": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "LinesProcessed"
+        },
+        "policies_created": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "PoliciesCreated"
+        }
       },
       "x-go-package": "github.com/silinternational/cover-api/api"
     },


### PR DESCRIPTION
### Fixed
- Update an item's `CoverageStartDate` when coverage is approved.
- Delay coverage to the next month on an item billed monthly if the monthly cutoff date has passed.

### Removed
- Remove `CoverageStartDate` and `CoverageEndPoint` from the `ItemCreate` struct, which is used on the PolicyItemsCreate endpoint because these dates were not properly supported at the time of creating a new Item.

---

### Internal changes:

- `Item` `Approve` takes the current time for better test coverage and uniform handling of the "current time".
- `Item` `Approve` does not accept a boolean to control whether the Item Approved event should be emitted. This boolean was always true except in test code.