### PR TITLE
set access token in session CVR-610

### DIFF
--- a/application/actions/actions_test.go
+++ b/application/actions/actions_test.go
@@ -124,3 +124,9 @@ func (as *ActionSuite) Test_robots() {
 	as.True(strings.HasPrefix(string(body), "User-agent"),
 		"incorrect response body:\n%s", body)
 }
+
+func (as *ActionSuite) SetAccessToken(actor models.User) {
+	uat, err := actor.CreateAccessToken(as.DB)
+	as.NoError(err)
+	as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+}

--- a/application/actions/audits_test.go
+++ b/application/actions/audits_test.go
@@ -52,9 +52,7 @@ func (as *ActionSuite) Test_auditsRun() {
 	}
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON(auditsPath)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(tt.input)

--- a/application/actions/audits_test.go
+++ b/application/actions/audits_test.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -53,8 +52,10 @@ func (as *ActionSuite) Test_auditsRun() {
 	}
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON(auditsPath)
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(tt.input)
 			body := res.Body.Bytes()

--- a/application/actions/audits_test.go
+++ b/application/actions/audits_test.go
@@ -54,7 +54,7 @@ func (as *ActionSuite) Test_auditsRun() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON(auditsPath)
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(tt.input)
 			body := res.Body.Bytes()

--- a/application/actions/auth_test.go
+++ b/application/actions/auth_test.go
@@ -27,23 +27,20 @@ func (as *ActionSuite) Test_AuthLogin_Invite() {
 		wantCode     string
 	}{
 		{
-			name: "Bad Invite Code",
-			queryParams: fmt.Sprintf("%s=badInviteCode",
-				InviteCodeParam),
+			name:         "Bad Invite Code",
+			queryParams:  fmt.Sprintf("%s=badInviteCode", InviteCodeParam),
 			wantStatus:   http.StatusBadRequest,
 			wantContains: string(api.ErrorProcessingAuthInviteCode),
 		},
 		{
-			name: "Invite Code not in DB",
-			queryParams: fmt.Sprintf("%s=%v",
-				InviteCodeParam, missingCode),
+			name:         "Invite Code not in DB",
+			queryParams:  fmt.Sprintf("%s=%v", InviteCodeParam, missingCode),
 			wantStatus:   http.StatusNotFound,
 			wantContains: string(api.ErrorProcessingAuthInviteCode),
 		},
 		{
-			name: "All Good",
-			queryParams: fmt.Sprintf("%s=%v",
-				InviteCodeParam, invite.ID),
+			name:         "All Good",
+			queryParams:  fmt.Sprintf("%s=%v", InviteCodeParam, invite.ID),
 			wantStatus:   http.StatusOK,
 			wantContains: `"RedirectURL":"` + domain.Env.SamlSsoURL,
 			wantCode:     invite.ID.String(),

--- a/application/actions/auth_test.go
+++ b/application/actions/auth_test.go
@@ -28,22 +28,22 @@ func (as *ActionSuite) Test_AuthLogin_Invite() {
 	}{
 		{
 			name: "Bad Invite Code",
-			queryParams: fmt.Sprintf("%s=123456&%s=badInviteCode",
-				ClientIDParam, InviteCodeParam),
+			queryParams: fmt.Sprintf("%s=badInviteCode",
+				InviteCodeParam),
 			wantStatus:   http.StatusBadRequest,
 			wantContains: string(api.ErrorProcessingAuthInviteCode),
 		},
 		{
 			name: "Invite Code not in DB",
-			queryParams: fmt.Sprintf("%s=123456&%s=%v",
-				ClientIDParam, InviteCodeParam, missingCode),
+			queryParams: fmt.Sprintf("%s=123456&%v",
+				InviteCodeParam, missingCode),
 			wantStatus:   http.StatusNotFound,
 			wantContains: string(api.ErrorProcessingAuthInviteCode),
 		},
 		{
 			name: "All Good",
-			queryParams: fmt.Sprintf("%s=123456&%s=%v",
-				ClientIDParam, InviteCodeParam, invite.ID),
+			queryParams: fmt.Sprintf("%s=123456&%v",
+				InviteCodeParam, invite.ID),
 			wantStatus:   http.StatusOK,
 			wantContains: `"RedirectURL":"` + domain.Env.SamlSsoURL,
 			wantCode:     invite.ID.String(),
@@ -51,7 +51,7 @@ func (as *ActionSuite) Test_AuthLogin_Invite() {
 	}
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			req := as.JSON("/auth/login?" + tt.queryParams)
+			req := as.JSON("/auth/login")
 			res := req.Post(nil)
 			body := res.Body.String()
 			as.Equal(tt.wantStatus, res.Code, "incorrect status code returned, body: %s", body)

--- a/application/actions/auth_test.go
+++ b/application/actions/auth_test.go
@@ -35,14 +35,14 @@ func (as *ActionSuite) Test_AuthLogin_Invite() {
 		},
 		{
 			name: "Invite Code not in DB",
-			queryParams: fmt.Sprintf("%s=123456&%v",
+			queryParams: fmt.Sprintf("%s=%v",
 				InviteCodeParam, missingCode),
 			wantStatus:   http.StatusNotFound,
 			wantContains: string(api.ErrorProcessingAuthInviteCode),
 		},
 		{
 			name: "All Good",
-			queryParams: fmt.Sprintf("%s=123456&%v",
+			queryParams: fmt.Sprintf("%s=%v",
 				InviteCodeParam, invite.ID),
 			wantStatus:   http.StatusOK,
 			wantContains: `"RedirectURL":"` + domain.Env.SamlSsoURL,

--- a/application/actions/auth_test.go
+++ b/application/actions/auth_test.go
@@ -51,7 +51,7 @@ func (as *ActionSuite) Test_AuthLogin_Invite() {
 	}
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			req := as.JSON("/auth/login")
+			req := as.JSON("/auth/login?" + tt.queryParams)
 			res := req.Post(nil)
 			body := res.Body.String()
 			as.Equal(tt.wantStatus, res.Code, "incorrect status code returned, body: %s", body)

--- a/application/actions/authn.go
+++ b/application/actions/authn.go
@@ -14,15 +14,15 @@ import (
 
 func AuthN(next buffalo.Handler) buffalo.Handler {
 	return func(c buffalo.Context) error {
-		bearerToken := domain.GetBearerTokenFromRequest(c.Request())
-		if bearerToken == "" {
-			err := errors.New("no bearer token provided")
+		authToken := domain.GetCombinedTokenFromRequest(c.Request())
+		if authToken == "" {
+			err := errors.New("no access token provided")
 			return reportError(c, api.NewAppError(err, api.ErrorNotAuthorized, api.CategoryUnauthorized))
 		}
 
 		var userAccessToken models.UserAccessToken
-		if err := userAccessToken.FindByBearerToken(models.DB, bearerToken); err != nil {
-			err := errors.New("invalid bearer token")
+		if err := userAccessToken.FindByAccessToken(models.DB, authToken); err != nil {
+			err := errors.New("invalid access token")
 			return reportError(c, api.NewAppError(err, api.ErrorNotAuthorized, api.CategoryUnauthorized))
 		}
 
@@ -32,7 +32,7 @@ func AuthN(next buffalo.Handler) buffalo.Handler {
 		}
 
 		if isExpired {
-			err = errors.New("expired bearer token")
+			err = errors.New("expired access token")
 			return reportError(c, api.NewAppError(err, api.ErrorNotAuthorized, api.CategoryUnauthorized))
 		}
 

--- a/application/actions/authn.go
+++ b/application/actions/authn.go
@@ -14,14 +14,18 @@ import (
 
 func AuthN(next buffalo.Handler) buffalo.Handler {
 	return func(c buffalo.Context) error {
-		authToken := domain.GetCombinedTokenFromRequest(c.Request())
-		if authToken == "" {
+		accessToken, ok := c.Session().Get(AccessTokenSessionKey).(string)
+		if !ok {
+			log.Error("failed to retrieve access token from session")
+		}
+
+		if accessToken == "" {
 			err := errors.New("no access token provided")
 			return reportError(c, api.NewAppError(err, api.ErrorNotAuthorized, api.CategoryUnauthorized))
 		}
 
 		var userAccessToken models.UserAccessToken
-		if err := userAccessToken.FindByAccessToken(models.DB, authToken); err != nil {
+		if err := userAccessToken.FindByAccessToken(models.DB, accessToken); err != nil {
 			err := errors.New("invalid access token")
 			return reportError(c, api.NewAppError(err, api.ErrorNotAuthorized, api.CategoryUnauthorized))
 		}

--- a/application/actions/claimfiles_test.go
+++ b/application/actions/claimfiles_test.go
@@ -84,10 +84,12 @@ func (as *ActionSuite) Test_ClaimFilesAttach() {
 	}
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			claimID := tt.claim.ID
 			req := as.JSON("/%s/%s/%s",
 				domain.TypeClaim, claimID.String(), domain.TypeFile)
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(tt.request)
 
@@ -160,8 +162,10 @@ func (as *ActionSuite) Test_ClaimFilesDelete() {
 	}
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/%s/%s", domain.TypeClaimFile, tt.id.String())
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Delete()
 

--- a/application/actions/claimfiles_test.go
+++ b/application/actions/claimfiles_test.go
@@ -84,9 +84,7 @@ func (as *ActionSuite) Test_ClaimFilesAttach() {
 	}
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			claimID := tt.claim.ID
 			req := as.JSON("/%s/%s/%s",
 				domain.TypeClaim, claimID.String(), domain.TypeFile)
@@ -162,9 +160,7 @@ func (as *ActionSuite) Test_ClaimFilesDelete() {
 	}
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/%s/%s", domain.TypeClaimFile, tt.id.String())
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Delete()

--- a/application/actions/claimfiles_test.go
+++ b/application/actions/claimfiles_test.go
@@ -87,7 +87,7 @@ func (as *ActionSuite) Test_ClaimFilesAttach() {
 			claimID := tt.claim.ID
 			req := as.JSON("/%s/%s/%s",
 				domain.TypeClaim, claimID.String(), domain.TypeFile)
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(tt.request)
 
@@ -161,7 +161,7 @@ func (as *ActionSuite) Test_ClaimFilesDelete() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/%s/%s", domain.TypeClaimFile, tt.id.String())
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Delete()
 

--- a/application/actions/claimitems_test.go
+++ b/application/actions/claimitems_test.go
@@ -2,7 +2,6 @@ package actions
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -117,8 +116,10 @@ func (as *ActionSuite) Test_ClaimItemsUpdate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON(claimItemsPath + "/" + tt.claimItem.ID.String())
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Put(tt.input)
 

--- a/application/actions/claimitems_test.go
+++ b/application/actions/claimitems_test.go
@@ -116,9 +116,7 @@ func (as *ActionSuite) Test_ClaimItemsUpdate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON(claimItemsPath + "/" + tt.claimItem.ID.String())
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Put(tt.input)

--- a/application/actions/claimitems_test.go
+++ b/application/actions/claimitems_test.go
@@ -118,7 +118,7 @@ func (as *ActionSuite) Test_ClaimItemsUpdate() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON(claimItemsPath + "/" + tt.claimItem.ID.String())
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Put(tt.input)
 

--- a/application/actions/claims_test.go
+++ b/application/actions/claims_test.go
@@ -72,8 +72,10 @@ func (as *ActionSuite) Test_ClaimsList() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/claims" + tt.queryString)
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Get()
 
@@ -148,9 +150,11 @@ func (as *ActionSuite) Test_PoliciesClaimsList() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			url := fmt.Sprintf("%s/%s%s", policiesPath, policy.ID, claimsPath)
 			req := as.JSON(url)
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Get()
 
@@ -231,8 +235,10 @@ func (as *ActionSuite) Test_ClaimsView() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/claims/" + tt.claim.ID.String())
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Get()
 
@@ -344,8 +350,10 @@ func (as *ActionSuite) Test_ClaimsUpdate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/claims/" + tt.claim.ID.String())
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Put(tt.input)
 
@@ -456,8 +464,10 @@ func (as *ActionSuite) Test_ClaimsCreate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON(fmt.Sprintf("/policies/%s/claims", tt.policy.ID))
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(tt.input)
 
@@ -572,8 +582,10 @@ func (as *ActionSuite) Test_ClaimsItemsCreate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON(fmt.Sprintf("/%s/%s/%s", domain.TypeClaim, tt.claim.ID, domain.TypeItem))
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 
 			res := req.Post(tt.input)
@@ -659,8 +671,10 @@ func (as *ActionSuite) Test_ClaimsSubmit() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/%s/%s/%s", domain.TypeClaim, tt.oldClaim.ID.String(), api.ResourceSubmit)
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(nil)
 
@@ -736,9 +750,11 @@ func (as *ActionSuite) Test_ClaimsRequestRevision() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/%s/%s/%s",
 				domain.TypeClaim, tt.oldClaim.ID.String(), api.ResourceRevision)
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			const message = "change all of it"
 			res := req.Post(api.ClaimStatusInput{StatusReason: message})
@@ -816,9 +832,11 @@ func (as *ActionSuite) Test_ClaimsPreapprove() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/%s/%s/%s",
 				domain.TypeClaim, tt.oldClaim.ID.String(), api.ResourcePreapprove)
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(nil)
 
@@ -898,9 +916,11 @@ func (as *ActionSuite) Test_ClaimsReceipt() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/%s/%s/%s",
 				domain.TypeClaim, tt.oldClaim.ID.String(), api.ResourceReceipt)
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(api.ClaimStatusInput{StatusReason: tt.reason})
 
@@ -1032,9 +1052,11 @@ func (as *ActionSuite) Test_ClaimsApprove() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/%s/%s/%s",
 				domain.TypeClaim, tt.oldClaim.ID.String(), api.ResourceApprove)
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(nil)
 
@@ -1142,9 +1164,11 @@ func (as *ActionSuite) Test_ClaimsDeny() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/%s/%s/%s",
 				domain.TypeClaim, tt.oldClaim.ID.String(), api.ResourceDeny)
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			const message = "change all of it"
 			res := req.Post(api.ClaimStatusInput{StatusReason: message})
@@ -1222,9 +1246,11 @@ func (as *ActionSuite) Test_ClaimsRemove() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/%s/%s",
 				domain.TypeClaim, tt.claim.ID.String())
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Delete()
 

--- a/application/actions/claims_test.go
+++ b/application/actions/claims_test.go
@@ -73,7 +73,7 @@ func (as *ActionSuite) Test_ClaimsList() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/claims" + tt.queryString)
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Get()
 
@@ -150,7 +150,7 @@ func (as *ActionSuite) Test_PoliciesClaimsList() {
 		as.T().Run(tt.name, func(t *testing.T) {
 			url := fmt.Sprintf("%s/%s%s", policiesPath, policy.ID, claimsPath)
 			req := as.JSON(url)
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Get()
 
@@ -232,7 +232,7 @@ func (as *ActionSuite) Test_ClaimsView() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/claims/" + tt.claim.ID.String())
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Get()
 
@@ -345,7 +345,7 @@ func (as *ActionSuite) Test_ClaimsUpdate() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/claims/" + tt.claim.ID.String())
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Put(tt.input)
 
@@ -457,7 +457,7 @@ func (as *ActionSuite) Test_ClaimsCreate() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON(fmt.Sprintf("/policies/%s/claims", tt.policy.ID))
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(tt.input)
 
@@ -573,7 +573,7 @@ func (as *ActionSuite) Test_ClaimsItemsCreate() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON(fmt.Sprintf("/%s/%s/%s", domain.TypeClaim, tt.claim.ID, domain.TypeItem))
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 
 			res := req.Post(tt.input)
@@ -660,7 +660,7 @@ func (as *ActionSuite) Test_ClaimsSubmit() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/%s/%s/%s", domain.TypeClaim, tt.oldClaim.ID.String(), api.ResourceSubmit)
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(nil)
 
@@ -738,7 +738,7 @@ func (as *ActionSuite) Test_ClaimsRequestRevision() {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/%s/%s/%s",
 				domain.TypeClaim, tt.oldClaim.ID.String(), api.ResourceRevision)
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			const message = "change all of it"
 			res := req.Post(api.ClaimStatusInput{StatusReason: message})
@@ -818,7 +818,7 @@ func (as *ActionSuite) Test_ClaimsPreapprove() {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/%s/%s/%s",
 				domain.TypeClaim, tt.oldClaim.ID.String(), api.ResourcePreapprove)
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(nil)
 
@@ -900,7 +900,7 @@ func (as *ActionSuite) Test_ClaimsReceipt() {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/%s/%s/%s",
 				domain.TypeClaim, tt.oldClaim.ID.String(), api.ResourceReceipt)
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(api.ClaimStatusInput{StatusReason: tt.reason})
 
@@ -1034,7 +1034,7 @@ func (as *ActionSuite) Test_ClaimsApprove() {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/%s/%s/%s",
 				domain.TypeClaim, tt.oldClaim.ID.String(), api.ResourceApprove)
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(nil)
 
@@ -1144,7 +1144,7 @@ func (as *ActionSuite) Test_ClaimsDeny() {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/%s/%s/%s",
 				domain.TypeClaim, tt.oldClaim.ID.String(), api.ResourceDeny)
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			const message = "change all of it"
 			res := req.Post(api.ClaimStatusInput{StatusReason: message})
@@ -1224,7 +1224,7 @@ func (as *ActionSuite) Test_ClaimsRemove() {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/%s/%s",
 				domain.TypeClaim, tt.claim.ID.String())
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Delete()
 

--- a/application/actions/claims_test.go
+++ b/application/actions/claims_test.go
@@ -72,9 +72,7 @@ func (as *ActionSuite) Test_ClaimsList() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/claims" + tt.queryString)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Get()
@@ -150,9 +148,7 @@ func (as *ActionSuite) Test_PoliciesClaimsList() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			url := fmt.Sprintf("%s/%s%s", policiesPath, policy.ID, claimsPath)
 			req := as.JSON(url)
 			req.Headers["content-type"] = domain.ContentJson
@@ -235,9 +231,7 @@ func (as *ActionSuite) Test_ClaimsView() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/claims/" + tt.claim.ID.String())
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Get()
@@ -350,9 +344,7 @@ func (as *ActionSuite) Test_ClaimsUpdate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/claims/" + tt.claim.ID.String())
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Put(tt.input)
@@ -464,9 +456,7 @@ func (as *ActionSuite) Test_ClaimsCreate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON(fmt.Sprintf("/policies/%s/claims", tt.policy.ID))
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(tt.input)
@@ -582,9 +572,7 @@ func (as *ActionSuite) Test_ClaimsItemsCreate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON(fmt.Sprintf("/%s/%s/%s", domain.TypeClaim, tt.claim.ID, domain.TypeItem))
 			req.Headers["content-type"] = domain.ContentJson
 
@@ -671,9 +659,7 @@ func (as *ActionSuite) Test_ClaimsSubmit() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/%s/%s/%s", domain.TypeClaim, tt.oldClaim.ID.String(), api.ResourceSubmit)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(nil)
@@ -750,9 +736,7 @@ func (as *ActionSuite) Test_ClaimsRequestRevision() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/%s/%s/%s",
 				domain.TypeClaim, tt.oldClaim.ID.String(), api.ResourceRevision)
 			req.Headers["content-type"] = domain.ContentJson
@@ -832,9 +816,7 @@ func (as *ActionSuite) Test_ClaimsPreapprove() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/%s/%s/%s",
 				domain.TypeClaim, tt.oldClaim.ID.String(), api.ResourcePreapprove)
 			req.Headers["content-type"] = domain.ContentJson
@@ -916,9 +898,7 @@ func (as *ActionSuite) Test_ClaimsReceipt() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/%s/%s/%s",
 				domain.TypeClaim, tt.oldClaim.ID.String(), api.ResourceReceipt)
 			req.Headers["content-type"] = domain.ContentJson
@@ -1052,9 +1032,7 @@ func (as *ActionSuite) Test_ClaimsApprove() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/%s/%s/%s",
 				domain.TypeClaim, tt.oldClaim.ID.String(), api.ResourceApprove)
 			req.Headers["content-type"] = domain.ContentJson
@@ -1164,9 +1142,7 @@ func (as *ActionSuite) Test_ClaimsDeny() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/%s/%s/%s",
 				domain.TypeClaim, tt.oldClaim.ID.String(), api.ResourceDeny)
 			req.Headers["content-type"] = domain.ContentJson
@@ -1246,9 +1222,7 @@ func (as *ActionSuite) Test_ClaimsRemove() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/%s/%s",
 				domain.TypeClaim, tt.claim.ID.String())
 			req.Headers["content-type"] = domain.ContentJson

--- a/application/actions/dependents_test.go
+++ b/application/actions/dependents_test.go
@@ -70,8 +70,10 @@ func (as *ActionSuite) Test_DependentsList() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, uatErr := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(uatErr)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/policies/" + tt.policy.ID.String() + "/dependents")
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Get()
 
@@ -212,8 +214,10 @@ func (as *ActionSuite) Test_DependentsCreate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, uatErr := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(uatErr)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/policies/" + tt.policy.ID.String() + "/dependents")
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(tt.reqBody)
 
@@ -344,8 +348,10 @@ func (as *ActionSuite) Test_DependentsUpdate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, uatErr := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(uatErr)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/%s/%s", domain.TypePolicyDependent, tt.oldDep.ID)
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Put(tt.input)
 
@@ -433,8 +439,10 @@ func (as *ActionSuite) Test_DependentsDelete() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, uatErr := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(uatErr)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/%s/%s", domain.TypePolicyDependent, tt.oldDep.ID)
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Delete()
 

--- a/application/actions/dependents_test.go
+++ b/application/actions/dependents_test.go
@@ -71,7 +71,7 @@ func (as *ActionSuite) Test_DependentsList() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/policies/" + tt.policy.ID.String() + "/dependents")
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Get()
 
@@ -213,7 +213,7 @@ func (as *ActionSuite) Test_DependentsCreate() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/policies/" + tt.policy.ID.String() + "/dependents")
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(tt.reqBody)
 
@@ -289,7 +289,7 @@ func (as *ActionSuite) Test_DependentsUpdate() {
 			wantStatus: http.StatusUnauthorized,
 			wantInBody: []string{
 				api.ErrorNotAuthorized.String(),
-				"no bearer token provided",
+				"no access token provided",
 			},
 		},
 		{
@@ -345,7 +345,7 @@ func (as *ActionSuite) Test_DependentsUpdate() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/%s/%s", domain.TypePolicyDependent, tt.oldDep.ID)
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Put(tt.input)
 
@@ -406,7 +406,7 @@ func (as *ActionSuite) Test_DependentsDelete() {
 			wantStatus: http.StatusUnauthorized,
 			wantInBody: []string{
 				api.ErrorNotAuthorized.String(),
-				"no bearer token provided",
+				"no access token provided",
 			},
 		},
 		{
@@ -434,7 +434,7 @@ func (as *ActionSuite) Test_DependentsDelete() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/%s/%s", domain.TypePolicyDependent, tt.oldDep.ID)
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Delete()
 

--- a/application/actions/dependents_test.go
+++ b/application/actions/dependents_test.go
@@ -70,9 +70,7 @@ func (as *ActionSuite) Test_DependentsList() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, uatErr := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(uatErr)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/policies/" + tt.policy.ID.String() + "/dependents")
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Get()
@@ -214,9 +212,7 @@ func (as *ActionSuite) Test_DependentsCreate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, uatErr := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(uatErr)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/policies/" + tt.policy.ID.String() + "/dependents")
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(tt.reqBody)
@@ -348,9 +344,7 @@ func (as *ActionSuite) Test_DependentsUpdate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, uatErr := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(uatErr)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/%s/%s", domain.TypePolicyDependent, tt.oldDep.ID)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Put(tt.input)
@@ -439,9 +433,7 @@ func (as *ActionSuite) Test_DependentsDelete() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, uatErr := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(uatErr)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/%s/%s", domain.TypePolicyDependent, tt.oldDep.ID)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Delete()

--- a/application/actions/entitycodes_test.go
+++ b/application/actions/entitycodes_test.go
@@ -45,7 +45,7 @@ func (as *ActionSuite) Test_entityCodesList() {
 	}
 	for _, tt := range tests {
 		req := as.JSON(entityCodesPath)
-		req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+		req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 		res := req.Get()
 		body := res.Body.Bytes()
 
@@ -112,7 +112,7 @@ func (as *ActionSuite) Test_entityCodesUpdate() {
 	}
 	for _, tt := range tests {
 		req := as.JSON("%s/%s", entityCodesPath, inactiveCode.ID)
-		req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+		req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 		input := api.EntityCodeInput{
 			Active:        true,
 			IncomeAccount: "newacct",
@@ -174,7 +174,7 @@ func (as *ActionSuite) Test_entityCodesView() {
 	}
 	for _, tt := range tests {
 		req := as.JSON("%s/%s", entityCodesPath, inactiveCode.ID)
-		req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+		req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 		res := req.Get()
 		body := res.Body.Bytes()
 
@@ -235,7 +235,7 @@ func (as *ActionSuite) Test_entityCodesCreate() {
 	}
 	for _, tt := range tests {
 		req := as.JSON("%s", entityCodesPath)
-		req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+		req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 		res := req.Post(input)
 		body := res.Body.Bytes()
 

--- a/application/actions/entitycodes_test.go
+++ b/application/actions/entitycodes_test.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/silinternational/cover-api/api"
@@ -44,8 +43,9 @@ func (as *ActionSuite) Test_entityCodesList() {
 		},
 	}
 	for _, tt := range tests {
+		uat, _ := tt.actor.CreateAccessToken(as.DB)
+		as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 		req := as.JSON(entityCodesPath)
-		req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 		res := req.Get()
 		body := res.Body.Bytes()
 
@@ -111,8 +111,9 @@ func (as *ActionSuite) Test_entityCodesUpdate() {
 		},
 	}
 	for _, tt := range tests {
+		uat, _ := tt.actor.CreateAccessToken(as.DB)
+		as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 		req := as.JSON("%s/%s", entityCodesPath, inactiveCode.ID)
-		req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 		input := api.EntityCodeInput{
 			Active:        true,
 			IncomeAccount: "newacct",
@@ -173,8 +174,9 @@ func (as *ActionSuite) Test_entityCodesView() {
 		},
 	}
 	for _, tt := range tests {
+		uat, _ := tt.actor.CreateAccessToken(as.DB)
+		as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 		req := as.JSON("%s/%s", entityCodesPath, inactiveCode.ID)
-		req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 		res := req.Get()
 		body := res.Body.Bytes()
 
@@ -234,8 +236,9 @@ func (as *ActionSuite) Test_entityCodesCreate() {
 		ParentEntity:  "XYZ",
 	}
 	for _, tt := range tests {
+		uat, _ := tt.actor.CreateAccessToken(as.DB)
+		as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 		req := as.JSON("%s", entityCodesPath)
-		req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 		res := req.Post(input)
 		body := res.Body.Bytes()
 

--- a/application/actions/itemcategories_test.go
+++ b/application/actions/itemcategories_test.go
@@ -46,7 +46,7 @@ func (as *ActionSuite) Test_ItemCategoriesList() {
 	models.MustCreate(as.DB, &disabled)
 
 	req := as.JSON("/config/item-categories")
-	req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", fixtures.Policies[0].Members[0].Email)
+	req.Headers["Authorization"] = fmt.Sprintf("Access %s", fixtures.Policies[0].Members[0].Email)
 	req.Headers["content-type"] = domain.ContentJson
 	res := req.Get()
 

--- a/application/actions/itemcategories_test.go
+++ b/application/actions/itemcategories_test.go
@@ -45,8 +45,10 @@ func (as *ActionSuite) Test_ItemCategoriesList() {
 	}
 	models.MustCreate(as.DB, &disabled)
 
+	uat, uatErr := fixtures.Policies[0].Members[0].CreateAccessToken(as.DB)
+	as.NoError(uatErr)
+	as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 	req := as.JSON("/config/item-categories")
-	req.Headers["Authorization"] = fmt.Sprintf("Access %s", fixtures.Policies[0].Members[0].Email)
 	req.Headers["content-type"] = domain.ContentJson
 	res := req.Get()
 

--- a/application/actions/items_test.go
+++ b/application/actions/items_test.go
@@ -93,7 +93,7 @@ func (as *ActionSuite) Test_ItemsList() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/%s/%s/%s", domain.TypePolicy, tt.policy.ID.String(), domain.TypeItem)
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Get()
 
@@ -169,7 +169,7 @@ func (as *ActionSuite) Test_ItemsCreate() {
 			wantStatus: http.StatusUnauthorized,
 			wantInBody: []string{
 				api.ErrorNotAuthorized.String(),
-				"no bearer token provided",
+				"no access token provided",
 			},
 		},
 		{
@@ -200,7 +200,7 @@ func (as *ActionSuite) Test_ItemsCreate() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/%s/%s/%s", domain.TypePolicy, tt.policy.ID.String(), domain.TypeItem)
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(tt.newItem)
 
@@ -257,7 +257,7 @@ func (as *ActionSuite) Test_ItemsSubmit() {
 			wantStatus: http.StatusUnauthorized,
 			wantInBody: []string{
 				api.ErrorNotAuthorized.String(),
-				"no bearer token provided",
+				"no access token provided",
 			},
 		},
 		{
@@ -301,7 +301,7 @@ func (as *ActionSuite) Test_ItemsSubmit() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/%s/%s/%s", domain.TypeItem, tt.oldItem.ID.String(), api.ResourceSubmit)
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(nil)
 
@@ -360,7 +360,7 @@ func (as *ActionSuite) Test_ItemsRevision() {
 			wantStatus: http.StatusUnauthorized,
 			wantInBody: []string{
 				api.ErrorNotAuthorized.String(),
-				"no bearer token provided",
+				"no access token provided",
 			},
 		},
 		{
@@ -415,7 +415,7 @@ func (as *ActionSuite) Test_ItemsRevision() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/%s/%s/%s", domain.TypeItem, tt.oldItem.ID.String(), api.ResourceRevision)
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(api.ItemStatusInput{StatusReason: tt.reason})
 
@@ -471,7 +471,7 @@ func (as *ActionSuite) Test_ItemsApprove() {
 			wantStatus: http.StatusUnauthorized,
 			wantInBody: []string{
 				api.ErrorNotAuthorized.String(),
-				"no bearer token provided",
+				"no Access token provided",
 			},
 		},
 		{
@@ -505,7 +505,7 @@ func (as *ActionSuite) Test_ItemsApprove() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/%s/%s/%s", domain.TypeItem, tt.oldItem.ID.String(), api.ResourceApprove)
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(nil)
 
@@ -562,7 +562,7 @@ func (as *ActionSuite) Test_ItemsDeny() {
 			wantStatus: http.StatusUnauthorized,
 			wantInBody: []string{
 				api.ErrorNotAuthorized.String(),
-				"no bearer token provided",
+				"no Access token provided",
 			},
 		},
 		{
@@ -607,7 +607,7 @@ func (as *ActionSuite) Test_ItemsDeny() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/%s/%s/%s", domain.TypeItem, tt.oldItem.ID.String(), api.ResourceDeny)
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 
 			res := req.Post(api.ItemStatusInput{StatusReason: tt.reason})
@@ -686,7 +686,7 @@ func (as *ActionSuite) Test_ItemsUpdate() {
 			wantStatus: http.StatusUnauthorized,
 			wantInBody: []string{
 				api.ErrorNotAuthorized.String(),
-				"no bearer token provided",
+				"no Access token provided",
 			},
 		},
 		{
@@ -747,7 +747,7 @@ func (as *ActionSuite) Test_ItemsUpdate() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/items/%s", tt.oldItem.ID.String())
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Put(tt.newItem)
 
@@ -818,7 +818,7 @@ func (as *ActionSuite) Test_ItemsRemove() {
 			wantHTTPStatus: http.StatusUnauthorized,
 			wantInBody: []string{
 				api.ErrorNotAuthorized.String(),
-				"no bearer token provided",
+				"no Access token provided",
 			},
 		},
 		{
@@ -862,7 +862,7 @@ func (as *ActionSuite) Test_ItemsRemove() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/%s/%s", domain.TypeItem, tt.item.ID.String())
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Delete()
 

--- a/application/actions/items_test.go
+++ b/application/actions/items_test.go
@@ -92,9 +92,7 @@ func (as *ActionSuite) Test_ItemsList() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, uatErr := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(uatErr)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/%s/%s/%s", domain.TypePolicy, tt.policy.ID.String(), domain.TypeItem)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Get()
@@ -201,9 +199,7 @@ func (as *ActionSuite) Test_ItemsCreate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, uatErr := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(uatErr)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/%s/%s/%s", domain.TypePolicy, tt.policy.ID.String(), domain.TypeItem)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(tt.newItem)
@@ -304,9 +300,7 @@ func (as *ActionSuite) Test_ItemsSubmit() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/%s/%s/%s", domain.TypeItem, tt.oldItem.ID.String(), api.ResourceSubmit)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(nil)
@@ -420,9 +414,7 @@ func (as *ActionSuite) Test_ItemsRevision() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/%s/%s/%s", domain.TypeItem, tt.oldItem.ID.String(), api.ResourceRevision)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(api.ItemStatusInput{StatusReason: tt.reason})
@@ -512,9 +504,7 @@ func (as *ActionSuite) Test_ItemsApprove() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/%s/%s/%s", domain.TypeItem, tt.oldItem.ID.String(), api.ResourceApprove)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(nil)
@@ -616,9 +606,7 @@ func (as *ActionSuite) Test_ItemsDeny() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/%s/%s/%s", domain.TypeItem, tt.oldItem.ID.String(), api.ResourceDeny)
 			req.Headers["content-type"] = domain.ContentJson
 
@@ -758,9 +746,7 @@ func (as *ActionSuite) Test_ItemsUpdate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, uatErr := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(uatErr)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/items/%s", tt.oldItem.ID.String())
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Put(tt.newItem)
@@ -875,9 +861,7 @@ func (as *ActionSuite) Test_ItemsRemove() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/%s/%s", domain.TypeItem, tt.item.ID.String())
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Delete()

--- a/application/actions/items_test.go
+++ b/application/actions/items_test.go
@@ -92,8 +92,10 @@ func (as *ActionSuite) Test_ItemsList() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, uatErr := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(uatErr)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/%s/%s/%s", domain.TypePolicy, tt.policy.ID.String(), domain.TypeItem)
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Get()
 
@@ -199,8 +201,10 @@ func (as *ActionSuite) Test_ItemsCreate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, uatErr := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(uatErr)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/%s/%s/%s", domain.TypePolicy, tt.policy.ID.String(), domain.TypeItem)
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(tt.newItem)
 
@@ -300,8 +304,10 @@ func (as *ActionSuite) Test_ItemsSubmit() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/%s/%s/%s", domain.TypeItem, tt.oldItem.ID.String(), api.ResourceSubmit)
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(nil)
 
@@ -414,8 +420,10 @@ func (as *ActionSuite) Test_ItemsRevision() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/%s/%s/%s", domain.TypeItem, tt.oldItem.ID.String(), api.ResourceRevision)
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(api.ItemStatusInput{StatusReason: tt.reason})
 
@@ -471,7 +479,7 @@ func (as *ActionSuite) Test_ItemsApprove() {
 			wantStatus: http.StatusUnauthorized,
 			wantInBody: []string{
 				api.ErrorNotAuthorized.String(),
-				"no Access token provided",
+				"no access token provided",
 			},
 		},
 		{
@@ -504,8 +512,10 @@ func (as *ActionSuite) Test_ItemsApprove() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/%s/%s/%s", domain.TypeItem, tt.oldItem.ID.String(), api.ResourceApprove)
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(nil)
 
@@ -562,7 +572,7 @@ func (as *ActionSuite) Test_ItemsDeny() {
 			wantStatus: http.StatusUnauthorized,
 			wantInBody: []string{
 				api.ErrorNotAuthorized.String(),
-				"no Access token provided",
+				"no access token provided",
 			},
 		},
 		{
@@ -606,8 +616,10 @@ func (as *ActionSuite) Test_ItemsDeny() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/%s/%s/%s", domain.TypeItem, tt.oldItem.ID.String(), api.ResourceDeny)
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 
 			res := req.Post(api.ItemStatusInput{StatusReason: tt.reason})
@@ -686,7 +698,7 @@ func (as *ActionSuite) Test_ItemsUpdate() {
 			wantStatus: http.StatusUnauthorized,
 			wantInBody: []string{
 				api.ErrorNotAuthorized.String(),
-				"no Access token provided",
+				"no access token provided",
 			},
 		},
 		{
@@ -746,8 +758,10 @@ func (as *ActionSuite) Test_ItemsUpdate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, uatErr := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(uatErr)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/items/%s", tt.oldItem.ID.String())
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Put(tt.newItem)
 
@@ -818,7 +832,7 @@ func (as *ActionSuite) Test_ItemsRemove() {
 			wantHTTPStatus: http.StatusUnauthorized,
 			wantInBody: []string{
 				api.ErrorNotAuthorized.String(),
-				"no Access token provided",
+				"no access token provided",
 			},
 		},
 		{
@@ -861,8 +875,10 @@ func (as *ActionSuite) Test_ItemsRemove() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/%s/%s", domain.TypeItem, tt.item.ID.String())
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Delete()
 

--- a/application/actions/ledger_test.go
+++ b/application/actions/ledger_test.go
@@ -54,8 +54,10 @@ func (as *ActionSuite) Test_LedgerReportList() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON(ledgerReportPath)
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			res := req.Get()
 
 			body := res.Body.String()
@@ -139,8 +141,10 @@ func (as *ActionSuite) Test_LedgerReportView() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON(fmt.Sprintf("%s/%s", ledgerReportPath, tt.lrID))
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			res := req.Get()
 
 			body := res.Body.String()
@@ -208,8 +212,10 @@ func (as *ActionSuite) Test_LedgerReportCreate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON(ledgerReportPath)
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			res := req.Post(api.LedgerReportCreateInput{
 				Type: tt.reportType,
 				Date: time.Now().UTC().Format(domain.DateFormat),
@@ -280,8 +286,10 @@ func (as *ActionSuite) Test_LedgerReportReconcile() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON(fmt.Sprintf("%s/%s", ledgerReportPath, lr.ID))
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			res := req.Put(nil)
 
 			body := res.Body.String()
@@ -348,8 +356,10 @@ func (as *ActionSuite) Test_LedgerAnnualProcess() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON(ledgerReportPath + "/annual")
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			res := req.Post(nil)
 
 			body := res.Body.String()
@@ -406,8 +416,10 @@ func (as *ActionSuite) Test_LedgerAnnualRenewalStatus() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON(ledgerReportPath + "/annual")
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			res := req.Get()
 			body := res.Body.Bytes()
 
@@ -495,8 +507,10 @@ func (as *ActionSuite) Test_LedgerMonthlyProcess() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON(ledgerReportPath + "/monthly")
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			res := req.Post(nil)
 
 			body := res.Body.String()
@@ -552,8 +566,10 @@ func (as *ActionSuite) Test_LedgerMonthlyStatus() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON(ledgerReportPath + "/monthly")
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			res := req.Get()
 
 			body := res.Body.String()

--- a/application/actions/ledger_test.go
+++ b/application/actions/ledger_test.go
@@ -55,7 +55,7 @@ func (as *ActionSuite) Test_LedgerReportList() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON(ledgerReportPath)
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			res := req.Get()
 
 			body := res.Body.String()
@@ -140,7 +140,7 @@ func (as *ActionSuite) Test_LedgerReportView() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON(fmt.Sprintf("%s/%s", ledgerReportPath, tt.lrID))
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			res := req.Get()
 
 			body := res.Body.String()
@@ -209,7 +209,7 @@ func (as *ActionSuite) Test_LedgerReportCreate() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON(ledgerReportPath)
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			res := req.Post(api.LedgerReportCreateInput{
 				Type: tt.reportType,
 				Date: time.Now().UTC().Format(domain.DateFormat),
@@ -281,7 +281,7 @@ func (as *ActionSuite) Test_LedgerReportReconcile() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON(fmt.Sprintf("%s/%s", ledgerReportPath, lr.ID))
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			res := req.Put(nil)
 
 			body := res.Body.String()
@@ -349,7 +349,7 @@ func (as *ActionSuite) Test_LedgerAnnualProcess() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON(ledgerReportPath + "/annual")
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			res := req.Post(nil)
 
 			body := res.Body.String()
@@ -407,7 +407,7 @@ func (as *ActionSuite) Test_LedgerAnnualRenewalStatus() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON(ledgerReportPath + "/annual")
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			res := req.Get()
 			body := res.Body.Bytes()
 
@@ -496,7 +496,7 @@ func (as *ActionSuite) Test_LedgerMonthlyProcess() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON(ledgerReportPath + "/monthly")
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			res := req.Post(nil)
 
 			body := res.Body.String()
@@ -553,7 +553,7 @@ func (as *ActionSuite) Test_LedgerMonthlyStatus() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON(ledgerReportPath + "/monthly")
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			res := req.Get()
 
 			body := res.Body.String()

--- a/application/actions/ledger_test.go
+++ b/application/actions/ledger_test.go
@@ -54,9 +54,7 @@ func (as *ActionSuite) Test_LedgerReportList() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON(ledgerReportPath)
 			res := req.Get()
 
@@ -141,9 +139,7 @@ func (as *ActionSuite) Test_LedgerReportView() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON(fmt.Sprintf("%s/%s", ledgerReportPath, tt.lrID))
 			res := req.Get()
 
@@ -212,9 +208,7 @@ func (as *ActionSuite) Test_LedgerReportCreate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON(ledgerReportPath)
 			res := req.Post(api.LedgerReportCreateInput{
 				Type: tt.reportType,
@@ -286,9 +280,7 @@ func (as *ActionSuite) Test_LedgerReportReconcile() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON(fmt.Sprintf("%s/%s", ledgerReportPath, lr.ID))
 			res := req.Put(nil)
 
@@ -356,9 +348,7 @@ func (as *ActionSuite) Test_LedgerAnnualProcess() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON(ledgerReportPath + "/annual")
 			res := req.Post(nil)
 
@@ -416,9 +406,7 @@ func (as *ActionSuite) Test_LedgerAnnualRenewalStatus() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON(ledgerReportPath + "/annual")
 			res := req.Get()
 			body := res.Body.Bytes()
@@ -507,9 +495,7 @@ func (as *ActionSuite) Test_LedgerMonthlyProcess() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON(ledgerReportPath + "/monthly")
 			res := req.Post(nil)
 
@@ -566,9 +552,7 @@ func (as *ActionSuite) Test_LedgerMonthlyStatus() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON(ledgerReportPath + "/monthly")
 			res := req.Get()
 

--- a/application/actions/policies_test.go
+++ b/application/actions/policies_test.go
@@ -87,9 +87,7 @@ func (as *ActionSuite) Test_PoliciesList() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, uatErr := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(uatErr)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/policies" + tt.queryString)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Get()
@@ -216,9 +214,7 @@ func (as *ActionSuite) Test_PoliciesView() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, uatErr := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(uatErr)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/policies/" + tt.policyID.String())
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Get()
@@ -296,9 +292,7 @@ func (as *ActionSuite) Test_PoliciesCreateTeam() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/policies")
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(tt.input)
@@ -393,9 +387,7 @@ func (as *ActionSuite) Test_PoliciesUpdate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/policies/" + tt.policy.ID.String())
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Put(tt.update)
@@ -509,9 +501,7 @@ func (as *ActionSuite) Test_PoliciesListMembers() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, uatErr := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(uatErr)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/policies/" + tt.policyID + "/members")
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Get()
@@ -624,9 +614,7 @@ func (as *ActionSuite) Test_PoliciesInviteMember() {
 				Name:  tt.inviteeName,
 			}
 
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/policies/" + tt.policyID.String() + "/members")
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(input)
@@ -699,9 +687,7 @@ func (as *ActionSuite) Test_PolicyLedgerReportCreate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("%s/%s/ledger-reports", policiesPath, policy.ID.String())
 			res := req.Post(api.PolicyLedgerReportCreateInput{
 				Month: tt.month,
@@ -795,9 +781,7 @@ func (as *ActionSuite) Test_PolicyLedgerReportView() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("%s/%s/ledger-reports?month=%d&year=%d", policiesPath, policy.ID.String(), tt.month, tt.year)
 			res := req.Get()
 
@@ -872,9 +856,7 @@ func (as *ActionSuite) Test_PolicyStrikesCreate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("%s/%s/%s", policiesPath, tt.policy.ID.String(), api.ResourceStrikes)
 			res := req.Post(api.StrikeInput{Description: "New Strike"})
 

--- a/application/actions/policies_test.go
+++ b/application/actions/policies_test.go
@@ -89,7 +89,7 @@ func (as *ActionSuite) Test_PoliciesList() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/policies" + tt.queryString)
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Get()
 
@@ -216,7 +216,7 @@ func (as *ActionSuite) Test_PoliciesView() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/policies/" + tt.policyID.String())
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Get()
 
@@ -294,7 +294,7 @@ func (as *ActionSuite) Test_PoliciesCreateTeam() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/policies")
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(tt.input)
 
@@ -389,7 +389,7 @@ func (as *ActionSuite) Test_PoliciesUpdate() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/policies/" + tt.policy.ID.String())
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Put(tt.update)
 
@@ -503,7 +503,7 @@ func (as *ActionSuite) Test_PoliciesListMembers() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/policies/" + tt.policyID + "/members")
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Get()
 
@@ -616,7 +616,7 @@ func (as *ActionSuite) Test_PoliciesInviteMember() {
 			}
 
 			req := as.JSON("/policies/" + tt.policyID.String() + "/members")
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(input)
 
@@ -689,7 +689,7 @@ func (as *ActionSuite) Test_PolicyLedgerReportCreate() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("%s/%s/ledger-reports", policiesPath, policy.ID.String())
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			res := req.Post(api.PolicyLedgerReportCreateInput{
 				Month: tt.month,
 				Year:  tt.year,
@@ -783,7 +783,7 @@ func (as *ActionSuite) Test_PolicyLedgerReportView() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("%s/%s/ledger-reports?month=%d&year=%d", policiesPath, policy.ID.String(), tt.month, tt.year)
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			res := req.Get()
 
 			body := res.Body.String()
@@ -858,7 +858,7 @@ func (as *ActionSuite) Test_PolicyStrikesCreate() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("%s/%s/%s", policiesPath, tt.policy.ID.String(), api.ResourceStrikes)
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			res := req.Post(api.StrikeInput{Description: "New Strike"})
 
 			body := res.Body.String()

--- a/application/actions/policies_test.go
+++ b/application/actions/policies_test.go
@@ -2,7 +2,6 @@ package actions
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -88,8 +87,10 @@ func (as *ActionSuite) Test_PoliciesList() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, uatErr := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(uatErr)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/policies" + tt.queryString)
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Get()
 
@@ -215,8 +216,10 @@ func (as *ActionSuite) Test_PoliciesView() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, uatErr := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(uatErr)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/policies/" + tt.policyID.String())
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Get()
 
@@ -293,8 +296,10 @@ func (as *ActionSuite) Test_PoliciesCreateTeam() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/policies")
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(tt.input)
 
@@ -388,8 +393,10 @@ func (as *ActionSuite) Test_PoliciesUpdate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/policies/" + tt.policy.ID.String())
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Put(tt.update)
 
@@ -502,8 +509,10 @@ func (as *ActionSuite) Test_PoliciesListMembers() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, uatErr := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(uatErr)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/policies/" + tt.policyID + "/members")
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Get()
 
@@ -615,8 +624,10 @@ func (as *ActionSuite) Test_PoliciesInviteMember() {
 				Name:  tt.inviteeName,
 			}
 
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/policies/" + tt.policyID.String() + "/members")
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(input)
 
@@ -688,8 +699,10 @@ func (as *ActionSuite) Test_PolicyLedgerReportCreate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("%s/%s/ledger-reports", policiesPath, policy.ID.String())
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			res := req.Post(api.PolicyLedgerReportCreateInput{
 				Month: tt.month,
 				Year:  tt.year,
@@ -782,8 +795,10 @@ func (as *ActionSuite) Test_PolicyLedgerReportView() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("%s/%s/ledger-reports?month=%d&year=%d", policiesPath, policy.ID.String(), tt.month, tt.year)
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			res := req.Get()
 
 			body := res.Body.String()
@@ -857,8 +872,10 @@ func (as *ActionSuite) Test_PolicyStrikesCreate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("%s/%s/%s", policiesPath, tt.policy.ID.String(), api.ResourceStrikes)
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			res := req.Post(api.StrikeInput{Description: "New Strike"})
 
 			body := res.Body.String()

--- a/application/actions/policymembers_test.go
+++ b/application/actions/policymembers_test.go
@@ -44,9 +44,7 @@ func (as *ActionSuite) TestPolicyMember_Delete() {
 	}
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON(fmt.Sprintf("%s/%s", policyMemberPath, tt.polUserID))
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Delete()

--- a/application/actions/policymembers_test.go
+++ b/application/actions/policymembers_test.go
@@ -45,7 +45,7 @@ func (as *ActionSuite) TestPolicyMember_Delete() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON(fmt.Sprintf("%s/%s", policyMemberPath, tt.polUserID))
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Delete()
 

--- a/application/actions/policymembers_test.go
+++ b/application/actions/policymembers_test.go
@@ -44,8 +44,10 @@ func (as *ActionSuite) TestPolicyMember_Delete() {
 	}
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON(fmt.Sprintf("%s/%s", policyMemberPath, tt.polUserID))
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Delete()
 

--- a/application/actions/repairs_test.go
+++ b/application/actions/repairs_test.go
@@ -54,7 +54,7 @@ func (as *ActionSuite) Test_repairsRun() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON(repairsPath)
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(tt.input)
 			body := res.Body.Bytes()

--- a/application/actions/repairs_test.go
+++ b/application/actions/repairs_test.go
@@ -52,9 +52,7 @@ func (as *ActionSuite) Test_repairsRun() {
 	}
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON(repairsPath)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(tt.input)

--- a/application/actions/repairs_test.go
+++ b/application/actions/repairs_test.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -53,8 +52,10 @@ func (as *ActionSuite) Test_repairsRun() {
 	}
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON(repairsPath)
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(tt.input)
 			body := res.Body.Bytes()

--- a/application/actions/steward_test.go
+++ b/application/actions/steward_test.go
@@ -65,7 +65,7 @@ func (as *ActionSuite) Test_StewardListRecent() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON(stewardPath + "/" + api.ResourceRecent)
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Get()
 

--- a/application/actions/steward_test.go
+++ b/application/actions/steward_test.go
@@ -63,9 +63,7 @@ func (as *ActionSuite) Test_StewardListRecent() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON(stewardPath + "/" + api.ResourceRecent)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Get()

--- a/application/actions/steward_test.go
+++ b/application/actions/steward_test.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -64,8 +63,10 @@ func (as *ActionSuite) Test_StewardListRecent() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON(stewardPath + "/" + api.ResourceRecent)
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Get()
 

--- a/application/actions/strikes_test.go
+++ b/application/actions/strikes_test.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -56,8 +55,10 @@ func (as *ActionSuite) Test_StrikesUpdate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("%s/%s", strikesPath, tt.strike.ID.String())
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			res := req.Put(api.StrikeInput{Description: newDescription})
 
 			body := res.Body.String()
@@ -109,8 +110,10 @@ func (as *ActionSuite) Test_StrikesDelete() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("%s/%s", strikesPath, tt.strike.ID.String())
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			res := req.Delete()
 
 			body := res.Body.String()

--- a/application/actions/strikes_test.go
+++ b/application/actions/strikes_test.go
@@ -57,7 +57,7 @@ func (as *ActionSuite) Test_StrikesUpdate() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("%s/%s", strikesPath, tt.strike.ID.String())
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			res := req.Put(api.StrikeInput{Description: newDescription})
 
 			body := res.Body.String()
@@ -110,7 +110,7 @@ func (as *ActionSuite) Test_StrikesDelete() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("%s/%s", strikesPath, tt.strike.ID.String())
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			res := req.Delete()
 
 			body := res.Body.String()

--- a/application/actions/strikes_test.go
+++ b/application/actions/strikes_test.go
@@ -55,9 +55,7 @@ func (as *ActionSuite) Test_StrikesUpdate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("%s/%s", strikesPath, tt.strike.ID.String())
 			res := req.Put(api.StrikeInput{Description: newDescription})
 
@@ -110,9 +108,7 @@ func (as *ActionSuite) Test_StrikesDelete() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("%s/%s", strikesPath, tt.strike.ID.String())
 			res := req.Delete()
 

--- a/application/actions/users_test.go
+++ b/application/actions/users_test.go
@@ -169,9 +169,7 @@ func (as *ActionSuite) Test_UsersMeUpdate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, uatErr := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(uatErr)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/users/me")
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Put(tt.input)
@@ -262,9 +260,7 @@ func (as *ActionSuite) Test_UsersMeFilesAttach() {
 	}
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
-			uat, err := tt.actor.CreateAccessToken(as.DB)
-			as.NoError(err)
-			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
+			as.SetAccessToken(tt.actor)
 			req := as.JSON("/users/me/files")
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(tt.input)

--- a/application/actions/users_test.go
+++ b/application/actions/users_test.go
@@ -75,8 +75,10 @@ func (as *ActionSuite) Test_usersMe() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.user.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/users/me")
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.token)
 
 			res := req.Get()
 
@@ -126,7 +128,7 @@ func (as *ActionSuite) Test_UsersMeUpdate() {
 			wantStatus: http.StatusUnauthorized,
 			wantInBody: []string{
 				api.ErrorNotAuthorized.String(),
-				"no Access token provided",
+				"no access token provided",
 			},
 		},
 		{
@@ -167,8 +169,10 @@ func (as *ActionSuite) Test_UsersMeUpdate() {
 
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, uatErr := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(uatErr)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/users/me")
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Put(tt.input)
 
@@ -258,8 +262,10 @@ func (as *ActionSuite) Test_UsersMeFilesAttach() {
 	}
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
+			uat, err := tt.actor.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req := as.JSON("/users/me/files")
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(tt.input)
 
@@ -307,7 +313,9 @@ func (as *ActionSuite) Test_UsersMeFilesDelete() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/users/me/files")
-			req.Headers["Authorization"] = fmt.Sprintf("Access %s", currentUser.Email)
+			uat, err := currentUser.CreateAccessToken(as.DB)
+			as.NoError(err)
+			as.Session.Set(AccessTokenSessionKey, uat.AccessToken)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Delete()
 

--- a/application/actions/users_test.go
+++ b/application/actions/users_test.go
@@ -76,7 +76,7 @@ func (as *ActionSuite) Test_usersMe() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/users/me")
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.token)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.token)
 
 			res := req.Get()
 
@@ -126,7 +126,7 @@ func (as *ActionSuite) Test_UsersMeUpdate() {
 			wantStatus: http.StatusUnauthorized,
 			wantInBody: []string{
 				api.ErrorNotAuthorized.String(),
-				"no bearer token provided",
+				"no Access token provided",
 			},
 		},
 		{
@@ -168,7 +168,7 @@ func (as *ActionSuite) Test_UsersMeUpdate() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/users/me")
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Put(tt.input)
 
@@ -259,7 +259,7 @@ func (as *ActionSuite) Test_UsersMeFilesAttach() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/users/me/files")
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", tt.actor.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", tt.actor.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Post(tt.input)
 
@@ -307,7 +307,7 @@ func (as *ActionSuite) Test_UsersMeFilesDelete() {
 	for _, tt := range tests {
 		as.T().Run(tt.name, func(t *testing.T) {
 			req := as.JSON("/users/me/files")
-			req.Headers["Authorization"] = fmt.Sprintf("Bearer %s", currentUser.Email)
+			req.Headers["Authorization"] = fmt.Sprintf("Access %s", currentUser.Email)
 			req.Headers["content-type"] = domain.ContentJson
 			res := req.Delete()
 

--- a/application/api/errorcodes.go
+++ b/application/api/errorcodes.go
@@ -56,7 +56,6 @@ const (
 	ErrorInviteExpired            = ErrorKey("ErrorInviteExpired")
 	ErrorLoadingAuthProvider      = ErrorKey("ErrorLoadingAuthProvider")
 	ErrorMissingAuthEmail         = ErrorKey("ErrorMissingAuthEmail")
-	ErrorMissingLogoutToken       = ErrorKey("ErrorMissingLogoutToken")
 	ErrorProcessingAuthInviteCode = ErrorKey("ErrorProcessingAuthInviteCode")
 	ErrorWithAuthUser             = ErrorKey("ErrorWithAuthUser")
 

--- a/application/api/errorcodes.go
+++ b/application/api/errorcodes.go
@@ -56,9 +56,7 @@ const (
 	ErrorInviteExpired            = ErrorKey("ErrorInviteExpired")
 	ErrorLoadingAuthProvider      = ErrorKey("ErrorLoadingAuthProvider")
 	ErrorMissingAuthEmail         = ErrorKey("ErrorMissingAuthEmail")
-	ErrorMissingClientID          = ErrorKey("ErrorMissingClientID")
 	ErrorMissingLogoutToken       = ErrorKey("ErrorMissingLogoutToken")
-	ErrorMissingSessionClientID   = ErrorKey("ErrorMissingSessionClientID")
 	ErrorProcessingAuthInviteCode = ErrorKey("ErrorProcessingAuthInviteCode")
 	ErrorWithAuthUser             = ErrorKey("ErrorWithAuthUser")
 

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -293,21 +293,29 @@ func EmailFromAddress(name *string) string {
 	return addr
 }
 
-// GetBearerTokenFromRequest obtains the token from an Authorization header beginning
+// GetBearerTokenFromRequest obtains the token from a cookie beginning
 // with "Bearer". If not found, an empty string is returned.
 func GetBearerTokenFromRequest(r *http.Request) string {
-	authorizationHeader := r.Header.Get("Authorization")
-	if authorizationHeader == "" {
+	cookie, err := r.Cookie("bearer-token")
+	if err != nil {
+		log.Error("failed to retrieve bearer token cookie:", err)
+		return ""
+	}
+
+	authorizationCookie := cookie.Value
+
+	if authorizationCookie == "" {
 		return ""
 	}
 
 	re := regexp.MustCompile(`^(?i)Bearer (.*)$`)
-	matches := re.FindSubmatch([]byte(authorizationHeader))
+	matches := re.FindStringSubmatch(authorizationCookie)
 	if len(matches) < 2 {
+		log.Error("failed to extract Bearer token from cookie")
 		return ""
 	}
 
-	return string(matches[1])
+	return matches[1]
 }
 
 // IsOtherThanNoRows returns false if the error is nil or is just reporting that there

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -462,14 +462,6 @@ func IsProduction() bool {
 	return false
 }
 
-func IsDevelopment() bool {
-	return Env.GoEnv == EnvDevelopment
-}
-
-func IsTest() bool {
-	return Env.GoEnv == EnvTest
-}
-
 func checkSamlConfig(env *EnvStruct) {
 	if env.GoEnv == EnvDevelopment || env.GoEnv == EnvTest {
 		return

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -292,21 +292,22 @@ func EmailFromAddress(name *string) string {
 	return addr
 }
 
-// GetBearerTokenFromRequest obtains the token from a cookie beginning
-// with "Bearer". If not found, an empty string is returned.
-func GetBearerTokenFromRequest(r *http.Request) string {
-	cookie, err := r.Cookie("bearer-token")
+// GetCombinedTokenFromRequest obtains the token from a cookie in the request.
+// If not found, an empty string is returned.
+func GetCombinedTokenFromRequest(r *http.Request) string {
+	cookie, err := r.Cookie("access-token")
 	if err != nil {
-		log.Error("failed to retrieve bearer token cookie:", err)
+		log.Error("failed to retrieve access token cookie:", err)
 		return ""
 	}
-	clientId, err := r.Cookie("seed")
+
+	clientID, err := r.Cookie("client-id")
 	if err != nil {
 		log.Error("failed to retrieve seed cookie:", err)
 		return ""
 	}
 
-	return clientId.Value + cookie.Value
+	return clientID.Value + cookie.Value
 }
 
 // IsOtherThanNoRows returns false if the error is nil or is just reporting that there
@@ -478,6 +479,10 @@ func IsProduction() bool {
 		return true
 	}
 	return false
+}
+
+func IsDevelopment() bool {
+	return Env.GoEnv == EnvDevelopment
 }
 
 func checkSamlConfig(env *EnvStruct) {

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"math/rand"
 	"net/http"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -301,21 +300,13 @@ func GetBearerTokenFromRequest(r *http.Request) string {
 		log.Error("failed to retrieve bearer token cookie:", err)
 		return ""
 	}
-
-	authorizationCookie := cookie.Value
-
-	if authorizationCookie == "" {
+	clientId, err := r.Cookie("seed")
+	if err != nil {
+		log.Error("failed to retrieve seed cookie:", err)
 		return ""
 	}
 
-	re := regexp.MustCompile(`^(?i)Bearer (.*)$`)
-	matches := re.FindStringSubmatch(authorizationCookie)
-	if len(matches) < 2 {
-		log.Error("failed to extract Bearer token from cookie")
-		return ""
-	}
-
-	return matches[1]
+	return clientId.Value + cookie.Value
 }
 
 // IsOtherThanNoRows returns false if the error is nil or is just reporting that there

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -292,24 +291,6 @@ func EmailFromAddress(name *string) string {
 	return addr
 }
 
-// GetCombinedTokenFromRequest obtains the token from a cookie in the request.
-// If not found, an empty string is returned.
-func GetCombinedTokenFromRequest(r *http.Request) string {
-	cookie, err := r.Cookie("access-token")
-	if err != nil {
-		log.Error("failed to retrieve access token cookie:", err)
-		return ""
-	}
-
-	clientID, err := r.Cookie("client-id")
-	if err != nil {
-		log.Error("failed to retrieve seed cookie:", err)
-		return ""
-	}
-
-	return clientID.Value + cookie.Value
-}
-
 // IsOtherThanNoRows returns false if the error is nil or is just reporting that there
 // were no rows in the result set for a sql query.
 func IsOtherThanNoRows(err error) bool {
@@ -483,6 +464,10 @@ func IsProduction() bool {
 
 func IsDevelopment() bool {
 	return Env.GoEnv == EnvDevelopment
+}
+
+func IsTest() bool {
+	return Env.GoEnv == EnvTest
 }
 
 func checkSamlConfig(env *EnvStruct) {

--- a/application/grifts/db.go
+++ b/application/grifts/db.go
@@ -160,7 +160,7 @@ func createUserFixtures(tx *pop.Connection) ([]*models.User, error) {
 	for i := range fixUserTokens {
 		fixUserTokens[i].ID = domain.GetUUID()
 		fixUserTokens[i].UserID = fixUsers[i].ID
-		fixUserTokens[i].TokenHash = models.HashClientIdAccessToken(fixUsers[i].Email)
+		fixUserTokens[i].TokenHash = models.HashAccessToken(fixUsers[i].Email)
 		fixUserTokens[i].ExpiresAt = oneYearFromNow
 
 		err := tx.Create(&fixUserTokens[i])

--- a/application/models/testutils.go
+++ b/application/models/testutils.go
@@ -336,7 +336,7 @@ func CreateUserFixtures(tx *pop.Connection, n int) Fixtures {
 		MustCreate(tx, &users[i])
 
 		accessTokenFixtures[i].UserID = users[i].ID
-		accessTokenFixtures[i].TokenHash = HashClientIdAccessToken(users[i].Email)
+		accessTokenFixtures[i].TokenHash = HashAccessToken(users[i].Email)
 		accessTokenFixtures[i].ExpiresAt = time.Now().UTC().Add(time.Minute * 60)
 		accessTokenFixtures[i].LastUsedAt = nulls.NewTime(time.Now())
 		MustCreate(tx, &accessTokenFixtures[i])

--- a/application/models/user.go
+++ b/application/models/user.go
@@ -222,6 +222,10 @@ func (u *Users) FindSignators(tx *pop.Connection) {
 
 // CreateAccessToken - Create and store new UserAccessToken
 func (u *User) CreateAccessToken(tx *pop.Connection) (UserAccessToken, error) {
+	if u.ID == uuid.Nil {
+		log.Error("user must have an ID in CreateAccessToken")
+		return UserAccessToken{}, nil
+	}
 	uat := InitAccessToken()
 	uat.UserID = u.ID
 

--- a/application/models/user.go
+++ b/application/models/user.go
@@ -86,8 +86,8 @@ func (u *User) Update(tx *pop.Connection) error {
 	return update(tx, u)
 }
 
-// HashClientIdAccessToken just returns a sha256.Sum256 of the input value
-func HashClientIdAccessToken(accessToken string) string {
+// HashAccessToken just returns a sha256.Sum256 of the input value
+func HashAccessToken(accessToken string) string {
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(accessToken)))
 }
 
@@ -221,13 +221,13 @@ func (u *Users) FindSignators(tx *pop.Connection) {
 }
 
 // CreateAccessToken - Create and store new UserAccessToken
-func (u *User) CreateAccessToken(tx *pop.Connection, clientID string) (UserAccessToken, error) {
-	if clientID == "" {
-		return UserAccessToken{}, fmt.Errorf(
-			"cannot create token with empty clientID for user %s %s", u.FirstName, u.LastName)
-	}
+func (u *User) CreateAccessToken(tx *pop.Connection) (UserAccessToken, error) {
+	// if clientID == "" {
+	// 	return UserAccessToken{}, fmt.Errorf(
+	// 		"cannot create token with empty clientID for user %s %s", u.FirstName, u.LastName)
+	// }
 
-	uat := InitAccessToken(clientID)
+	uat := InitAccessToken()
 	uat.UserID = u.ID
 
 	if err := uat.Create(tx); err != nil {

--- a/application/models/user.go
+++ b/application/models/user.go
@@ -222,11 +222,6 @@ func (u *Users) FindSignators(tx *pop.Connection) {
 
 // CreateAccessToken - Create and store new UserAccessToken
 func (u *User) CreateAccessToken(tx *pop.Connection) (UserAccessToken, error) {
-	// if clientID == "" {
-	// 	return UserAccessToken{}, fmt.Errorf(
-	// 		"cannot create token with empty clientID for user %s %s", u.FirstName, u.LastName)
-	// }
-
 	uat := InitAccessToken()
 	uat.UserID = u.ID
 

--- a/application/models/useraccesstoken.go
+++ b/application/models/useraccesstoken.go
@@ -63,10 +63,10 @@ func (u *UserAccessToken) ValidateUpdate(tx *pop.Connection) (*validate.Errors, 
 	return validate.NewErrors(), nil
 }
 
-// DeleteByBearerToken uses a sha256.Sum256 of the bearerToken to find which UserAccessToken to delete
+// DeleteByAccessToken uses a sha256.Sum256 of the accessToken to find which UserAccessToken to delete
 // returns an api.AppError
-func (u *UserAccessToken) DeleteByBearerToken(tx *pop.Connection, bearerToken string) error {
-	if appErr := u.FindByBearerToken(tx, bearerToken); appErr != nil {
+func (u *UserAccessToken) DeleteByAccessToken(tx *pop.Connection, token string) error {
+	if appErr := u.FindByAccessToken(tx, token); appErr != nil {
 		return appErr
 	}
 	if err := u.Destroy(tx); err != nil {
@@ -93,11 +93,11 @@ func (u *UserAccessToken) Destroy(tx *pop.Connection) error {
 	return tx.Destroy(u)
 }
 
-// FindByBearerToken uses a sha256.Sum256 of the bearerToken to find the corresponding UserAccessToken
+// FindByAccessToken uses a sha256.Sum256 of the accessToken to find the corresponding UserAccessToken
 // returns an api.AppError
-func (u *UserAccessToken) FindByBearerToken(tx *pop.Connection, bearerToken string) error {
-	if err := tx.Eager().Where("access_token = ?", HashClientIdAccessToken(bearerToken)).First(u); err != nil {
-		l := len(bearerToken)
+func (u *UserAccessToken) FindByAccessToken(tx *pop.Connection, token string) error {
+	if err := tx.Eager().Where("access_token = ?", HashClientIdAccessToken(token)).First(u); err != nil {
+		l := len(token)
 		if l > 5 {
 			l = 5
 		}
@@ -110,7 +110,7 @@ func (u *UserAccessToken) FindByBearerToken(tx *pop.Connection, bearerToken stri
 			Err:      err,
 			Key:      api.ErrorFindingAccessToken,
 			Category: api.CategoryUser,
-			Message:  fmt.Sprintf("failed to find access token '%s...'", bearerToken[0:l]),
+			Message:  fmt.Sprintf("failed to find access token '%s...'", token[0:l]),
 		}
 		return &appErr
 	}

--- a/application/models/useraccesstoken.go
+++ b/application/models/useraccesstoken.go
@@ -96,7 +96,7 @@ func (u *UserAccessToken) Destroy(tx *pop.Connection) error {
 // FindByAccessToken uses a sha256.Sum256 of the accessToken to find the corresponding UserAccessToken
 // returns an api.AppError
 func (u *UserAccessToken) FindByAccessToken(tx *pop.Connection, token string) error {
-	if err := tx.Eager().Where("access_token = ?", HashClientIdAccessToken(token)).First(u); err != nil {
+	if err := tx.Eager().Where("access_token = ?", HashAccessToken(token)).First(u); err != nil {
 		l := len(token)
 		if l > 5 {
 			l = 5
@@ -149,16 +149,16 @@ func (u *UserAccessToken) Update(tx *pop.Connection) error {
 }
 
 // InitAccessToken prepares a new value for the AccessToken field and the ExpiresAt field.
-func InitAccessToken(clientID string) UserAccessToken {
+func InitAccessToken() UserAccessToken {
 	token, _ := getRandomToken() // The init() function would have made sure there was no error
 
 	if domain.Env.GoEnv == domain.EnvDevelopment {
-		fmt.Printf("\n\nClientID+token: %s%s\n", clientID, token)
+		fmt.Printf("\n\ntoken: %s\n", token)
 	}
 
 	return UserAccessToken{
 		AccessToken: token,
-		TokenHash:   HashClientIdAccessToken(clientID + token),
+		TokenHash:   HashAccessToken(token),
 		ExpiresAt:   createAccessTokenExpiry(),
 	}
 }

--- a/application/models/useraccesstoken.go
+++ b/application/models/useraccesstoken.go
@@ -152,10 +152,6 @@ func (u *UserAccessToken) Update(tx *pop.Connection) error {
 func InitAccessToken() UserAccessToken {
 	token, _ := getRandomToken() // The init() function would have made sure there was no error
 
-	if domain.Env.GoEnv == domain.EnvDevelopment {
-		fmt.Printf("\n\ntoken: %s\n", token)
-	}
-
 	return UserAccessToken{
 		AccessToken: token,
 		TokenHash:   HashAccessToken(token),

--- a/application/swagger.json
+++ b/application/swagger.json
@@ -58,14 +58,6 @@
         ],
         "summary": "AuthLogin",
         "operationId": "AuthLogin",
-        "parameters": [
-          {
-            "description": "the user's client id",
-            "name": "client-id",
-            "in": "query",
-            "required": true
-          }
-        ],
         "responses": {
           "200": {
             "description": "returns a \"RedirectURL\" key with the saml idp url that has a saml request"
@@ -81,14 +73,6 @@
         ],
         "summary": "AuthLogout",
         "operationId": "AuthLogout",
-        "parameters": [
-          {
-            "description": "the user's bearer token",
-            "name": "token",
-            "in": "query",
-            "required": true
-          }
-        ],
         "responses": {
           "302": {
             "description": "redirect to UI"


### PR DESCRIPTION
### Changed
- generate access token instead of getting from UI

### Removed
- ClientID

goes with ui PR: https://github.com/silinternational/cover-api/pull/625
---

### Code Checklist
- [ ] Documentation (README, goswagger, etc.)
- [x] Unit tests created or updated
- [ ] Run `gofmt`
- [x] Run `make swaggerspec`
