### PR TITLE
ensure the Claim TotalPayout is updated after adding a ClaimItem

### DIFF
--- a/application/models/claim.go
+++ b/application/models/claim.go
@@ -410,6 +410,14 @@ func (c *Claim) AddItem(ctx context.Context, input api.ClaimItemCreateInput) (Cl
 		return ClaimItem{}, err
 	}
 
+	if err = c.calculatePayout(ctx); err != nil {
+		return ClaimItem{}, err
+	}
+
+	if err = update(tx, c); err != nil {
+		return ClaimItem{}, err
+	}
+
 	return claimItem, nil
 }
 

--- a/application/models/claim_test.go
+++ b/application/models/claim_test.go
@@ -1525,7 +1525,7 @@ func (ms *ModelSuite) TestClaim_AddItem() {
 
 			if tt.wantErr != nil {
 				ms.Error(err, " did not return expected error")
-				SameAppError(ms.T(), *tt.wantErr, err)
+				AssertSameAppError(ms.T(), *tt.wantErr, err)
 				return
 			}
 			ms.NoError(err)

--- a/application/models/claim_test.go
+++ b/application/models/claim_test.go
@@ -1474,3 +1474,77 @@ func (ms *ModelSuite) TestClaim_StopItemCoverage() {
 		})
 	}
 }
+
+func (ms *ModelSuite) TestClaim_AddItem() {
+	fixConfig := FixturesConfig{
+		NumberOfPolicies:   2,
+		ItemsPerPolicy:     1,
+		ClaimsPerPolicy:    1,
+		ClaimItemsPerClaim: 0,
+	}
+
+	fixtures := CreateItemFixtures(ms.DB, fixConfig)
+	claim := fixtures.Claims[0]
+	itemID := fixtures.Items[0].ID
+	otherItemID := fixtures.Items[1].ID
+
+	tests := []struct {
+		name       string
+		claim      Claim
+		input      api.ClaimItemCreateInput
+		wantErr    *api.AppError
+		wantPayout api.Currency
+	}{
+		{
+			name:  "item not on the correct policy",
+			claim: claim,
+			input: api.ClaimItemCreateInput{
+				ItemID: otherItemID,
+			},
+			wantErr: &api.AppError{Category: api.CategoryNotFound, Key: api.ErrorClaimItemCreateInvalidInput},
+		},
+		{
+			name:  "good input",
+			claim: claim,
+			input: api.ClaimItemCreateInput{
+				ItemID:         itemID,
+				RepairEstimate: 100,
+				PayoutOption:   api.PayoutOptionRepair,
+				FMV:            1000,
+			},
+			wantErr:    nil,
+			wantPayout: 95,
+		},
+	}
+
+	for _, tt := range tests {
+		ms.T().Run(tt.name, func(t *testing.T) {
+			ctx := CreateTestContext(fixtures.Users[0])
+
+			got, err := tt.claim.AddItem(ctx, tt.input)
+
+			if tt.wantErr != nil {
+				ms.Error(err, " did not return expected error")
+				SameAppError(ms.T(), *tt.wantErr, err)
+				return
+			}
+			ms.NoError(err)
+
+			ms.Equal(tt.input.ItemID, got.ItemID)
+			ms.Equal(tt.input.RepairEstimate, got.RepairEstimate)
+			ms.Equal(tt.input.PayoutOption, got.PayoutOption)
+			ms.Equal(tt.input.FMV, got.FMV)
+
+			var claimItemFromDB ClaimItem
+			Must(ms.DB.Find(&claimItemFromDB, got.ID))
+			ms.Equal(tt.input.ItemID, claimItemFromDB.ItemID)
+			ms.Equal(tt.input.RepairEstimate, claimItemFromDB.RepairEstimate)
+			ms.Equal(tt.input.PayoutOption, claimItemFromDB.PayoutOption)
+			ms.Equal(tt.input.FMV, claimItemFromDB.FMV)
+
+			var claimFromDB Claim
+			Must(ms.DB.Find(&claimFromDB, tt.claim.ID))
+			ms.Equal(tt.wantPayout, claimFromDB.TotalPayout)
+		})
+	}
+}

--- a/application/models/ledgerentry_test.go
+++ b/application/models/ledgerentry_test.go
@@ -343,7 +343,7 @@ func (ms *ModelSuite) TestLedgerEntry_balanceDescription() {
 }
 
 func (ms *ModelSuite) Test_NewLedgerEntry() {
-	f := CreateItemFixtures(ms.DB, FixturesConfig{NumberOfPolicies: 2, ClaimsPerPolicy: 1})
+	f := CreateItemFixtures(ms.DB, FixturesConfig{NumberOfPolicies: 2, ClaimsPerPolicy: 1, ClaimItemsPerClaim: 1})
 	householdPolicy := f.Policies[0]
 	householdPolicyItem := householdPolicy.Items[0]
 	ms.NoError(householdPolicyItem.SetAccountablePerson(ms.DB, f.Users[0].ID))

--- a/application/models/testutils.go
+++ b/application/models/testutils.go
@@ -939,8 +939,8 @@ func Must(err error) {
 	}
 }
 
-// SameAppError verifies that the actual error contains an AppError and that the key and category match expected
-func SameAppError(t *testing.T, expected api.AppError, actual error) {
+// AssertSameAppError verifies that the actual error contains an AppError and that the key and category match expected
+func AssertSameAppError(t *testing.T, expected api.AppError, actual error) {
 	require.Error(t, actual, "error is nil")
 	var appErr *api.AppError
 	require.True(t, errors.As(actual, &appErr),

--- a/application/models/testutils.go
+++ b/application/models/testutils.go
@@ -7,13 +7,16 @@
 package models
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"math/rand"
+	"testing"
 	"time"
 
 	"github.com/gobuffalo/events"
 	"github.com/gobuffalo/pop/v6"
+	"github.com/stretchr/testify/require"
 
 	"github.com/silinternational/cover-api/storage"
 
@@ -205,8 +208,6 @@ func UpdateClaimItems(tx *pop.Connection, claim Claim, params UpdateClaimItemsPa
 // createClaimFixture generates a Claim, a number of ClaimItems, and a number of ClaimFiles
 // Uses FixturesConfig fields: ClaimItemsPerClaim, ClaimFilesPerClaim
 func createClaimFixture(tx *pop.Connection, policy Policy, config FixturesConfig) Claim {
-	config.ClaimItemsPerClaim = domain.Max(1, config.ClaimItemsPerClaim)
-
 	if len(policy.Items) < config.ClaimItemsPerClaim {
 		panic(fmt.Sprintf("policy fixture must have at least %d items, it only has %d",
 			config.ClaimItemsPerClaim, len(policy.Items)))
@@ -936,4 +937,16 @@ func Must(err error) {
 	if err != nil {
 		panic(err.Error())
 	}
+}
+
+// SameAppError verifies that the actual error contains an AppError and that the key and category match expected
+func SameAppError(t *testing.T, expected api.AppError, actual error) {
+	require.Error(t, actual, "error is nil")
+	var appErr *api.AppError
+	require.True(t, errors.As(actual, &appErr),
+		"error does not contain an api.AppError, message: %s", actual.Error())
+	require.Equal(t, expected.Key, appErr.Key,
+		"error key does not match, message: %s", actual.Error())
+	require.Equal(t, expected.Category, appErr.Category,
+		"error category does not match, message: %s", actual.Error())
 }


### PR DESCRIPTION
### Fixed
- Update the TotalPayout on a Claim when adding a ClaimItem. Previously, it was only updated when the Claim itself was updated.

---

### Code Checklist
- [x] Documentation (README, goswagger, etc.)
- [x] Unit tests created or updated
- [x] Run `gofmt`
- [x] Run `make swaggerspec`

[CVR-709](https://itse.youtrack.cloud/issue/CVR-709)