### PR TITLE
Release 1.10.1 - fix ledger entry household_id assignment

### DIFF
--- a/application/models/ledgerentry.go
+++ b/application/models/ledgerentry.go
@@ -377,10 +377,13 @@ func NewLedgerEntry(accPersonName string, policy Policy, item *Item, claim *Clai
 		AccountNumber: policy.Account,
 		IncomeAccount: policy.EntityCode.IncomeAccount,
 		CostCenter:    costCenter,
-		HouseholdID:   policy.HouseholdID.String,
 		Name:          accPersonName,
 		PolicyName:    policy.Name,
 	}
+	if policy.HouseholdID.Valid {
+		le.HouseholdID = policy.HouseholdID.String
+	}
+
 	if item != nil {
 		le.ItemID = nulls.NewUUID(item.ID)
 		le.RiskCategoryName = item.RiskCategory.Name

--- a/application/models/ledgerentry.go
+++ b/application/models/ledgerentry.go
@@ -293,21 +293,16 @@ func (le *LedgerEntry) getDescription() string {
 	description := le.Type.Description(le.ClaimPayoutOption, le.Amount)
 
 	if le.PolicyName == "" {
-		return description
+		return description + " " + le.RiskCategoryName
 	}
 
 	description = fmt.Sprintf(`%s / %s`, description, le.PolicyName)
 
-	if le.PolicyType == api.PolicyTypeHousehold {
-		return description
+	if le.PolicyType == api.PolicyTypeHousehold || le.Name == "" {
+		return description + " " + le.RiskCategoryName
 	}
 
-	// For non-household policies
-	if le.Name == "" {
-		return description
-	}
-
-	return fmt.Sprintf(`%s (%s)`, description, le.Name)
+	return fmt.Sprintf(`%s (%s) %s`, description, le.Name, le.RiskCategoryName)
 }
 
 func (le *LedgerEntry) getItemName(tx *pop.Connection) string {

--- a/application/models/ledgerentry_test.go
+++ b/application/models/ledgerentry_test.go
@@ -446,10 +446,12 @@ func (ms *ModelSuite) TestLedgerEntry_getDescription() {
 
 	// Create new Ledger Entries for each policy
 	hhAccPersName := hhAccPerson.GetName().String()
+	hhPolicyItem.LoadRiskCategory(ms.DB, false)
 	hhEntry := NewLedgerEntry(hhAccPersName, hhPolicy, &hhPolicyItem, nil, now)
 	hhEntry.Type = LedgerEntryTypeNewCoverage
 
 	teamAccPersName := teamAccPerson.GetName().String()
+	teamPolicyItem.LoadRiskCategory(ms.DB, false)
 	teamEntry := NewLedgerEntry(teamAccPersName, teamPolicy, &teamPolicyItem, nil, now)
 	teamEntry.Type = LedgerEntryTypeCoverageRefund
 
@@ -463,13 +465,15 @@ func (ms *ModelSuite) TestLedgerEntry_getDescription() {
 			name:  "household policy item",
 			entry: hhEntry,
 			item:  hhPolicyItem,
-			want:  fmt.Sprintf("%s / %s", `Coverage premium: Add`, hhPolicy.Name),
+			want: fmt.Sprintf("%s / %s %s", `Coverage premium: Add`, hhPolicy.Name,
+				hhPolicyItem.RiskCategory.Name),
 		},
 		{
 			name:  "team policy item",
 			entry: teamEntry,
 			item:  teamPolicyItem,
-			want:  fmt.Sprintf("%s / %s (%s)", `Coverage reimbursement: Remove`, teamPolicy.Name, teamAccPersName),
+			want: fmt.Sprintf("%s / %s (%s) %s", `Coverage reimbursement: Remove`, teamPolicy.Name,
+				teamAccPersName, teamPolicyItem.RiskCategory.Name),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### Fixed
- Don't set the ledger entry household ID column when the policy's household ID isn't valid

---

[CVR-764](https://itse.youtrack.cloud/issue/CVR-764)
