### PR TITLE
CVR-770 new flag SafeToProcess

### DIFF
--- a/application/actions/ledger.go
+++ b/application/actions/ledger.go
@@ -187,7 +187,8 @@ func ledgerAnnualRenewalStatus(c buffalo.Context) error {
 		return reportError(c, api.NewAppError(err, api.ErrorNotAuthorized, api.CategoryForbidden))
 	}
 
-	endOfYear := domain.EndOfYear(time.Now().UTC().Year())
+	now := time.Now().UTC()
+	endOfYear := domain.EndOfYear(now.Year())
 
 	itemsToRenew, err := models.CountItemsToRenew(models.Tx(c), endOfYear, domain.BillingPeriodAnnual)
 	if err != nil {
@@ -197,6 +198,7 @@ func ledgerAnnualRenewalStatus(c buffalo.Context) error {
 	status := api.RenewalStatus{
 		IsComplete:     itemsToRenew == 0,
 		ItemsToProcess: itemsToRenew,
+		SafeToProcess:  now.Month() < 3,
 	}
 	return renderOk(c, status)
 }
@@ -252,6 +254,7 @@ func ledgerMonthlyRenewalStatus(c buffalo.Context) error {
 	status := api.RenewalStatus{
 		IsComplete:     itemsToRenew == 0,
 		ItemsToProcess: itemsToRenew,
+		SafeToProcess:  now.Day() >= models.MonthlyCutoffDay,
 	}
 	return renderOk(c, status)
 }

--- a/application/api/ledger.go
+++ b/application/api/ledger.go
@@ -119,6 +119,12 @@ type LedgerEntry struct {
 
 // swagger:model
 type RenewalStatus struct {
-	IsComplete     bool `json:"is_complete"`
-	ItemsToProcess int  `json:"items_to_process"`
+	// is the process job complete? (i.e. is the process not running?)
+	IsComplete bool `json:"is_complete"`
+
+	// how many items are available to process?
+	ItemsToProcess int `json:"items_to_process"`
+
+	// is it safe to allow the user to initiate a process job?
+	SafeToProcess bool `json:"safe_to_process"`
 }

--- a/application/models/item.go
+++ b/application/models/item.go
@@ -21,6 +21,8 @@ import (
 	"github.com/silinternational/cover-api/log"
 )
 
+// MonthlyCutoffDay is the day of the month before which monthly-billed coverage can be added for the current month.
+// On this day or later, coverage billing begins on the first of the next month.
 const MonthlyCutoffDay = 20
 
 var ValidItemCoverageStatuses = map[api.ItemCoverageStatus]struct{}{

--- a/application/models/ledgerreport.go
+++ b/application/models/ledgerreport.go
@@ -394,3 +394,17 @@ func (lr *LedgerReport) Reconcile(ctx context.Context) error {
 	lr.LoadLedgerEntries(tx, true)
 	return nil
 }
+
+// IsSafeToRenewAnnual returns true if the current time and the state of the database are such that it is safe to
+// initiate the annual renewal process.
+func IsSafeToRenewAnnual(tx *pop.Connection, now time.Time) bool {
+	// TODO: return false if the current year's renewals have been reconciled
+	return now.Month() < 3
+}
+
+// IsSafeToRenewAnnual returns true if the current time and the state of the database are such that it is safe to
+// initiate the monthly renewal process.
+func IsSafeToRenewMonthly(tx *pop.Connection, now time.Time) bool {
+	// TODO: return false if the current month's renewals have been reconciled
+	return now.Day() >= MonthlyCutoffDay
+}

--- a/application/models/ledgerreport_test.go
+++ b/application/models/ledgerreport_test.go
@@ -651,3 +651,68 @@ func (ms *ModelSuite) TestPolicyLedgerTable() {
 		})
 	}
 }
+
+func (ms *ModelSuite) Test_isSafeToRenewAnnual() {
+	tests := []struct {
+		name string
+		now  time.Time
+		want bool
+	}{
+		{
+			name: "January",
+			now:  time.Date(2020, 1, 31, 0, 0, 0, 0, time.UTC),
+			want: true,
+		},
+		{
+			name: "February",
+			now:  time.Date(2020, 2, 29, 0, 0, 0, 0, time.UTC),
+			want: true,
+		},
+		{
+			name: "March",
+			now:  time.Date(2020, 3, 31, 0, 0, 0, 0, time.UTC),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		ms.T().Run(tt.name, func(t *testing.T) {
+			got := IsSafeToRenewAnnual(ms.DB, tt.now)
+			ms.Equal(tt.want, got)
+		})
+	}
+}
+
+func (ms *ModelSuite) Test_isSafeToRenewMonthly() {
+	tests := []struct {
+		name string
+		now  time.Time
+		want bool
+	}{
+		{
+			name: "1st of the month",
+			now:  time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+			want: false,
+		},
+		{
+			name: "19th of the month",
+			now:  time.Date(2020, 1, 19, 0, 0, 0, 0, time.UTC),
+			want: false,
+		},
+		{
+			name: "20th of the month",
+			now:  time.Date(2020, 1, 20, 0, 0, 0, 0, time.UTC),
+			want: true,
+		},
+		{
+			name: "31st of the month",
+			now:  time.Date(2020, 1, 31, 0, 0, 0, 0, time.UTC),
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		ms.T().Run(tt.name, func(t *testing.T) {
+			got := IsSafeToRenewMonthly(ms.DB, tt.now)
+			ms.Equal(tt.want, got)
+		})
+	}
+}

--- a/application/swagger.json
+++ b/application/swagger.json
@@ -3716,13 +3716,20 @@
       "type": "object",
       "properties": {
         "is_complete": {
+          "description": "is the process job complete? (i.e. is the process not running?)",
           "type": "boolean",
           "x-go-name": "IsComplete"
         },
         "items_to_process": {
+          "description": "how many items are available to process?",
           "type": "integer",
           "format": "int64",
           "x-go-name": "ItemsToProcess"
+        },
+        "safe_to_process": {
+          "description": "is it safe to allow the user to initiate a process job?",
+          "type": "boolean",
+          "x-go-name": "SafeToProcess"
         }
       },
       "x-go-package": "github.com/silinternational/cover-api/api"


### PR DESCRIPTION
### Added
- Added a field to the `LedgerStatus` object to tell the UI whether it should enable the process renewals buttons.

---

### Code Checklist
- [x] Documentation (README, goswagger, etc.)
- [x] Unit tests created or updated
- [x] Run `gofmt`
- [x] Run `make swaggerspec`

_**Note:** this is the first of two PRs for [CVR-770](https://itse.youtrack.cloud/issue/CVR-770)_