### PR TITLE
predate the renewal transaction to help with report generation

### DIFF
--- a/application/models/policy.go
+++ b/application/models/policy.go
@@ -690,9 +690,10 @@ func (p *Policy) CreateRenewalLedgerEntry(tx *pop.Connection, riskCategoryID uui
 		return fmt.Errorf("failed to find risk category %s: %w", riskCategoryID, err)
 	}
 
-	now := time.Now().UTC()
+	// predate the transaction so the monthly report doesn't omit these transactions if run on the same day
+	dateSubmitted := time.Now().UTC().Add(-24 * time.Hour).Truncate(24 * time.Hour)
 
-	le := NewLedgerEntry("", *p, nil, nil, now)
+	le := NewLedgerEntry("", *p, nil, nil, dateSubmitted)
 	le.Type = LedgerEntryTypeCoverageRenewal
 	le.Amount = -amount
 	le.EntityCode = p.EntityCode.Code

--- a/application/models/policy_test.go
+++ b/application/models/policy_test.go
@@ -855,6 +855,8 @@ func (ms *ModelSuite) TestPolicy_CreateRenewalLedgerEntry() {
 	f.Items[0].RiskCategoryID = RiskCategoryMobileID()
 	UpdateItemStatus(ms.DB, f.Items[0], api.ItemCoverageStatusApproved, "")
 
+	yesterday := time.Now().UTC().Add(-24 * time.Hour).Truncate(24 * time.Hour)
+
 	tests := []struct {
 		name           string
 		policy         Policy
@@ -887,6 +889,7 @@ func (ms *ModelSuite) TestPolicy_CreateRenewalLedgerEntry() {
 			ms.Equal(-tt.amount, l[0].Amount)
 			ms.Equal(LedgerEntryTypeCoverageRenewal, l[0].Type)
 			ms.Equal(tt.policy.ID, l[0].PolicyID)
+			ms.Equal(yesterday, l[0].DateSubmitted)
 		})
 	}
 }


### PR DESCRIPTION
### Changed
- Predate renewal transactions so the monthly report doesn't omit them if the report is run on the same day as the renewals.

---

### Code Checklist
- [x] Documentation (README, goswagger, etc.)
- [x] Unit tests created or updated
- [x] Run `gofmt`
- [x] Run `make swaggerspec`

[CVR-762](https://itse.youtrack.cloud/issue/CVR-762)