### PR TITLE
remove HSTS and leave it up to the Cloudflare rule to apply the header

### DIFF
--- a/application/actions/app.go
+++ b/application/actions/app.go
@@ -31,7 +31,6 @@
 package actions
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/gobuffalo/buffalo"
@@ -109,8 +108,6 @@ func App() *buffalo.App {
 			SessionName:  "_cover_api_session",
 			SessionStore: cookieStore(),
 		})
-
-		app.Use(hstsMiddleware)
 
 		var err error
 		domain.T, err = i18n.New(locales.FS(), "en")
@@ -288,12 +285,4 @@ func cookieStore() sessions.Store {
 	}
 
 	return store
-}
-
-func hstsMiddleware(next buffalo.Handler) buffalo.Handler {
-	return func(c buffalo.Context) error {
-		headerValue := fmt.Sprintf("max-age=%d", domain.Env.HstsMaxAge)
-		c.Response().Header().Add("Strict-Transport-Security", headerValue)
-		return next(c)
-	}
 }

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -138,7 +138,6 @@ type EnvStruct struct {
 	ApiBaseURL                 string `required:"true" split_words:"true"`
 	AccessTokenLifetimeSeconds int    `default:"1166400" split_words:"true"` // 13.5 days
 	AppName                    string `default:"Cover" split_words:"true"`
-	HstsMaxAge                 int    `default:"3600" split_words:"true"` // default = 1 hour
 	LogLevel                   string `default:"debug" split_words:"true"`
 	AppNameLong                string `default:"Cover by SIL" split_words:"true"`
 	Port                       int    `default:"3000"`


### PR DESCRIPTION
### Removed
- Remove the `hstsMiddleware` which applies a `Strict-Transport-Security` header to all responses. This can easily be done in a Cloudflare Transport Rule. (See [cover-terraform](https://github.com/silinternational/cover-terraform/pull/45))
