### PR TITLE
allow deleting dependent with Inactive item

### DIFF
--- a/application/actions/dependents_test.go
+++ b/application/actions/dependents_test.go
@@ -380,11 +380,15 @@ func (as *ActionSuite) Test_DependentsDelete() {
 	fixtures := models.CreateItemFixtures(db, models.FixturesConfig{NumberOfPolicies: 2})
 	policies := fixtures.Policies
 	item := policies[0].Items[0]
+	inactiveItem := policies[1].Items[0]
+	inactiveItem.CoverageStatus = api.ItemCoverageStatusInactive
 
 	depFixtures := models.CreatePolicyDependentFixtures(db, policies[0], 2)
 	deletableDep := depFixtures.PolicyDependents[0]
 	lockedDep := depFixtures.PolicyDependents[1]
 
+	inactiveItem.PolicyDependentID = nulls.NewUUID(deletableDep.ID)
+	as.NoError(db.Update(&inactiveItem), "failed updating item fixture")
 	item.PolicyDependentID = nulls.NewUUID(lockedDep.ID)
 	as.NoError(db.Update(&item), "failed updating item fixture")
 

--- a/application/models/policydependent.go
+++ b/application/models/policydependent.go
@@ -67,11 +67,13 @@ func (p *PolicyDependent) Destroy(tx *pop.Connection) error {
 	return destroy(tx, p)
 }
 
-// RelatedItemNames returns a slice of the names of Items that are related to this dependent
+// RelatedItemNames returns a slice of the names of Items that are related to this dependent and not Inactive
 func (p *PolicyDependent) RelatedItemNames(tx *pop.Connection) []string {
 	names := []string{}
 	for _, item := range p.RelatedItems(tx) {
-		names = append(names, item.Name)
+		if item.CoverageStatus != api.ItemCoverageStatusInactive {
+			names = append(names, item.Name)
+		}
 	}
 	return names
 }


### PR DESCRIPTION

### Fixed
- Allow deleting a dependent with an Inactive item, since the item can't be updated
[CVR-813](https://itse.youtrack.cloud/issue/CVR-813)

### Code Checklist
- [ ] Documentation (README, goswagger, etc.)
- [x] Unit tests created or updated
- [ ] Run `gofmt`
- [ ] Run `make swaggerspec`
