### PR TITLE
coverage starts on the date of approval

### DIFF
--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -416,11 +416,6 @@ func BeginningOfDay(date time.Time) time.Time {
 	return time.Date(date.Year(), date.Month(), date.Day(), 0, 0, 0, 0, time.UTC)
 }
 
-func StartOfMonth(date time.Time) time.Time {
-	d := date.AddDate(0, 0, -date.Day()+1)
-	return d.Truncate(time.Hour * 24)
-}
-
 func EndOfMonth(date time.Time) time.Time {
 	d := date.AddDate(0, 1, -date.Day())
 	return d.Truncate(time.Hour * 24)

--- a/application/domain/domain_test.go
+++ b/application/domain/domain_test.go
@@ -202,45 +202,6 @@ func (ts *TestSuite) Test_BeginningOfDay() {
 	}
 }
 
-func (ts *TestSuite) Test_StartOfMonth() {
-	tests := []struct {
-		name string
-		time time.Time
-		want time.Time
-	}{
-		{
-			name: "first of month",
-			time: time.Date(2020, 1, 1, 1, 1, 1, 1, time.UTC),
-			want: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
-		},
-		{
-			name: "last of month",
-			time: time.Date(2020, 1, 31, 1, 1, 1, 1, time.UTC),
-			want: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
-		},
-		{
-			name: "30-day month",
-			time: time.Date(2020, 4, 30, 1, 1, 1, 1, time.UTC),
-			want: time.Date(2020, 4, 1, 0, 0, 0, 0, time.UTC),
-		},
-		{
-			name: "29-day month",
-			time: time.Date(2020, 2, 29, 1, 1, 1, 1, time.UTC),
-			want: time.Date(2020, 2, 1, 0, 0, 0, 0, time.UTC),
-		},
-		{
-			name: "28-day month",
-			time: time.Date(2021, 2, 28, 1, 1, 1, 1, time.UTC),
-			want: time.Date(2021, 2, 1, 0, 0, 0, 0, time.UTC),
-		},
-	}
-	for _, tt := range tests {
-		ts.T().Run(tt.name, func(t *testing.T) {
-			ts.Equal(tt.want, StartOfMonth(tt.time))
-		})
-	}
-}
-
 func (ts *TestSuite) Test_EndOfMonth() {
 	tests := []struct {
 		name string

--- a/application/models/item.go
+++ b/application/models/item.go
@@ -713,19 +713,19 @@ func (i *Item) getInitialCoverage(tx *pop.Connection, now time.Time) CoveragePer
 	if i.Category.GetBillingPeriod() == domain.BillingPeriodMonthly {
 		coverage.Premium = i.CalculateMonthlyPremium(tx)
 		if now.Day() < MonthlyCutoffDay {
-			coverage.StartDate = now
 			coverage.EndDate = domain.EndOfMonth(now)
 		} else {
 			oneMonthAhead := now.AddDate(0, 1, 0)
-			coverage.StartDate = domain.StartOfMonth(oneMonthAhead)
 			coverage.EndDate = domain.EndOfMonth(oneMonthAhead)
 		}
 	} else {
 		coverage.Premium = i.CalculateProratedPremium(tx, now)
-		coverage.StartDate = now
 		coverage.EndDate = domain.EndOfYear(now.Year())
 	}
 
+	// Coverage start date is the same regardless of billing, effectively giving free coverage
+	// in some cases. See CVR-729.
+	coverage.StartDate = now
 	return coverage
 }
 

--- a/application/models/item_test.go
+++ b/application/models/item_test.go
@@ -650,7 +650,6 @@ func (ms *ModelSuite) TestItem_Approve() {
 
 	sep1 := time.Date(2023, 9, 1, 0, 0, 0, 0, time.UTC)
 	sep30 := time.Date(2023, 9, 30, 0, 0, 0, 0, time.UTC)
-	oct1 := time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC)
 	oct31 := time.Date(2023, 10, 31, 0, 0, 0, 0, time.UTC)
 
 	testContext := CreateTestContext(f.Users[0])
@@ -684,7 +683,7 @@ func (ms *ModelSuite) TestItem_Approve() {
 			item:          monthlyLate,
 			now:           sep30,
 			wantAmount:    monthlyLate.CalculateMonthlyPremium(ms.DB),
-			wantStartDate: oct1,
+			wantStartDate: sep30,
 			wantEndDate:   oct31,
 		},
 	}
@@ -728,7 +727,6 @@ func (ms *ModelSuite) TestItem_getInitialCoverage() {
 
 	sep1 := time.Date(2023, 9, 1, 0, 0, 0, 0, time.UTC)
 	sep30 := time.Date(2023, 9, 30, 0, 0, 0, 0, time.UTC)
-	oct1 := time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC)
 	oct31 := time.Date(2023, 10, 31, 0, 0, 0, 0, time.UTC)
 
 	tests := []struct {
@@ -763,7 +761,7 @@ func (ms *ModelSuite) TestItem_getInitialCoverage() {
 			now:  sep30,
 			want: CoveragePeriod{
 				Premium:   monthlyLate.CalculateMonthlyPremium(ms.DB),
-				StartDate: oct1,
+				StartDate: sep30,
 				EndDate:   oct31,
 			},
 		},


### PR DESCRIPTION
### Fixed
- Coverage starts at the date of approval, not the first day of premium billing.

[CVR-719](https://itse.youtrack.cloud/issue/CVR-729)

---

### Code Checklist
- [x] Documentation (README, goswagger, etc.)
- [x] Unit tests created or updated
- [x] Run `gofmt`
- [x] Run `make swaggerspec`
