### PR TITLE
respond to robots.txt with a global disallow

### DIFF
--- a/application/actions/actions.go
+++ b/application/actions/actions.go
@@ -147,3 +147,10 @@ func getClientIPAddress(c buffalo.Context) (net.IP, error) {
 
 	return userIP, nil
 }
+
+func robots(c buffalo.Context) error {
+	const body = `User-agent: *
+Disallow: /
+`
+	return c.Render(200, r.String(body))
+}

--- a/application/actions/actions_test.go
+++ b/application/actions/actions_test.go
@@ -114,3 +114,13 @@ func (as *ActionSuite) decodeBody(body []byte, v any) error {
 	decoder.DisallowUnknownFields()
 	return decoder.Decode(v)
 }
+
+func (as *ActionSuite) Test_robots() {
+	req := as.JSON("/robots.txt")
+	res := req.Get()
+	body := res.Body.Bytes()
+
+	as.Equal(http.StatusOK, res.Code, "incorrect status code returned: %d\n%s", res.Code, body)
+	as.True(strings.HasPrefix(string(body), "User-agent"),
+		"incorrect response body:\n%s", body)
+}

--- a/application/actions/app.go
+++ b/application/actions/app.go
@@ -263,6 +263,11 @@ func App() *buffalo.App {
 		strikesGroup.PUT(idRegex, strikesUpdate)
 		strikesGroup.DELETE(idRegex, strikesDelete)
 
+		// robots
+		app.GET("/robots.txt", robots)
+		app.Middleware.Skip(AuthZ, robots)
+		app.Middleware.Skip(AuthN, robots)
+
 		listeners.RegisterListener()
 
 		job.Init(&app.Worker)


### PR DESCRIPTION
### Added
- Respond to `/robots.txt` with "User-agent: * Disallow /"

---

### Code Checklist
- [ ] Documentation (README, goswagger, etc.)
- [x] Unit tests created or updated
- [x] Run `gofmt`
- [ ] Run `make swaggerspec`
