### PR TITLE
use the latest version of gosec now that issue 1040 is resolved

### DIFF
--- a/application/codeship-test.sh
+++ b/application/codeship-test.sh
@@ -5,8 +5,7 @@ set -e
 # exit on first error
 set -x
 
-#curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $GOPATH/bin latest
-go install github.com/securego/gosec/v2/cmd/gosec@v2.17.0
+go install github.com/securego/gosec/v2/cmd/gosec@latest
 
 # https://github.com/securego/gosec#available-rules
 # G104 ignore errors not checked

--- a/application/models/models.go
+++ b/application/models/models.go
@@ -244,6 +244,9 @@ func fieldByName(i any, name ...string) reflect.Value {
 	}
 	f := reflect.ValueOf(i).Elem().FieldByName(name[0])
 	if !f.IsValid() {
+		if len(name) < 2 {
+			return reflect.Value{}
+		}
 		return fieldByName(i, name[1:]...)
 	}
 	return f


### PR DESCRIPTION

### Fixed
- Use the latest version of gosec since https://github.com/securego/gosec/issues/1040 is resolved.

---

### Code Checklist
- [x] Documentation (README, goswagger, etc.)
- [x] Unit tests created or updated
- [x] Run `gofmt`
- [x] Run `make swaggerspec`
