### PR TITLE
CVR-611 -- Remove email salutation

### DIFF
--- a/application/templates/mail/claim_approved_member.plush.html
+++ b/application/templates/mail/claim_approved_member.plush.html
@@ -1,17 +1,13 @@
 <div>
 	<%= partial("mail/body_header", {
-		previewText: "Dear " + personFirstName + ", Congratulations! We've approved the payout for your claim on " +
+		previewText: "Congratulations! We've approved the payout for the claim on " +
 			item.Name + ". You'll get a credit of " + totalPayout + " in your account by the end of this month.",
 		title: "Claim Approved",
 	}) %>
 
 	<div style="max-width: 80ch;">
 		<p>
-			Dear <%= personFirstName %>,
-		</p>
-
-		<p>
-			Congratulations! We've approved the payout for your claim on <%= item.Name %>. You'll get a credit of
+			Congratulations! We've approved the payout for the claim on <%= item.Name %>. You'll get a credit of
 			<%= totalPayout %> in your account by the end of this month.
 		</p>
 

--- a/application/templates/mail/claim_denied_member.plush.html
+++ b/application/templates/mail/claim_denied_member.plush.html
@@ -1,17 +1,13 @@
 <div>
 	<%= partial("mail/body_header", {
-		previewText: "Dear " + personFirstName + ", I regret to inform you that your claim on " + item.Name +
+		previewText: "I regret to inform you that the claim on " + item.Name +
 			" has been denied.",
 		title: "An Update on Your Coverage Request",
 	}) %>
 
 	<div style="max-width: 80ch;">
 		<p>
-			Dear <%= personFirstName %>,
-		</p>
-
-		<p>
-			I regret to inform you that your claim on <%= item.Name %> has been denied.
+			I regret to inform you that the claim on <%= item.Name %> has been denied.
 		</p>
 
 		<p>

--- a/application/templates/mail/claim_preapproved_member.plush.html
+++ b/application/templates/mail/claim_preapproved_member.plush.html
@@ -1,18 +1,14 @@
 <div>
 	<%= partial("mail/body_header", {
-		previewText: "Upload a " + payoutOptionLower + " receipt to get reimbursed. " + personFirstName +
-		", I'm pleased to inform you that your claim for " + item.Name +
+		previewText: "Upload a " + payoutOptionLower + " receipt to get reimbursed. " +
+		"I'm pleased to inform you that the claim for " + item.Name +
 		" has been accepted.",
 		title: "Claim Approved for " + payoutOption,
 	}) %>
 
 	<div style="max-width: 80ch;">
 		<p>
-			Dear <%= personFirstName %>,
-		</p>
-
-		<p>
-			I'm pleased to inform you that your claim for <%= item.Name %> has been accepted, and you're approved to
+			I'm pleased to inform you that the claim for <%= item.Name %> has been accepted, and you're approved to
 			<%= if ( payoutOption == "Repair" ) { %>
 				repair it.
 			<% } else { %>

--- a/application/templates/mail/claim_receipt_member.plush.html
+++ b/application/templates/mail/claim_receipt_member.plush.html
@@ -1,15 +1,11 @@
 <div>
 	<%= partial("mail/body_header", {
-	previewText: personFirstName + ", Thank you for reporting your claim.  We hope to make this process as simple"+
+	previewText: "Thank you for reporting your claim.  We hope to make this process as simple"+
 		" as possible for you. To complete your claim on " + item.Name + ", we need a receipt.",
 	title: "Claim Needs Receipt",
 	}) %>
 
 	<div style="max-width: 80ch;">
-		<p>
-			Dear <%= personFirstName %>,
-		</p>
-
 		<p>
 			Thank you for reporting your claim. We hope to make this process as simple as possible for you.
 			To complete your claim on <%= item.Name %>, we need a receipt.

--- a/application/templates/mail/claim_revision_member.plush.html
+++ b/application/templates/mail/claim_revision_member.plush.html
@@ -1,14 +1,10 @@
 <div>
 	<%= partial("mail/body_header", {
-		previewText: personFirstName + ", Thank you for reporting your claim.  We hope to make this process as simple as possible for you.",
+		previewText: "Thank you for reporting your claim.  We hope to make this process as simple as possible for you.",
 		title: "Claim Needs Changes",
 	}) %>
 
 	<div style="max-width: 80ch;">
-		<p>
-			Dear <%= personFirstName %>,
-		</p>
-
 		<p>
 			Thank you for reporting your claim. We hope to make this process as simple as possible for you.
 			To complete your claim on <%= item.Name %>, we need a little more information.

--- a/application/templates/mail/item_approved_member.plush.html
+++ b/application/templates/mail/item_approved_member.plush.html
@@ -1,15 +1,11 @@
 
 <div>
 	<%= partial("mail/body_header", {
-			previewText: "No action needed. Coverage is now active. Dear "+personFirstName+", "+item.Name+" has been approved for coverage.",
+			previewText: "No action needed. Coverage is now active. "+item.Name+" has been approved for coverage.",
 			title: "Coverage Approved",
 	}) %>
 
 	<div style="max-width: 80ch;">
-		<p>
-			Dear <%= personFirstName %>,
-		</p>
-
 		<p>
 			<%= item.Name %> has been approved for coverage and added to your <%= policyType %> policy.
 		</p>

--- a/application/templates/mail/item_denied_member.plush.html
+++ b/application/templates/mail/item_denied_member.plush.html
@@ -1,18 +1,14 @@
 
 <div>
 	<%= partial("mail/body_header", {
-		previewText: "Dear "+personFirstName+", You recently requested coverage on "+
+		previewText: "Coverage was recently requested on "+
 			item.Name+", but we're not able to cover this item at this time.",
 		title: "Coverage Denied",
 	}) %>
 
 	<div style="max-width: 80ch;">
 		<p>
-			Dear <%= personFirstName %>,
-		</p>
-
-		<p>
-			You recently requested coverage on <%= item.Name %>, but we're not able to cover this item
+			Coverage was recently requested on <%= item.Name %>, but we're not able to cover this item
 			at this time.
 		</p>
 

--- a/application/templates/mail/item_pending_member.plush.html
+++ b/application/templates/mail/item_pending_member.plush.html
@@ -1,6 +1,6 @@
 <div>
 	<%= partial("mail/body_header", {
-		previewText: "No action needed. Dear "+personFirstName+", You've applied to cover "
+		previewText: "No action needed. Coverage has been requested for "
 			+item.Name+". You'll have to wait a bit for the steward (me, "+
 			supportFirstName+") to approve coverage.",
 		title: "New Coverage",
@@ -9,10 +9,7 @@
 
 	<div style="max-width: 80ch;">
 		<p>
-			Dear <%= personFirstName %>,
-		</p>
-		<p>
-			You've applied to cover <%= item.Name %>. You'll have to wait a bit for the steward
+			Coverage has been requested for <%= item.Name %>. You'll have to wait a bit for the steward
 			(me, <%= supportFirstName %>) to approve coverage.  If and when I approve it, the
 			coverage will start on <%= coverageStartDate %>, and we'll charge you the premium,
 			which is prorated for the remainder of the year.

--- a/application/templates/mail/item_revision_member.plush.html
+++ b/application/templates/mail/item_revision_member.plush.html
@@ -1,18 +1,14 @@
 
 <div>
 	<%= partial("mail/body_header", {
-		previewText: "Dear "+personFirstName+", You recently requested coverage on "+
+		previewText: "Coverage has been requested for "+
 			item.Name+", but I need to clarify a few things on your request.",
 		title: "Coverage Application Needs Changes",
 	}) %>
 
 	<div style="max-width: 80ch;">
 		<p>
-			Dear <%= personFirstName %>,
-		</p>
-
-		<p>
-			You recently requested coverage on <%= item.Name %>, but I need to clarify a few things on your request.
+			Coverage has been requested for <%= item.Name %>, but I need to clarify a few things on your request.
 		</p>
 
 		<p>


### PR DESCRIPTION
### Fixed
- Remove the confusing salutation from policy member messages. Since there is no way to know who requested the action in most cases, we have to send all messages to all policy members. With the current notification implementation, we can't even insert the recipient's name in the salutation because the same message body is sent to all recipients.

https://itse.youtrack.cloud/issue/CVR-611