### PR TITLE
don't set ledger entry HouseholdID unless it's valid

### DIFF
--- a/application/models/ledgerentry.go
+++ b/application/models/ledgerentry.go
@@ -382,10 +382,13 @@ func NewLedgerEntry(accPersonName string, policy Policy, item *Item, claim *Clai
 		AccountNumber: policy.Account,
 		IncomeAccount: policy.EntityCode.IncomeAccount,
 		CostCenter:    costCenter,
-		HouseholdID:   policy.HouseholdID.String,
 		Name:          accPersonName,
 		PolicyName:    policy.Name,
 	}
+	if policy.HouseholdID.Valid {
+		le.HouseholdID = policy.HouseholdID.String
+	}
+
 	if item != nil {
 		le.ItemID = nulls.NewUUID(item.ID)
 		le.RiskCategoryName = item.RiskCategory.Name


### PR DESCRIPTION

### Fixed
- Don't set the ledger entry household ID column when the policy's household ID isn't valid

---

### Code Checklist
- [x] Documentation (README, goswagger, etc.)
- [x] Unit tests created or updated
- [x] Run `gofmt`
- [x] Run `make swaggerspec`

[CVR-764](https://itse.youtrack.cloud/issue/CVR-764)
