### PR TITLE
don't bill next month in "after cutoff" case

### DIFF
--- a/application/models/item.go
+++ b/application/models/item.go
@@ -711,11 +711,9 @@ func (i *Item) getInitialCoverage(tx *pop.Connection, now time.Time) CoveragePer
 
 	i.LoadCategory(tx, false)
 	if i.Category.GetBillingPeriod() == domain.BillingPeriodMonthly {
+		// After the cutoff day, no premiums are billed until the next month. See CVR-730.
 		if now.Day() < MonthlyCutoffDay {
 			coverage.Premium = i.CalculateMonthlyPremium(tx)
-		} else {
-			// After the cutoff day, no premiums are billed until the next month. See CVR-730.
-			coverage.Premium = 0
 		}
 		coverage.EndDate = domain.EndOfMonth(now)
 	} else {

--- a/application/models/item.go
+++ b/application/models/item.go
@@ -711,13 +711,13 @@ func (i *Item) getInitialCoverage(tx *pop.Connection, now time.Time) CoveragePer
 
 	i.LoadCategory(tx, false)
 	if i.Category.GetBillingPeriod() == domain.BillingPeriodMonthly {
-		coverage.Premium = i.CalculateMonthlyPremium(tx)
 		if now.Day() < MonthlyCutoffDay {
-			coverage.EndDate = domain.EndOfMonth(now)
+			coverage.Premium = i.CalculateMonthlyPremium(tx)
 		} else {
-			oneMonthAhead := now.AddDate(0, 1, 0)
-			coverage.EndDate = domain.EndOfMonth(oneMonthAhead)
+			// After the cutoff day, no premiums are billed until the next month. See CVR-730.
+			coverage.Premium = 0
 		}
+		coverage.EndDate = domain.EndOfMonth(now)
 	} else {
 		coverage.Premium = i.CalculateProratedPremium(tx, now)
 		coverage.EndDate = domain.EndOfYear(now.Year())

--- a/application/models/item_test.go
+++ b/application/models/item_test.go
@@ -724,7 +724,8 @@ func (ms *ModelSuite) TestItem_getInitialCoverage() {
 	f.ItemCategories[2].BillingPeriod = domain.BillingPeriodMonthly
 	Must(ms.DB.Update(&f.ItemCategories))
 
-	sep1 := time.Date(2023, 9, 1, 0, 0, 0, 0, time.UTC)
+	sep19 := time.Date(2023, 9, 19, 0, 0, 0, 0, time.UTC)
+	sep20 := time.Date(2023, 9, 20, 0, 0, 0, 0, time.UTC)
 	sep30 := time.Date(2023, 9, 30, 0, 0, 0, 0, time.UTC)
 
 	tests := []struct {
@@ -746,20 +747,20 @@ func (ms *ModelSuite) TestItem_getInitialCoverage() {
 		{
 			name: "monthlyEarly item",
 			item: monthlyEarly,
-			now:  sep1,
+			now:  sep19,
 			want: CoveragePeriod{
 				Premium:   monthlyEarly.CalculateMonthlyPremium(ms.DB),
-				StartDate: sep1,
+				StartDate: sep19,
 				EndDate:   sep30,
 			},
 		},
 		{
 			name: "monthlyLate item",
 			item: monthlyLate,
-			now:  sep30,
+			now:  sep20,
 			want: CoveragePeriod{
 				Premium:   0,
-				StartDate: sep30,
+				StartDate: sep20,
 				EndDate:   sep30,
 			},
 		},

--- a/application/models/item_test.go
+++ b/application/models/item_test.go
@@ -650,7 +650,6 @@ func (ms *ModelSuite) TestItem_Approve() {
 
 	sep1 := time.Date(2023, 9, 1, 0, 0, 0, 0, time.UTC)
 	sep30 := time.Date(2023, 9, 30, 0, 0, 0, 0, time.UTC)
-	oct31 := time.Date(2023, 10, 31, 0, 0, 0, 0, time.UTC)
 
 	testContext := CreateTestContext(f.Users[0])
 
@@ -682,9 +681,9 @@ func (ms *ModelSuite) TestItem_Approve() {
 			name:          "monthlyLate item",
 			item:          monthlyLate,
 			now:           sep30,
-			wantAmount:    monthlyLate.CalculateMonthlyPremium(ms.DB),
+			wantAmount:    0,
 			wantStartDate: sep30,
-			wantEndDate:   oct31,
+			wantEndDate:   sep30,
 		},
 	}
 
@@ -727,7 +726,6 @@ func (ms *ModelSuite) TestItem_getInitialCoverage() {
 
 	sep1 := time.Date(2023, 9, 1, 0, 0, 0, 0, time.UTC)
 	sep30 := time.Date(2023, 9, 30, 0, 0, 0, 0, time.UTC)
-	oct31 := time.Date(2023, 10, 31, 0, 0, 0, 0, time.UTC)
 
 	tests := []struct {
 		name string
@@ -760,9 +758,9 @@ func (ms *ModelSuite) TestItem_getInitialCoverage() {
 			item: monthlyLate,
 			now:  sep30,
 			want: CoveragePeriod{
-				Premium:   monthlyLate.CalculateMonthlyPremium(ms.DB),
+				Premium:   0,
 				StartDate: sep30,
-				EndDate:   oct31,
+				EndDate:   sep30,
 			},
 		},
 	}


### PR DESCRIPTION
### Fixed
- Don't bill ahead for next month in the case where coverage is approved after the monthly cutoff date.

[CVR-730](https://itse.youtrack.cloud/issue/CVR-730)

---

### Code Checklist
- [x] Documentation (README, goswagger, etc.)
- [x] Unit tests created or updated
- [x] Run `gofmt`
- [x] Run `make swaggerspec`
