### PR TITLE
fix policy search

### DIFF
--- a/application/models/policy.go
+++ b/application/models/policy.go
@@ -388,13 +388,13 @@ func scopeSearchPolicies(searchText string) pop.ScopeFunc {
 	return func(q *pop.Query) *pop.Query {
 		return q.Where("policies.id IN ("+
 			"SELECT policies.id FROM policies "+
-			"    JOIN policy_users pu ON policies.id = pu.policy_id "+
-			"    JOIN users on users.id = pu.user_id "+
-			"    AND ("+
+			"    LEFT JOIN policy_users pu ON policies.id = pu.policy_id "+
+			"    LEFT JOIN users on users.id = pu.user_id "+
+			"    WHERE "+
 			"        CONCAT(users.first_name, ' ', users.last_name) ILIKE ? "+
 			"        OR policies.cost_center ILIKE ? OR policies.household_id ILIKE ? "+
 			"        OR policies.name ILIKE ?"+
-			"    ) "+
+			"    "+
 			")", searchText, searchText, searchText, searchText)
 	}
 }

--- a/application/models/policy_test.go
+++ b/application/models/policy_test.go
@@ -665,6 +665,13 @@ func (ms *ModelSuite) TestPolicies_Query() {
 	f.Policies[3].Members[0].FirstName = "John"
 	ms.NoError(ms.DB.Update(&f.Policies[3].Members[0]))
 
+	// create a policy with no users
+	f2 := CreatePolicyFixtures(ms.DB, FixturesConfig{NumberOfPolicies: 1})
+	f2.Policies[0].Name = "ABC123"
+	Must(ms.DB.Update(&f2.Policies[0]))
+	f2.PolicyUsers[0].PolicyID = corpPolicy.ID
+	Must(ms.DB.Update(&f2.PolicyUsers[0]))
+
 	tests := []struct {
 		name                 string
 		query                string
@@ -706,6 +713,11 @@ func (ms *ModelSuite) TestPolicies_Query() {
 			wantNumberOfPolicies: 1,
 		},
 		{
+			name:                 "policy with no users",
+			query:                "search=" + "ABC",
+			wantNumberOfPolicies: 1,
+		},
+		{
 			name:                 "cost center",
 			query:                "search=" + corpPolicy.CostCenter,
 			wantNumberOfPolicies: 1,
@@ -733,7 +745,7 @@ func (ms *ModelSuite) TestPolicies_Query() {
 		{
 			name:                 "only inactive",
 			query:                "filter=active:false",
-			wantNumberOfPolicies: 4,
+			wantNumberOfPolicies: 5,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### Fixed
- Fixed the policy search feature. It was not including policies with no users.

---

### Code Checklist
- [x] Documentation (README, goswagger, etc.)
- [x] Unit tests created or updated
- [x] Run `gofmt`
- [x] Run `make swaggerspec`

[CVR-777](https://itse.youtrack.cloud/issue/CVR-777)
