### PR TITLE
use minimum premium on prorated premium calculation

### DIFF
--- a/application/models/item.go
+++ b/application/models/item.go
@@ -938,7 +938,9 @@ func (i *Item) CalculateAnnualPremium(tx *pop.Connection) api.Currency {
 
 func (i *Item) CalculateProratedPremium(tx *pop.Connection, t time.Time) api.Currency {
 	p := domain.CalculatePartialYearValue(int(i.CalculateAnnualPremium(tx)), t)
-	return api.Currency(p)
+
+	i.LoadCategory(tx, false)
+	return api.Currency(domain.Max(p, i.Category.MinimumPremium))
 }
 
 // CalculateMonthlyPremium returns the rounded product of the item's CoverageAmount and the category's

--- a/application/models/item_test.go
+++ b/application/models/item_test.go
@@ -986,6 +986,8 @@ func (ms *ModelSuite) TestItem_calculateProratedPremium() {
 
 	now := time.Date(1999, 3, 15, 0, 0, 0, 0, time.UTC)
 
+	item := Item{Category: ItemCategory{ID: domain.GetUUID(), MinimumPremium: 3000}}
+
 	tests := []struct {
 		name     string
 		coverage int
@@ -1001,10 +1003,15 @@ func (ms *ModelSuite) TestItem_calculateProratedPremium() {
 			coverage: 199999,
 			want:     3200,
 		},
+		{
+			name:     "lower than minimum",
+			coverage: 187450,
+			want:     3000,
+		},
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			item := Item{CoverageAmount: tt.coverage}
+			item.CoverageAmount = tt.coverage
 			got := item.CalculateProratedPremium(ms.DB, now)
 			ms.Equal(api.Currency(tt.want), got)
 		})


### PR DESCRIPTION
### Changed
- Include item category minimum premium in the prorated premium calculation

[CVR-740](https://itse.youtrack.cloud/issue/CVR-740)

---

### Code Checklist
- [x] Documentation (README, goswagger, etc.)
- [x] Unit tests created or updated
- [x] Run `gofmt`
- [x] Run `make swaggerspec`
