### PR TITLE
fix the debug container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-dev: buffalo adminer migrate grifts
+dev: killdebug buffalo adminer migrate grifts
 
 migrate: db
 	docker-compose run --rm buffalo whenavail db 5432 10 buffalo-pop pop migrate up
@@ -18,7 +18,7 @@ adminer:
 buffalo: db
 	docker-compose up -d buffalo
 
-debug: killbuffalo
+debug: killbuffalo killdebug rmdebug
 	docker-compose up -d debug
 	docker-compose logs -f debug
 
@@ -58,6 +58,12 @@ testenv: rmtestdb migratetestdb
 
 killbuffalo:
 	docker-compose kill buffalo
+
+killdebug:
+	docker-compose kill debug
+
+rmdebug:
+	docker-compose rm -f debug
 
 clean:
 	docker-compose kill

--- a/application/Dockerfile-dev
+++ b/application/Dockerfile-dev
@@ -38,7 +38,9 @@ RUN go get github.com/gobuffalo/suite/v3 \
   github.com/stretchr/testify \
   github.com/gorilla/pat \
   github.com/gorilla/context
-RUN CGO_ENABLED=0 go get -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv
+
+# install dlv for debugging
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.9.0
 
 ADD . .
 

--- a/application/debug.sh
+++ b/application/debug.sh
@@ -3,7 +3,7 @@
 set -x
 set -e
 
-CGO_ENABLED=0 go build -gcflags "all=-N -l" -o /tmp/app
+CGO_ENABLED=0 go build -gcflags "all=-N -l" -o /tmp/app ./cmd/app
 
 #dlv --listen=:2345 --headless=true --log=true --log-output=debugger,debuglineerr,gdbwire,lldbout,rpc --accept-multiclient --api-version=2 exec /tmp/app
 dlv --listen=:2345 --headless=true --accept-multiclient --api-version=2 exec /tmp/app


### PR DESCRIPTION
### Fixed
- Use `go install` for downloading and installing dlv in the buffalo container.
- Correct the build line in the debug script for the new location of `main.go`.
- Change the `dev` and `debug` Make targets to kill the other container.

---

### Code Checklist
- [x] Documentation (README, goswagger, etc.)
- [x] Unit tests created or updated
- [x] Run `gofmt`
- [x] Run `make swaggerspec`
